### PR TITLE
Fix dynamic versioning by fetching full git history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,42 @@
-name: Publish Python 🐍 distribution 📦 to PyPI
+name: Release Drafter and Publish Python 🐍 distribution 📦 to PyPI
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
 
 jobs:
+  release-drafter:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Build distribution 📦
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build
-        run: >-
-          python3 -m
-          pip install
-          build
-          --user
+        run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball
-        run: python3 -m build
+        run: python -m build
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
@@ -32,7 +46,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
+    if: github.event_name == 'release'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -40,8 +54,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/camelot-py
     permissions:
-      id-token: write # IMPORTANT: mandatory for trusted publishing
-
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v5
@@ -53,16 +66,14 @@ jobs:
 
   github-release:
     name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
+      Sign and upload to GitHub Release
+    if: github.event_name == 'release'
     needs:
       - publish-to-pypi
     runs-on: ubuntu-latest
-
     permissions:
-      contents: write # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write # IMPORTANT: mandatory for sigstore
-
+      contents: write
+      id-token: write
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v5
@@ -75,21 +86,10 @@ jobs:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          "$GITHUB_REF_NAME"
-          --repo "$GITHUB_REPOSITORY"
-          --notes ""
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        # Upload to GitHub Release using the `gh` CLI.
-        # `dist/` contains the built packages, and the
-        # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          "$GITHUB_REF_NAME" dist/**
+          "${{ github.event.release.tag_name }}" dist/**
           --repo "$GITHUB_REPOSITORY"

--- a/docs/dev/releasing.rst
+++ b/docs/dev/releasing.rst
@@ -1,0 +1,45 @@
+Making a New Release
+====================
+
+This document outlines the process for creating a new release of `camelot-py`.
+
+The release process is semi-automated using GitHub Actions and `release-drafter`.
+
+Prerequisites
+-------------
+
+- You must have maintainer access to the `camelot-dev/camelot` repository.
+
+Release Steps
+-------------
+
+1.  **Drafting the Release**
+
+    Every time a pull request is merged into the `master` branch, the `release-drafter` GitHub Action will automatically update a draft release. This draft will include all the changes since the last release. You can view the draft under the "Releases" section of the repository.
+
+2.  **Publishing the Release**
+
+    When you are ready to create a new release, follow these steps:
+
+    a. Navigate to the `Releases <https://github.com/camelot-dev/camelot/releases>`_ page of the repository.
+
+    b. You should see a draft release at the top of the page. Click the "Edit" button (pencil icon) next to the draft release.
+
+    c. Review the release notes that have been automatically generated. You can edit them if needed.
+
+    d. **Crucially, update the version number in the "Tag version" field.** Follow `semantic versioning <https://semver.org/>`_. For example, if the last release was `v1.0.0`, the new one could be `v1.1.0` for a minor release or `v1.0.1` for a patch release.
+
+    e. Once you are satisfied with the release notes and version number, click the "Publish release" button.
+
+3.  **Automated Publishing**
+
+    Once you publish the release, a GitHub Action will automatically be triggered to:
+
+    - Build the Python distribution (wheel and source tarball).
+    - Publish the distribution to PyPI.
+    - Sign the distribution with Sigstore.
+    - Upload the distribution and signatures as assets to the GitHub release.
+
+    You can monitor the progress of this action under the "Actions" tab of the repository.
+
+And that's it! The new release will be available on PyPI and GitHub.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,4 +125,5 @@ If you want to contribute to the project, this part of the documentation is for 
    :maxdepth: 2
 
    dev/contributing
+   dev/releasing
    Changelog <https://github.com/camelot-dev/camelot/releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "camelot-py"
-version = "1.0.0"
+dynamic = ["version"]
 description = "PDF Table Extraction for Humans."
 authors = [
     {name = "Vinayak Mehta", email = "vmehta94@gmail.com"},
@@ -9,6 +9,7 @@ license = {text = "MIT"}
 readme = "README.md"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+"Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -36,7 +37,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project.urls]
@@ -145,3 +146,6 @@ disallow_any_generics = true
 
 # This one can be tricky to get passing if you use a lot of untyped libraries
 # warn_return_any = true
+
+[tool.setuptools_scm]
+write_to = "camelot/__version__.py"


### PR DESCRIPTION
The release workflow was failing because `setuptools-scm` was generating a development version (e.g., `1.0.3.dev0+...`) instead of the clean tag version (e.g., `1.0.2`). This was caused by a shallow checkout in the build job, which did not provide `setuptools-scm` with the necessary git history and tags.

This commit fixes the issue by adding `fetch-depth: 0` to the `actions/checkout` step. This ensures the full git history is available, allowing `setuptools-scm` to correctly identify the version from the release tag. This resolves both the version mismatch and the subsequent PyPI error about local versions.