### PR TITLE
Fix warnings in test session and parser

### DIFF
--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -1,7 +1,5 @@
 """Implementation of hybrid table parser."""
 
-import numpy as np
-
 from ..utils import bboxes_overlap
 from ..utils import boundaries_to_split_lines
 from .base import BaseParser
@@ -162,10 +160,10 @@ class Hybrid(BaseParser):
         table = parser._generate_table(table_idx, bbox, cols, rows, **kwargs)
         # Because hybrid can inject extraneous splits from both lattice and
         # network, remove lines / cols that are completely empty.
-        table.df = table.df.replace("", np.nan)
-        table.df = table.df.dropna(axis=0, how="all")
-        table.df = table.df.dropna(axis=1, how="all")
-        table.df = table.df.replace(np.nan, "")
+        # drop empty rows
+        table.df = table.df.loc[~(table.df == "").all(axis=1)]
+        # drop empty columns
+        table.df = table.df.loc[:, ~(table.df == "").all(axis=0)]
         table.shape = table.df.shape
         return table
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -201,7 +201,20 @@ def tests(session: Session) -> None:
         *plot_requires,
     )
     try:
-        session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+        session.run(
+            "coverage",
+            "run",
+            "--parallel",
+            "-m",
+            "pytest",
+            *session.posargs,
+            env={
+                "PYTHONWARNINGS": (
+                    "ignore:ARC4 has been moved to"
+                    " cryptography.hazmat.decrepit.ciphers.algorithms.ARC4"
+                )
+            },
+        )
     finally:
         if session.interactive:
             session.notify("coverage", posargs=[])

--- a/noxfile.py
+++ b/noxfile.py
@@ -201,20 +201,7 @@ def tests(session: Session) -> None:
         *plot_requires,
     )
     try:
-        session.run(
-            "coverage",
-            "run",
-            "--parallel",
-            "-m",
-            "pytest",
-            *session.posargs,
-            env={
-                "PYTHONWARNINGS": (
-                    "ignore:ARC4 has been moved to"
-                    " cryptography.hazmat.decrepit.ciphers.algorithms.ARC4"
-                )
-            },
-        )
+        session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
         if session.interactive:
             session.notify("coverage", posargs=[])


### PR DESCRIPTION
This commit addresses two warnings that appear during the test session:

1.  A `FutureWarning` in `camelot/parsers/hybrid.py` related to the
    downcasting behavior of `pandas.DataFrame.replace`. The code has been
    refactored to avoid the use of `replace` with `np.nan` and instead
    uses a more direct method to remove empty rows and columns.

2.  A `CryptographyDeprecationWarning` originating from the `pypdf`
    dependency. This warning is suppressed by setting the
    `PYTHONWARNINGS` environment variable in the `noxfile.py` for the
    test session. This approach is used because filtering the warning
    via `pytest.ini` is not feasible due to the way the warning is
    raised.



Fixes #612 

(Sorry for the messy grouping of issues. I am testing / fighting the :robot: 
Whats matter most is that we are still progressing again in this repo.)