### PR TITLE
Bugfix for Stream._group_rows

### DIFF
--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -129,6 +129,7 @@ class Stream(BaseParser):
         rows = []
         temp = []
 
+        text.sort(key=lambda x: (-x.y0, x.x0))
         for t in text:
             # is checking for upright necessary?
             # if t.get_text().strip() and all([obj.upright for obj in t._objs if


### PR DESCRIPTION
PDFMiner text objects should be sorted before the row grouping algorithm, otherwise items that belong on the same row will not be correctly grouped together.

In `_generate_columns_and_rows` this is done correctly the first time:
Line 328: `t_bbox["horizontal"].sort(key=lambda x: (-x.y0, x.x0))`

But `inner_text` is not sorted at any point after being extended with `outer_text`, which means that the _group_rows algorithm does not always work correctly - motivating example below:

**Motivating Example**
My table looks like this:
<img width="562" alt="image" src="https://github.com/camelot-dev/camelot/assets/60572077/ba4a14db-2c90-49dd-834f-efcb9fe578d4">

Initial column detection identified just three columns (because those columns being longer pushed the mode to three)
<img width="562" alt="Screenshot 2023-05-18 at 12 00 58" src="https://github.com/camelot-dev/camelot/assets/60572077/4d211e92-5a13-48eb-8eea-13f5cba27e82">

`inner_text` was then populated by this column:
<img width="562" alt="Screenshot 2023-05-18 at 12 00 58" src="https://github.com/camelot-dev/camelot/assets/60572077/4b6360d5-a5d5-4f50-9c2d-4f65c018c24d">

and subsequently extended with the `outer_text` from here:
![image](https://github.com/camelot-dev/camelot/assets/60572077/a94e8a11-1249-48cb-8324-4966f43d56b5)

Because `inner_text` isn't sorted, _group_rows first finds rows of length 1 from the one `inner_text` columns, and then finds longer rows from the `outer_text` column.
As a result the `inner_text` column isn't added.

The sort in this PR fixes the problem and seems a reasonable place to apply it to me, but I am not familiar with this codebase - I've only debugged this one case.
