### PR TITLE
Update install.rst

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ A great way to start contributing to Camelot is to pick an issue tagged with the
 To install the dependencies needed for development, you can use pip:
 
 <pre>
-$ pip install camelot-py[dev]
+$ pip install "camelot-py[dev]"
 </pre>
 
 Alternatively, you can clone the project repository, and install using pip:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ conda install -c conda-forge camelot-py
 After [installing the dependencies](https://camelot-py.readthedocs.io/en/master/user/install-deps.html) ([tk](https://packages.ubuntu.com/bionic/python/python-tk) and [ghostscript](https://www.ghostscript.com/)), you can simply use pip to install Camelot:
 
 <pre>
-$ pip install camelot-py[cv]
+$ pip install "camelot-py[cv]"
 </pre>
 
 ### From the source code
@@ -113,7 +113,7 @@ $ git clone https://www.github.com/camelot-dev/camelot
 You can install the development dependencies easily, using pip:
 
 <pre>
-$ pip install camelot-py[dev]
+$ pip install "camelot-py[dev]"
 </pre>
 
 ### Testing

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -37,7 +37,7 @@ Setting up a development environment
 
 To install the dependencies needed for development, you can use pip::
 
-    $ pip install camelot-py[dev]
+    $ pip install "camelot-py[dev]"
 
 Alternatively, you can clone the project repository, and install using pip::
 

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -25,7 +25,7 @@ Using pip
 
 After :ref:`installing the dependencies <install_deps>`, which include `Tkinter`_ and `ghostscript`_, you can simply use pip to install Camelot::
 
-    $ pip install camelot-py[cv]
+    $ pip install 'camelot-py[cv]'
 
 .. _Tkinter: https://wiki.python.org/moin/TkInter
 .. _ghostscript: https://www.ghostscript.com

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -25,7 +25,7 @@ Using pip
 
 After :ref:`installing the dependencies <install_deps>`, which include `Tkinter`_ and `ghostscript`_, you can simply use pip to install Camelot::
 
-    $ pip install 'camelot-py[cv]'
+    $ pip install "camelot-py[cv]"
 
 .. _Tkinter: https://wiki.python.org/moin/TkInter
 .. _ghostscript: https://www.ghostscript.com


### PR DESCRIPTION
MacOS now uses zsh by default.  Square brackets must be escaped in zsh