### PR TITLE
[REF] add DataFrame to_excel params, requirements.txt XlsxWriter>=0.9.8

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -712,7 +712,7 @@ class TableList(object):
                 filepath = os.path.join(dirname, filename)
                 z.write(filepath, os.path.basename(filepath))
 
-    def export(self, path, f="csv", compress=False):
+    def export(self, path, f="csv", compress=False, df_kwargs={}):
         """Exports the list of tables to specified file format.
 
         Parameters
@@ -723,6 +723,8 @@ class TableList(object):
             File format. Can be csv, json, excel, html and sqlite.
         compress : bool
             Whether or not to add files to a ZIP archive.
+        df_kwargs : dict, optional (default: {})
+            A dict of `pandas.DataFrame.to_excel https://github.com/pandas-dev/pandas/blob/master/pandas/core/generic.py#L1924`
 
         """
         dirname = os.path.dirname(path)
@@ -742,7 +744,7 @@ class TableList(object):
             writer = pd.ExcelWriter(filepath)
             for table in self._tables:
                 sheet_name = "page-{}-table-{}".format(table.page, table.order)
-                table.df.to_excel(writer, sheet_name=sheet_name, encoding="utf-8")
+                table.df.to_excel(writer, sheet_name=sheet_name, encoding="utf-8", **df_kwargs)
             writer.save()
             if compress:
                 zipname = os.path.join(os.path.dirname(path), root) + ".zip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openpyxl>=2.5.8
 pandas>=0.23.4
 pdfminer.six>=20170720
 PyPDF2>=1.26.0
+XlsxWriter>=0.9.8


### PR DESCRIPTION
Hi guys,

Basically camelot is using [`pandas.DataFrame.to_excel`](https://github.com/pandas-dev/pandas/blob/master/pandas/core/generic.py#L1924) to export excel file.
But it seems there are 2 available options `sheet_name`, `encoding` are supported, the idea is follow the 
https://github.com/camelot-dev/camelot/blob/7d4c9e53c67b4be005d7f060190d68b26512f361/camelot/io.py#L15
then I've create new `df_kwargs` which is used for `df.to_excel`.

While using export feature, I also faced issue with minimum version of `XlsxWriter` is 0.9.8, then I've just added to this commit.

Regards,
