### PR TITLE
[ TextEdges ] allow single non-empty char textline

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -128,7 +128,7 @@ class TextEdges(object):
         rows.
         """
         for tl in textlines:
-            if len(tl.get_text().strip()) > 1:  # TODO: hacky
+            if len(tl.get_text().strip()) >= 1:  # TODO: hacky
                 self.update(tl)
 
     def get_relevant(self):


### PR DESCRIPTION
In `TextEdges.generate` function, updating criteria of selection of textline to atleast one non white-space character. Currently, this is set to two due to to greater than one condition.

This was causing problem when trying to extract tables from [this](https://drive.google.com/file/d/1kJcGi8WaWbB26T-lUO-wHDxYy3fAFGe9/view?usp=sharing) file. 

In the attached file, cells post Manipur (16th row) on first page mostly contain single digit values which were not updating the `TextEdges` object. Hence the table bbox geneated later only covered values upto Manipur. It was fixed by allowing single non white-space character cell to pass.

Besides, post this change, somehow one extra test case got passed on my system (not sure how)