### PR TITLE
[MRG] Add return type to TableList __getitem__ method

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -682,7 +682,7 @@ class TableList:
     def __len__(self):
         return len(self._tables)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx) -> Table:
         return self._tables[idx]
 
     @staticmethod


### PR DESCRIPTION
This PR simply adds a return type to the `TableList` `__getitem__` method so that when you write code like:

```python
tables = camelot.read_pdf(file_path, pages=pages)
table1 = tables[0]
```

you get automatic type inference on the `table1` variable.