### PR TITLE
Fixed encoding trouble

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -632,7 +632,7 @@ class Table(object):
 
         """
         html_string = self.df.to_html(**kwargs)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(html_string)
 
     def to_sqlite(self, path, **kwargs):

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from io import open
 import os
 import sqlite3

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -599,7 +599,7 @@ class Table(object):
         kw = {"orient": "records"}
         kw.update(kwargs)
         json_string = self.df.to_json(**kw)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(json_string)
 
     def to_excel(self, path, **kwargs):

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from io import open
 import os
 import sqlite3
 import zipfile


### PR DESCRIPTION
Ensure `to_json()` and `to_html()` handle Unicode properly on both 2.7 and 3+, by explicitly encoding `unicode` strings to `utf-8` before calling  to `write()`.