### PR TITLE
[MRG] Missing os import fixed in example notebooks

### DIFF
--- a/examples/hybrid-parser-step-by-step.ipynb
+++ b/examples/hybrid-parser-step-by-step.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "# Bootstrap and common imports\n",
-    "import sys, time\n",
+    "import sys, time, os\n",
     "\n",
     "sys.path.insert(\n",
     "    0, os.path.abspath(\"\")\n",

--- a/examples/parser-comparison-notebook.ipynb
+++ b/examples/parser-comparison-notebook.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# Bootstrap and common imports\n",
-    "import sys, time\n",
+    "import sys, time, os\n",
     "\n",
     "sys.path.insert(\n",
     "    0, os.path.abspath(\"\")\n",


### PR DESCRIPTION
`import os` was missing in two notebooks in the examples directory, which has been corrected in this PR.