### PR TITLE
Do not run tests on pull_request since it already runs against a push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   - push
-  - pull_request
 
 jobs:
   tests:


### PR DESCRIPTION
The tests actions runs twice because it runs on push & pull_request. This PR let's run the test action only against a push. 