### PR TITLE
Remove chardet dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "click>=8.0.1",
-    "chardet>=5.1.0",
     "numpy>=1.24.4; python_version < '3.12'",
     "numpy>=1.26.1; python_version >= '3.12'",
     "openpyxl>=3.1.0",


### PR DESCRIPTION
To resolve https://github.com/camelot-dev/camelot/issues/673. 

Removes the `chardet` dependency, because:

- `chardet` is [unused](https://github.com/search?q=repo%3Acamelot-dev%2Fcamelot%20chardet&type=code)
- it was originally added to resolve [an issue within `pdfminer-six` dependencies](https://github.com/camelot-dev/camelot/commit/2635f910e49cbd533ddc00680d5f2ef7eec4524c)
- `pdfminer-six` has since [removed the `chardet` dependency](https://github.com/pdfminer/pdfminer.six/blob/9e1243c4ad000bf9bbe60e81fc8dde2fccc0ed3b/CHANGELOG.md?plain=1#L236) as of `pdfminer-six== 20220506`
- this package's [requirement](https://github.com/camelot-dev/camelot/blob/master/pyproject.toml#L26) is `pdfminer-six>=20240706`

Therefore, `chardet` is not needed as a dependency of this package. This is helpful to users, who will need to install fewer dependencies now. Furthermore, `chardet` is LGPL licensed, which is copyleft and requires this package to share the same licensing if it remains a dependency.