### PR TITLE
Index out of range latt

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -155,7 +155,7 @@ class Lattice(BaseParser):
         """
         indices = []
         for r_idx, c_idx, text in idx:
-            if r_idx in t.cells:
+            if r_idx < len(t.cells) and c_idx < len(t.cells[r_idx]):
                 for d in shift_text:
                     if d == "l":
                         if t.cells[r_idx][c_idx].hspan:
@@ -356,7 +356,7 @@ class Lattice(BaseParser):
                         table, indices, shift_text=self.shift_text
                     )
                     for r_idx, c_idx, text in indices:
-                        if r_idx in table.cells:
+                        if r_idx < len(table.cells) and c_idx < len(table.cells[r_idx]):
                             table.cells[r_idx][c_idx].text = text
         accuracy = compute_accuracy([[100, pos_errors]])
 

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -155,23 +155,24 @@ class Lattice(BaseParser):
         """
         indices = []
         for r_idx, c_idx, text in idx:
-            for d in shift_text:
-                if d == "l":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].left:
-                            c_idx -= 1
-                if d == "r":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].right:
-                            c_idx += 1
-                if d == "t":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].top:
-                            r_idx -= 1
-                if d == "b":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].bottom:
-                            r_idx += 1
+            if r_idx in t.cells:
+                for d in shift_text:
+                    if d == "l":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].left:
+                                c_idx -= 1
+                    if d == "r":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].right:
+                                c_idx += 1
+                    if d == "t":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].top:
+                                r_idx -= 1
+                    if d == "b":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].bottom:
+                                r_idx += 1
             indices.append((r_idx, c_idx, text))
         return indices
 
@@ -355,7 +356,8 @@ class Lattice(BaseParser):
                         table, indices, shift_text=self.shift_text
                     )
                     for r_idx, c_idx, text in indices:
-                        table.cells[r_idx][c_idx].text = text
+                        if r_idx in table.cells:
+                            table.cells[r_idx][c_idx].text = text
         accuracy = compute_accuracy([[100, pos_errors]])
 
         if self.copy_text is not None:


### PR DESCRIPTION
If a content of a table spills outside of the bounding line then it gets index of error. As table cell dosent have the index which is getting accessed due to spilling of table hence we are getting Index Out of range