### PR TITLE
Call pdftopng in python instead of subprocess

### DIFF
--- a/camelot/backends/poppler_backend.py
+++ b/camelot/backends/poppler_backend.py
@@ -6,17 +6,5 @@ import subprocess
 
 class PopplerBackend(object):
     def convert(self, pdf_path, png_path):
-        pdftopng_executable = shutil.which("pdftopng")
-        if pdftopng_executable is None:
-            raise OSError(
-                "pdftopng is not installed. You can install it using the 'pip install pdftopng' command."
-            )
-
-        pdftopng_command = [pdftopng_executable, pdf_path, png_path]
-
-        try:
-            subprocess.check_output(
-                " ".join(pdftopng_command), stderr=subprocess.STDOUT, shell=True
-            )
-        except subprocess.CalledProcessError as e:
-            raise ValueError(e.output)
+        from pdftopng.pdftopng import convert
+        convert(pdf_path, png_path)


### PR DESCRIPTION
Using the poppler backed failed for me because I was running it from an un-activated venv and pdftopng was not in the PATH.

My original workaround was even shorter - I imported the convert function directly into the PopplerBackend class. But this import will fail on initialization if pdftopng is not installed and will prevent using the ghostscript backend, so I converted it to late import.