### PR TITLE
Fix: unwanted data leaks into the last cell

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -367,7 +367,7 @@ class Lattice(BaseParser):
                     flag_size=self.flag_size,
                     strip_text=self.strip_text,
                 )
-                if indices[:2] != (-1, -1):
+                if indices[0][:2] != (-1, -1):
                     pos_errors.append(error)
                     indices = Lattice._reduce_index(
                         table, indices, shift_text=self.shift_text


### PR DESCRIPTION
`indices` is in the form like [(r_idx, c_idx, text), ...], which makes `indices[:2] != (-1, -1)` always True.
Then unwanted data may appended into `table.cells[-1][-1]`.