### PR TITLE
[MRG] No need to monkey-patch Click.HelpFormatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ coverage.xml
 .pytest_cache/
 _build/
 
+.venv/
+htmlcov/
+
 # vscode
 .vscode

--- a/camelot/__init__.py
+++ b/camelot/__init__.py
@@ -2,20 +2,10 @@
 
 import logging
 
-from click import HelpFormatter
-
 from .__version__ import __version__
 from .io import read_pdf
 from .plotting import PlotMethods
 
-
-def _write_usage(self, prog, args="", prefix="Usage: "):
-    return self._write_usage("camelot", args, prefix=prefix)
-
-
-# monkey patch click.HelpFormatter
-HelpFormatter._write_usage = HelpFormatter.write_usage
-HelpFormatter.write_usage = _write_usage
 
 # set up logging
 logger = logging.getLogger("camelot")

--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -29,7 +29,7 @@ class Config(object):
 pass_config = click.make_pass_decorator(Config)
 
 
-@click.group()
+@click.group(name="camelot")
 @click.version_option(version=__version__)
 @click.option("-q", "--quiet", is_flag=False, help="Suppress logs and warnings.")
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,109 +9,163 @@ from camelot.utils import TemporaryDirectory
 
 
 testdir = os.path.dirname(os.path.abspath(__file__))
-testdir = os.path.join(testdir, 'files')
+testdir = os.path.join(testdir, "files")
+
+
+def test_help_output():
+    runner = CliRunner()
+    prog_name = runner.get_default_prog_name(cli)
+    result = runner.invoke(cli, ["--help"])
+    output = result.output
+
+    assert prog_name == "camelot"
+    assert result.output.startswith("Usage: %(prog_name)s [OPTIONS] COMMAND" % locals())
+    assert all(
+        v in result.output
+        for v in ["Options:", "--version", "--help", "Commands:", "lattice", "stream"]
+    )
 
 
 def test_cli_lattice():
     with TemporaryDirectory() as tempdir:
-        infile = os.path.join(testdir, 'foo.pdf')
-        outfile = os.path.join(tempdir, 'foo.csv')
+        infile = os.path.join(testdir, "foo.pdf")
+        outfile = os.path.join(tempdir, "foo.csv")
         runner = CliRunner()
-        result = runner.invoke(cli, ['--format', 'csv', '--output', outfile,
-                                     'lattice', infile])
+        result = runner.invoke(
+            cli, ["--format", "csv", "--output", outfile, "lattice", infile]
+        )
         assert result.exit_code == 0
-        assert result.output == 'Found 1 tables\n'
+        assert result.output == "Found 1 tables\n"
 
-        result = runner.invoke(cli, ['--format', 'csv',
-                                     'lattice', infile])
-        output_error = 'Error: Please specify output file path using --output'
+        result = runner.invoke(cli, ["--format", "csv", "lattice", infile])
+        output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
 
-        result = runner.invoke(cli, ['--output', outfile,
-                                     'lattice', infile])
-        format_error = 'Please specify output file format using --format'
+        result = runner.invoke(cli, ["--output", outfile, "lattice", infile])
+        format_error = "Please specify output file format using --format"
         assert format_error in result.output
 
 
 def test_cli_stream():
     with TemporaryDirectory() as tempdir:
-        infile = os.path.join(testdir, 'budget.pdf')
-        outfile = os.path.join(tempdir, 'budget.csv')
+        infile = os.path.join(testdir, "budget.pdf")
+        outfile = os.path.join(tempdir, "budget.csv")
         runner = CliRunner()
-        result = runner.invoke(cli, ['--format', 'csv', '--output', outfile,
-                                     'stream', infile])
+        result = runner.invoke(
+            cli, ["--format", "csv", "--output", outfile, "stream", infile]
+        )
         assert result.exit_code == 0
-        assert result.output == 'Found 1 tables\n'
+        assert result.output == "Found 1 tables\n"
 
-        result = runner.invoke(cli, ['--format', 'csv', 'stream', infile])
-        output_error = 'Error: Please specify output file path using --output'
+        result = runner.invoke(cli, ["--format", "csv", "stream", infile])
+        output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
 
-        result = runner.invoke(cli, ['--output', outfile, 'stream', infile])
-        format_error = 'Please specify output file format using --format'
+        result = runner.invoke(cli, ["--output", outfile, "stream", infile])
+        format_error = "Please specify output file format using --format"
         assert format_error in result.output
 
 
 def test_cli_password():
     with TemporaryDirectory() as tempdir:
-        infile = os.path.join(testdir, 'health_protected.pdf')
-        outfile = os.path.join(tempdir, 'health_protected.csv')
+        infile = os.path.join(testdir, "health_protected.pdf")
+        outfile = os.path.join(tempdir, "health_protected.csv")
         runner = CliRunner()
-        result = runner.invoke(cli, ['--password', 'userpass',
-                                     '--format', 'csv', '--output', outfile,
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            [
+                "--password",
+                "userpass",
+                "--format",
+                "csv",
+                "--output",
+                outfile,
+                "stream",
+                infile,
+            ],
+        )
         assert result.exit_code == 0
-        assert result.output == 'Found 1 tables\n'
+        assert result.output == "Found 1 tables\n"
 
-        output_error = 'file has not been decrypted'
+        output_error = "file has not been decrypted"
         # no password
-        result = runner.invoke(cli, ['--format', 'csv', '--output', outfile,
-                                     'stream', infile])
+        result = runner.invoke(
+            cli, ["--format", "csv", "--output", outfile, "stream", infile]
+        )
         assert output_error in str(result.exception)
 
         # bad password
-        result = runner.invoke(cli, ['--password', 'wrongpass',
-                                     '--format', 'csv', '--output', outfile,
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            [
+                "--password",
+                "wrongpass",
+                "--format",
+                "csv",
+                "--output",
+                outfile,
+                "stream",
+                infile,
+            ],
+        )
         assert output_error in str(result.exception)
 
 
 def test_cli_output_format():
     with TemporaryDirectory() as tempdir:
-        infile = os.path.join(testdir, 'health.pdf')
-        outfile = os.path.join(tempdir, 'health.{}')
+        infile = os.path.join(testdir, "health.pdf")
+        outfile = os.path.join(tempdir, "health.{}")
         runner = CliRunner()
 
         # json
-        result = runner.invoke(cli, ['--format', 'json', '--output', outfile.format('json'),
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            ["--format", "json", "--output", outfile.format("json"), "stream", infile],
+        )
         assert result.exit_code == 0
 
         # excel
-        result = runner.invoke(cli, ['--format', 'excel', '--output', outfile.format('xlsx'),
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            ["--format", "excel", "--output", outfile.format("xlsx"), "stream", infile],
+        )
         assert result.exit_code == 0
 
         # html
-        result = runner.invoke(cli, ['--format', 'html', '--output', outfile.format('html'),
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            ["--format", "html", "--output", outfile.format("html"), "stream", infile],
+        )
         assert result.exit_code == 0
 
         # zip
-        result = runner.invoke(cli, ['--zip', '--format', 'csv', '--output', outfile.format('csv'),
-                                     'stream', infile])
+        result = runner.invoke(
+            cli,
+            [
+                "--zip",
+                "--format",
+                "csv",
+                "--output",
+                outfile.format("csv"),
+                "stream",
+                infile,
+            ],
+        )
         assert result.exit_code == 0
+
 
 def test_cli_quiet():
     with TemporaryDirectory() as tempdir:
-        infile = os.path.join(testdir, 'blank.pdf')
-        outfile = os.path.join(tempdir, 'blank.csv')
+        infile = os.path.join(testdir, "blank.pdf")
+        outfile = os.path.join(tempdir, "blank.csv")
         runner = CliRunner()
 
-        result = runner.invoke(cli, ['--format', 'csv', '--output', outfile,
-                                     'stream', infile])
-        assert 'No tables found on page-1' in result.output
+        result = runner.invoke(
+            cli, ["--format", "csv", "--output", outfile, "stream", infile]
+        )
+        assert "No tables found on page-1" in result.output
 
-        result = runner.invoke(cli, ['--quiet', '--format', 'csv',
-                                     '--output', outfile, 'stream', infile])
-        assert 'No tables found on page-1' not in result.output
+        result = runner.invoke(
+            cli, ["--quiet", "--format", "csv", "--output", outfile, "stream", infile]
+        )
+        assert "No tables found on page-1" not in result.output


### PR DESCRIPTION
While working on adding tests for Excalibur (camelot-dev/excalibur#49), I've noticed this code:

```python
def _write_usage(self, prog, args='', prefix='Usage: '):
    return self._write_usage('camelot', args, prefix=prefix)


# monkey patch click.HelpFormatter
HelpFormatter._write_usage = HelpFormatter.write_usage
HelpFormatter.write_usage = _write_usage
```

This monkey patching causes Excalibur's (or any other click-based) CLI to return camelot for the program name in the help output, which is a bit confusing, so I decided to propose this PR to fix it.

In order not to show camelot as the program name in the help output (passing --help), it's enough to set `@group(name='camelot')` on the main Click group for the CLI. The existing approach which monkey patches `click.HelpFormatter.write_usage()`, will affect any other Click CLI tool that uses camelot as its dependency, e.g. Excalibur.

Added a test to verify it works as expected in the help output.