### PR TITLE
Fix use resolution argument to generate image with GS

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -211,8 +211,8 @@ class Lattice(BaseParser):
         from ..ext.ghostscript import Ghostscript
 
         self.imagename = "".join([self.rootname, ".png"])
-        gs_call = "-q -sDEVICE=png16m -o {} -r300 {}".format(
-            self.imagename, self.filename
+        gs_call = "-q -sDEVICE=png16m -o {} -r{} {}".format(
+            self.imagename, self.resolution, self.filename
         )
         gs_call = gs_call.encode().split()
         null = open(os.devnull, "wb")


### PR DESCRIPTION
The resolution argument is passed to Parser, even so is not used to generate image.