### PR TITLE
FIX-#59 - REPLACING "pdf-table-extarct" WITH "pdfplumber"

### DIFF
--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -17,14 +17,14 @@ Sadly, a lot of today's open data is trapped in PDF tables.
 Why another PDF table extraction library?
 -----------------------------------------
 
-There are both open (`Tabula`_, `pdf-table-extract`_) and closed-source (`smallpdf`_, `PDFTables`_) tools that are widely used to extract tables from PDF files. They either give a nice output or fail miserably. There is no in between. This is not helpful since everything in the real world, including PDF table extraction, is fuzzy. This leads to the creation of ad-hoc table extraction scripts for each type of PDF table.
+There are both open (`Tabula`_, `pdfplumber`_) and closed-source (`smallpdf`_, `PDFTables`_) tools that are widely used to extract tables from PDF files. They either give a nice output or fail miserably. There is no in between. This is not helpful since everything in the real world, including PDF table extraction, is fuzzy. This leads to the creation of ad-hoc table extraction scripts for each type of PDF table.
 
 Camelot was created to offer users complete control over table extraction. If you can't get your desired output with the default settings, you can tweak them and get the job done!
 
 Here is a `comparison`_ of Camelot's output with outputs from other open-source PDF parsing libraries and tools.
 
 .. _Tabula: http://tabula.technology/
-.. _pdf-table-extract: https://github.com/ashima/pdf-table-extract
+.. _pdfplumber: https://github.com/ashima/pdfplumber
 .. _PDFTables: https://pdftables.com/
 .. _Smallpdf: https://smallpdf.com
 .. _comparison: https://github.com/camelot-dev/camelot/wiki/Comparison-with-other-PDF-Table-Extraction-libraries-and-tools


### PR DESCRIPTION
Replaced the text "pdf-table-extract" in the intro page with "pdfplumber"