### PR TITLE
[MRG] Test: Fix typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --verbose --cov-config .coveragerc --cov-report term --cov-report xml --cov=camelot --mpl
+adopts = --verbose --cov-config .coveragerc --cov-report term --cov-report xml --cov=camelot --mpl
 python_files = tests/test_*.py


### PR DESCRIPTION
Change `addopts` to `adopts` to make tests run

Signed-off-by: Karl Bonde Torp <k.torp@samsung.com>