### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "numpy>=1.26.1; python_version >= '3.12'",
     "openpyxl>=3.1.0",
     "pdfminer-six>=20240706",
+    "pillow>=10; python_version < '3.9'",
+    "pillow>=11; python_version >= '3.9'",
     "pypdf>=3.17,<4.0; python_version < '3.12'",
     "pypdf>=4.0,<6.0; python_version >= '3.12'",
     "pandas>=1.5.3; python_version < '3.10'",


### PR DESCRIPTION
added pillow as a dependency, pillow v10 for below py 3.9 and pillow v11 for py 3.9 and above. Resolves [Issue 552](https://github.com/camelot-dev/camelot/issues/552). Pillow versions obtained from [here](https://pillow.readthedocs.io/en/stable/installation/python-support.html)