### PR TITLE
[MRG]Added test case for method bbox_no_intersection from utils to check no intersection logic

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+"Test to check intersection logic when no intersection area returned"
+import os
+import sys
+
+from pdfminer.pdfparser import PDFParser
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfpage import PDFTextExtractionNotAllowed
+from pdfminer.pdfinterp import PDFResourceManager
+from pdfminer.pdfinterp import PDFPageInterpreter
+from pdfminer.converter import PDFPageAggregator
+from pdfminer.layout import (
+    LAParams,
+    LTAnno,
+    LTChar,
+    LTTextLineHorizontal,
+    LTTextLineVertical,
+    LTImage,
+    LTTextBoxHorizontal
+)
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+testdir = os.path.join(testdir, "files")
+
+from camelot.utils import bbox_intersection_area
+
+def get_text_from_pdf(filename):
+    "Method to extract text object from pdf"
+    #https://stackoverflow.com/questions/22898145/how-to-extract-text-and-text-coordinates-from-a-pdf-file
+    #https://pdfminer-docs.readthedocs.io/programming.html#performing-layout-analysis
+    document = open(filename, 'rb')
+    #Create resource manager
+    rsrcmgr = PDFResourceManager()
+    # Set parameters for analysis.
+    laparams = LAParams()
+    # Create a PDF page aggregator object.
+    device = PDFPageAggregator(rsrcmgr, laparams=laparams)
+    interpreter = PDFPageInterpreter(rsrcmgr, device)
+    for page in PDFPage.get_pages(document):
+        interpreter.process_page(page)
+        # receive the LTPage object for the page.
+        layout = device.get_result()
+        for element in layout:
+            if isinstance(element, LTTextBoxHorizontal):
+                return element
+
+def test_bbox_intersection_text():
+    """
+    Test to check area of intersection between both boxes when no intersection area returned
+    """
+    filename1 = os.path.join(testdir, "foo.pdf")
+    pdftextelement1 = get_text_from_pdf(filename1)
+    filename2 = os.path.join(testdir, "tabula/12s0324.pdf")
+    pdftextelement2 = get_text_from_pdf(filename2)
+
+    assert bbox_intersection_area(pdftextelement1, pdftextelement2) == 0.0


### PR DESCRIPTION
This PR contains the test case written to test the logic for method def bbox_intersection_area(ba, bb) from utils when no intersecting area is available.[line 403 and 404 from the utils.py]

Below is the test run output

```
$ python setup.py -v test
running pytest
running egg_info
writing camelot_py.egg-info\PKG-INFO
writing dependency_links to camelot_py.egg-info\dependency_links.txt
writing entry points to camelot_py.egg-info\entry_points.txt
writing requirements to camelot_py.egg-info\requires.txt
writing top-level names to camelot_py.egg-info\top_level.txt
'license_file' option was not specified
reading manifest file 'camelot_py.egg-info\SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'camelot_py.egg-info\SOURCES.txt'
running build_ext
============================= test session starts =============================
platform win32 -- Python 3.8.2, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- C:\Users\XXXXX\XXXXX\XXXXX\camelot\venv3\Scripts\python.exe
cachedir: .pytest_cache
Matplotlib: 3.4.2
Freetype: 2.6.1
rootdir: C:\Users\XXXXX\XXXXX\XXXXX\camelot, configfile: setup.cfg
plugins: cov-2.12.1, mock-3.6.1, mpl-0.13
collecting ... collected 65 items

tests/test_utils.py::test_bbox_intersection_text PASSED                  [100%]

```