### PR TITLE
use GTE (vs GT) in textedge intersection

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -69,7 +69,7 @@ class TextEdge(object):
             self.intersections += 1
             # a textedge is valid only if it extends uninterrupted
             # over a required number of textlines
-            if self.intersections > TEXTEDGE_REQUIRED_ELEMENTS:
+            if self.intersections >= TEXTEDGE_REQUIRED_ELEMENTS:
                 self.is_valid = True
 
 


### PR DESCRIPTION
We recently found a case where a table was being skipped and not exported. Upon debugging, we found this to be the issue.
The issue had been reported in https://github.com/camelot-dev/camelot/issues/342 
