### PR TITLE
MAINT: Update PyPDF2 version

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from PyPDF2 import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter
 
 from .core import TableList
 from .parsers import Stream, Lattice

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from PyPDF2 import PdfFileReader, PdfFileWriter
+from PyPDF2 import PdfReader, PdfWriter
 
 from .core import TableList
 from .parsers import Stream, Lattice
@@ -72,19 +72,19 @@ class PDFHandler(object):
             page_numbers.append({"start": 1, "end": 1})
         else:
             with open(self.filepath, "rb") as f:
-                infile = PdfFileReader(f, strict=False)
+                infile = PdfReader(f, strict=False)
 
-                if infile.isEncrypted:
+                if infile.is_encrypted:
                     infile.decrypt(self.password)
 
                 if pages == "all":
-                    page_numbers.append({"start": 1, "end": infile.getNumPages()})
+                    page_numbers.append({"start": 1, "end": len(infile.pages)})
                 else:
                     for r in pages.split(","):
                         if "-" in r:
                             a, b = r.split("-")
                             if b == "end":
-                                b = infile.getNumPages()
+                                b = len(infile.pages)
                             page_numbers.append({"start": int(a), "end": int(b)})
                         else:
                             page_numbers.append({"start": int(r), "end": int(r)})
@@ -108,14 +108,14 @@ class PDFHandler(object):
 
         """
         with open(filepath, "rb") as fileobj:
-            infile = PdfFileReader(fileobj, strict=False)
+            infile = PdfReader(fileobj, strict=False)
             if infile.isEncrypted:
                 infile.decrypt(self.password)
             fpath = os.path.join(temp, f"page-{page}.pdf")
             froot, fext = os.path.splitext(fpath)
-            p = infile.getPage(page - 1)
-            outfile = PdfFileWriter()
-            outfile.addPage(p)
+            p = infile.pages[page - 1]
+            outfile = PdfWriter()
+            outfile.add_page(p)
             with open(fpath, "wb") as f:
                 outfile.write(f)
             layout, dim = get_page_layout(fpath)
@@ -128,16 +128,16 @@ class PDFHandler(object):
                 fpath_new = "".join([froot.replace("page", "p"), "_rotated", fext])
                 os.rename(fpath, fpath_new)
                 instream = open(fpath_new, "rb")
-                infile = PdfFileReader(instream, strict=False)
-                if infile.isEncrypted:
+                infile = PdfReader(instream, strict=False)
+                if infile.is_encrypted:
                     infile.decrypt(self.password)
-                outfile = PdfFileWriter()
-                p = infile.getPage(0)
+                outfile = PdfWriter()
+                p = infile.pages[0]
                 if rotation == "anticlockwise":
-                    p.rotateClockwise(90)
+                    p.rotate(90)
                 elif rotation == "clockwise":
-                    p.rotateCounterClockwise(90)
-                outfile.addPage(p)
+                    p.rotate(-90)
+                outfile.add_page(p)
                 with open(fpath, "wb") as f:
                     outfile.write(f)
                 instream.close()

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -109,7 +109,7 @@ class PDFHandler(object):
         """
         with open(filepath, "rb") as fileobj:
             infile = PdfReader(fileobj, strict=False)
-            if infile.isEncrypted:
+            if infile.is_encrypted:
                 infile.decrypt(self.password)
             fpath = os.path.join(temp, f"page-{page}.pdf")
             froot, fext = os.path.splitext(fpath)

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -116,7 +116,7 @@ To extract tables from encrypted PDF files you must provide a password when call
 
         $ camelot --password userpass lattice foo.pdf
 
-Currently Camelot only supports PDFs encrypted with ASCII passwords and algorithm `code 1 or 2`_. An exception is thrown if the PDF cannot be read. This may be due to no password being provided, an incorrect password, or an unsupported encryption algorithm.
+Camelot supports PDFs with all encryption types supported by `pypdf`_. This might require installing PyCryptodome. An exception is thrown if the PDF cannot be read. This may be due to no password being provided, an incorrect password, or an unsupported encryption algorithm.
 
 Further encryption support may be added in future, however in the meantime if your PDF files are using unsupported encryption algorithms you are advised to remove encryption before calling :meth:`read_pdf() <camelot.read_pdf>`. This can been successfully achieved with third-party tools such as `QPDF`_.
 
@@ -124,7 +124,7 @@ Further encryption support may be added in future, however in the meantime if yo
 
     $ qpdf --password=<PASSWORD> --decrypt input.pdf output.pdf
 
-.. _code 1 or 2: https://github.com/mstamy2/PyPDF2/issues/378
+.. _pypdf: https://pypdf.readthedocs.io/en/latest/user/pdf-version-support.html
 .. _QPDF: https://www.github.com/qpdf/qpdf
 
 ----

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     "openpyxl>=2.5.8",
     "pandas>=0.23.4",
     "pdfminer.six>=20200726",
-    "PyPDF2>=2.0.0",
+    "pypdf>=3.0.0",
     "tabulate>=0.8.9",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     "openpyxl>=2.5.8",
     "pandas>=0.23.4",
     "pdfminer.six>=20200726",
-    "PyPDF2>=1.26.0",
+    "PyPDF2>=2.0.0",
     "tabulate>=0.8.9",
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,7 +95,7 @@ def test_cli_password():
         assert result.exit_code == 0
         assert result.output == "Found 1 tables\n"
 
-        output_error = "file has not been decrypted"
+        output_error = "File has not been decrypted"
         # no password
         result = runner.invoke(
             cli, ["--format", "csv", "--output", outfile, "stream", infile]
@@ -183,7 +183,7 @@ def test_cli_quiet():
         result = runner.invoke(
             cli, ["--format", "csv", "--output", outfile, "stream", infile]
         )
-        assert "No tables found on page-1" in result.output
+        assert "Found 0 tables" in result.output
 
         result = runner.invoke(
             cli, ["--quiet", "--format", "csv", "--output", outfile, "stream", infile]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -65,14 +65,14 @@ def test_no_tables_found_warnings_suppressed():
 
 def test_no_password():
     filename = os.path.join(testdir, "health_protected.pdf")
-    message = "file has not been decrypted"
+    message = "File has not been decrypted"
     with pytest.raises(Exception, match=message):
         tables = camelot.read_pdf(filename)
 
 
 def test_bad_password():
     filename = os.path.join(testdir, "health_protected.pdf")
-    message = "file has not been decrypted"
+    message = "File has not been decrypted"
     with pytest.raises(Exception, match=message):
         tables = camelot.read_pdf(filename, password="wrongpass")
 


### PR DESCRIPTION
PyPDF2 changed the syntax and deprecated Python 3.5 and older. As camelot requirest 3.6 or newer, there is no reason not to upgrade.

Fixes #339 