### PR TITLE
[MRG]Improve test coverage

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -118,3 +118,9 @@ def test_bad_password():
     message = "file has not been decrypted"
     with pytest.raises(Exception, match=message):
         tables = camelot.read_pdf(filename, password="wrongpass")
+
+def test_content_type():
+    url="https://camelot-py.readthedocs.io/en/master/_static/csv/foo.csv"
+    message = "File format not supported"
+    with pytest.raises(NotImplementedError, match=message):
+        tables = camelot.read_pdf(url)


### PR DESCRIPTION
Added test to check if the error message is displayed accurately when an
unsupported URL that doesn't have a pdf content is passed.

Files changed: tests/test_error.py
Test added: test_content_type()