### PR TITLE
Fixed library discovery on Windows

### DIFF
--- a/camelot/ext/ghostscript/_gsprint.py
+++ b/camelot/ext/ghostscript/_gsprint.py
@@ -244,6 +244,9 @@ def __win32_finddll():
 if sys.platform == "win32":
     libgs = __win32_finddll()
     if not libgs:
+        import ctypes.util
+        libgs = ctypes.util.find_library("".join(("gsdll", str(ctypes.sizeof(ctypes.c_voidp) * 8), ".dll"))) # finds in %PATH%
+    if not libgs:
         raise RuntimeError("Please make sure that Ghostscript is installed")
     libgs = windll.LoadLibrary(libgs)
 else:


### PR DESCRIPTION
When `gsdll.dll` is not found in the usual place in the Windows registry, `ctypes.util.find_library()` is used as a fallback to search `%PATH%`, before raising `RuntimeError`.