### PR TITLE
fix float division by zero

### DIFF
--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -373,7 +373,7 @@ def text_in_bbox(bbox, text):
                 continue
             if bbox_intersect(ba, bb):
                 # if the intersection is larger than 80% of ba's size, we keep the longest
-                if (bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8:
+                if (bbox_area(ba)>0) and ((bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8):
                     if bbox_longer(bb, ba):
                         rest.discard(ba)
     unique_boxes = list(rest)

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -373,7 +373,7 @@ def text_in_bbox(bbox, text):
                 continue
             if bbox_intersect(ba, bb):
                 # if the intersection is larger than 80% of ba's size, we keep the longest
-                if (bbox_area(ba)>0) and ((bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8):
+                if (bbox_area(ba)==0) or ((bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8):
                     if bbox_longer(bb, ba):
                         rest.discard(ba)
     unique_boxes = list(rest)


### PR DESCRIPTION
In some cases, the text area is 0. For this case, the function text_in_bbox(bbox, text) can be crashed due to the logic:
`if  (bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8:`
since bbox_area(ba)=0.

Thus, i update the logic by the new condition:
`if (bbox_area(ba)>0) and ((bbox_intersection_area(ba, bb) / bbox_area(ba)) > 0.8)`
which can handle such a case.
 