### PR TITLE
Bugfix - Stream._group_rows

### DIFF
--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -122,6 +122,7 @@ class Stream(BaseParser):
         rows = []
         temp = []
 
+        text.sort(key=lambda x: (-x.y0, x.x0))
         for t in text:
             # is checking for upright necessary?
             # if t.get_text().strip() and all([obj.upright for obj in t._objs if


### PR DESCRIPTION
PDFMiner text objects should be sorted before the row grouping algorithm, otherwise items that belong on the same row will not be correctly grouped together.

In `_generate_columns_and_rows` this is done correctly the first time:
Line 328: `t_bbox["horizontal"].sort(key=lambda x: (-x.y0, x.x0))`

But `inner_text` is not sorted at any point after being extended with `outer_text`, which means that the `_group_rows` algorithm does not always work correctly - motivating example below:

**Motivating Example**
My table looks like this:
![image](https://github.com/camelot-dev/camelot/assets/60572077/1d6f65fc-9a4e-4194-b44a-f8a899563f7d)

Initial column detection identified just three columns (because those columns being longer pushed the mode to three)
![image](https://github.com/camelot-dev/camelot/assets/60572077/83e60355-cd7f-4ce7-ac59-9c2a9676fcb4)

`inner_text` was then populated by this column:
![image](https://github.com/camelot-dev/camelot/assets/60572077/8494aff6-796c-405d-8343-b478cd5ae219)

and subsequently extended with the `outer_text` from here:
![image](https://github.com/camelot-dev/camelot/assets/60572077/6108ab1d-b7e7-4c38-be79-b0ef1eba9024)

Because `inner_text` isn't sorted, `_group_rows` first finds rows of length 1 from the one `inner_text` columns, and then finds longer rows from the `outer_text` column.
As a result the `inner_text` column isn't added.

The sort in this PR fixes the problem and seems a reasonable place to apply it to me, but I am not familiar with this codebase - I've only debugged this one case.