### PR TITLE
docs: update branch name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Try it yourself in our interactive quickstart notebook. [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/camelot-dev/camelot/blob/master/examples/camelot-quickstart-notebook.ipynb)
 
-Or check out a simple example using [this pdf](https://github.com/camelot-dev/camelot/blob/main/docs/_static/pdf/foo.pdf).
+Or check out a simple example using [this pdf](https://github.com/camelot-dev/camelot/blob/master/docs/_static/pdf/foo.pdf).
 
 <pre>
 >>> import camelot
@@ -48,7 +48,7 @@ Or check out a simple example using [this pdf](https://github.com/camelot-dev/ca
 
 Camelot also comes packaged with a [command-line interface](https://camelot-py.readthedocs.io/en/latest/user/cli.html)!
 
-Refer to the [QuickStart Guide](https://github.com/camelot-dev/camelot/blob/main/docs/user/quickstart.rst#quickstart) to quickly get started with Camelot, extract tables from PDFs and explore some basic options.
+Refer to the [QuickStart Guide](https://github.com/camelot-dev/camelot/blob/master/docs/user/quickstart.rst#quickstart) to quickly get started with Camelot, extract tables from PDFs and explore some basic options.
 
 **Tip:** Visit the `parser-comparison-notebook` to get an overview of all the packed parsers and their features. [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/camelot-dev/camelot/blob/master/examples/parser-comparison-notebook.ipynb)
 
@@ -119,4 +119,4 @@ Camelot uses [Semantic Versioning](https://semver.org/). For the available versi
 
 ## License
 
-This project is licensed under the MIT License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/master/LICENSE) file for details.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,7 @@ html_theme = "sphinx_book_theme"
 # documentation.
 html_theme_options = {
     "repository_url": "https://github.com/camelot-dev/camelot",
-    "repository_branch": "main",
+    "repository_branch": "master",
     "path_to_docs": "/docs",
     "use_repository_button": True,
     # "launch_buttons": "dict to notebooks to launch",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ Release v\ |version|. (:ref:`Installation <install>`)
     :target: https://camelot-py.readthedocs.io/
     :alt: Documentation Status
 
-.. image:: https://codecov.io/github/camelot-dev/camelot/badge.svg?branch=main&service=github
-    :target: https://codecov.io/github/camelot-dev/camelot/?branch=main
+.. image:: https://codecov.io/github/camelot-dev/camelot/badge.svg?branch=master&service=github
+    :target: https://codecov.io/github/camelot-dev/camelot/?branch=master
 
 .. image:: https://img.shields.io/pypi/v/camelot-py.svg
     :target: https://pypi.org/project/camelot-py/

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -229,7 +229,7 @@ Table areas that you want camelot to analyze can be passed as a list of comma-se
 Specify table regions
 ---------------------
 
-However there may be cases like `[1] <../_static/pdf/table_regions.pdf>`__ and `[2] <https://github.com/camelot-dev/camelot/blob/main/tests/files/tableception.pdf>`__, where the table might not lie at the exact coordinates every time but in an approximate region.
+However there may be cases like `[1] <../_static/pdf/table_regions.pdf>`__ and `[2] <https://github.com/camelot-dev/camelot/blob/master/tests/files/tableception.pdf>`__, where the table might not lie at the exact coordinates every time but in an approximate region.
 
 You can use the ``table_regions`` keyword argument to :meth:`read_pdf() <camelot.read_pdf>` to solve for such cases. When ``table_regions`` is specified, camelot will only analyze the specified regions to look for tables.
 


### PR DESCRIPTION
It appears that the default branch is set to master rather than main. The README and GitHub Actions configuration haven't been updated accordingly.

I have updated the documentation, but I've left the GitHub Actions branch as is to prevent any unnecessary approvals from GitHub Actions.

below is the github action branch which I do not update 

https://github.com/camelot-dev/camelot/blob/master/.github/workflows/tests.yml

```yaml
name: Tests

on:
  push:
    branches: [main]
  pull_request:

```
