### PR TITLE
Silence warnings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -201,7 +201,20 @@ def tests(session: Session) -> None:
         *plot_requires,
     )
     try:
-        session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
+        session.run(
+            "coverage",
+            "run",
+            "--parallel",
+            "-m",
+            "pytest",
+            *session.posargs,
+            env={
+                "PYTHONWARNINGS": (
+                    "ignore:ARC4 has been moved to"
+                    " cryptography.hazmat.decrepit.ciphers.algorithms.ARC4"
+                )
+            },
+        )
     finally:
         if session.interactive:
             session.notify("coverage", posargs=[])


### PR DESCRIPTION
A CryptographyDeprecationWarning originating from the pypdf dependency. This warning is suppressed by setting the PYTHONWARNINGS environment variable in the noxfile.py for the test session. This approach is used because filtering the warning via pytest.ini is not feasible due to the way the warning is raised.