### PR TITLE
I've addressed a few regressions and documentation issues that came u…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,40 @@
-name: Publish Python 🐍 distribution 📦 to PyPI
+name: Release Drafter and Publish Python 🐍 distribution 📦 to PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
 
 jobs:
+  release-drafter:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build distribution 📦
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build
-        run: >-
-          python3 -m
-          pip install
-          build
-          --user
+        run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+        run: python -m build
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
@@ -32,7 +44,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    if: github.event_name == 'release'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -40,8 +52,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/camelot-py
     permissions:
-      id-token: write # IMPORTANT: mandatory for trusted publishing
-
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v5
@@ -53,16 +64,14 @@ jobs:
 
   github-release:
     name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
+      Sign and upload to GitHub Release
+    if: github.event_name == 'release'
     needs:
       - publish-to-pypi
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write # IMPORTANT: mandatory for sigstore
-
+      contents: write
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v5
@@ -75,21 +84,10 @@ jobs:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          "$GITHUB_REF_NAME"
-          --repo "$GITHUB_REPOSITORY"
-          --notes ""
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Upload to GitHub Release using the `gh` CLI.
-        # `dist/` contains the built packages, and the
-        # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          "$GITHUB_REF_NAME" dist/**
+          "${{ github.event.release.tag_name }}" dist/**
           --repo "$GITHUB_REPOSITORY"

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -1,0 +1,45 @@
+Making a New Release
+====================
+
+This document outlines the process for creating a new release of `camelot-py`.
+
+The release process is semi-automated using GitHub Actions and `release-drafter`.
+
+Prerequisites
+-------------
+
+- You must have maintainer access to the `camelot-dev/camelot` repository.
+
+Release Steps
+-------------
+
+1.  **Drafting the Release**
+
+    Every time a pull request is merged into the `master` branch, the `release-drafter` GitHub Action will automatically update a draft release. This draft will include all the changes since the last release. You can view the draft under the "Releases" section of the repository.
+
+2.  **Publishing the Release**
+
+    When you are ready to create a new release, follow these steps:
+
+    a. Navigate to the `Releases <https://github.com/camelot-dev/camelot/releases>`_ page of the repository.
+
+    b. You should see a draft release at the top of the page. Click the "Edit" button (pencil icon) next to the draft release.
+
+    c. Review the release notes that have been automatically generated. You can edit them if needed.
+
+    d. **Crucially, update the version number in the "Tag version" field.** Follow `semantic versioning <https://semver.org/>`_. For example, if the last release was `v1.0.0`, the new one could be `v1.1.0` for a minor release or `v1.0.1` for a patch release.
+
+    e. Once you are satisfied with the release notes and version number, click the "Publish release" button.
+
+3.  **Automated Publishing**
+
+    Once you publish the release, a GitHub Action will automatically be triggered to:
+
+    - Build the Python distribution (wheel and source tarball).
+    - Publish the distribution to PyPI.
+    - Sign the distribution with Sigstore.
+    - Upload the distribution and signatures as assets to the GitHub release.
+
+    You can monitor the progress of this action under the "Actions" tab of the repository.
+
+And that's it! The new release will be available on PyPI and GitHub.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,4 +125,5 @@ If you want to contribute to the project, this part of the documentation is for 
    :maxdepth: 2
 
    dev/contributing
+   dev/releasing
    Changelog <https://github.com/camelot-dev/camelot/releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = {text = "MIT"}
 readme = "README.md"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+"Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
…p after a repository change:

- I updated the release workflow in `.github/workflows/release.yml` to use `release-drafter`. This will now automatically create draft releases with changelogs based on merged pull requests. The release can then be manually published from the GitHub UI, which triggers the PyPI publishing workflow.
- I added the `Programming Language :: Python :: 3` classifier to `pyproject.toml`. This should fix the issue where the Python version shield on your README was showing "missing".
- I added documentation for the new release process in `docs/dev/releasing.rst` and linked it in the main `index.rst`.
