### PR TITLE
feat: Drop Python 3.8 support and add Python 3.13 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.8", os: "ubuntu-latest", session: "tests" }
           - { python: "3.9", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.13", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "windows-latest", session: "tests" }
           - { python: "3.10", os: "macos-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "typeguard" }

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ from nox import session
 package = "camelot"
 
 # TODO: certain sessions are pinned to Python 3.10
-python_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+python_versions = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",
@@ -106,7 +106,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 break
 
 
-@session(name="pre-commit", python=python_versions[2])
+@session(name="pre-commit", python=python_versions[1])
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
     args = session.posargs or [
@@ -133,7 +133,7 @@ def precommit(session: Session) -> None:
         activate_virtualenv_in_precommit_hooks(session)
 
 
-@session(python=python_versions[2])
+@session(python=python_versions[1])
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     requirements = session.run(
@@ -196,7 +196,7 @@ def tests(session: Session) -> None:
             session.notify("coverage", posargs=[])
 
 
-@session(python=python_versions[2])
+@session(python=python_versions[1])
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report", "-i"]
@@ -209,7 +209,7 @@ def coverage(session: Session) -> None:
     session.run("coverage", *args)
 
 
-@session(python=python_versions[2])
+@session(python=python_versions[1])
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
@@ -232,7 +232,7 @@ def xdoctest(session: Session) -> None:
     session.run("python", "-m", "xdoctest", *args)
 
 
-@session(name="docs-build", python=python_versions[5])
+@session(name="docs-build", python=python_versions[4])
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
@@ -258,7 +258,7 @@ def docs_build(session: Session) -> None:
     session.run("sphinx-build", *args)
 
 
-@session(python=python_versions[2])
+@session(python=python_versions[1])
 def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "click>=8.0.1",
     "chardet>=5.1.0",


### PR DESCRIPTION
This commit drops support for Python 3.8, which was failing due to an issue with an older version of setuptools and the license field in pyproject.toml.

The supported Python version range is now '>=3.9'.

Additionally, this commit adds a test job for Python 3.13 to the CI workflow to ensure compatibility with the latest Python version.