### PR TITLE
Release v1.0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "click>=8.0.1",
-    "chardet>=5.1.0",
     "numpy>=1.24.4; python_version < '3.12'",
     "numpy>=1.26.1; python_version >= '3.12'",
     "openpyxl>=3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "camelot-py"
-version = "1.0.9"
+version = "1.0.10"
 description = "PDF Table Extraction for Humans."
 authors = [
     {name = "Vinayak Mehta", email = "vmehta94@gmail.com"},


### PR DESCRIPTION
See #694 for more information.

Releases v1.0.10 of `camelot-py`.