### PR TITLE
I wasn't able to get camelot working without installing ghostscript in my python environment as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ conda install -c conda-forge camelot-py
 After [installing the dependencies](https://camelot-py.readthedocs.io/en/latest/user/install-deps.html) ([tk](https://packages.ubuntu.com/bionic/python/python-tk) and [ghostscript](https://www.ghostscript.com/)), you can also just use pip to install Camelot:
 
 ```bash
+pip install ghostscript
 pip install "camelot-py[base]"
 ```
 


### PR DESCRIPTION
Therefore I added the following command to the documentation : `pip install ghostscript`
This was despite having ghostscript installed system wide