### PR TITLE
Ensure PdfiumBackend closes document and image handles

### DIFF
--- a/camelot/backends/pdfium_backend.py
+++ b/camelot/backends/pdfium_backend.py
@@ -38,8 +38,13 @@ class PdfiumBackend(ConversionBackend):
         if not self.installed():
             raise OSError(f"pypdfium2 is not available: {PDFIUM_EXC!r}")
         doc = pdfium.PdfDocument(pdf_path)
-        doc.init_forms()
-        image = doc[0].render(scale=resolution / 72).to_pil()
-        image.save(png_path)
-        image.close()
-        doc.close()
+        try:
+            doc.init_forms()
+            image = doc[0].render(scale=resolution / 72).to_pil()
+            try:
+                image.save(png_path)
+            finally:
+                image.close()
+        finally:
+            doc.close()
+


### PR DESCRIPTION
Fixes #660

ensures PdfDocument and rendered PIL Image are always closed,
even if rendering or saving raises an exception. this prevents
open file handle leaks seen in the PyPI release
