### PR TITLE
Fix PermissionError on Windows when parsing multiple PDFs (#678)

### DIFF
--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -231,7 +231,15 @@ class TemporaryDirectory:
         traceback : [type]
             [description]
         """
-        pass
+        # Unregister the atexit callback so we don't try to clean up twice.
+        # Then immediately delete the temp directory. This fixes PermissionError
+        # on Windows when processing multiple PDFs, where pdfium/pypdf file
+        # handles may still be open when atexit runs at program exit.
+        try:
+            atexit.unregister(shutil.rmtree)
+        except ValueError:
+            pass
+        shutil.rmtree(self.name, ignore_errors=True)
 
 
 def build_file_path_in_temp_dir(filename, extension=None):


### PR DESCRIPTION
Fixes camelot-dev/camelot#678

## Bug
When parsing multiple PDFs on Windows with Python 3.13+, Camelot raises PermissionError during atexit cleanup of temporary directories. This happens because:
1. TemporaryDirectory registers shutil.rmtree via atexit to delete the temp dir at program exit
2. When processing multiple PDFs, the pdfium/pypdf file handles may still be open when atexit runs
3. On Windows, open file handles prevent directory deletion, causing PermissionError (WinError 5)

## Fix
In TemporaryDirectory.__exit__, we now:
1. Unregister the atexit callback to prevent double-cleanup
2. Immediately call shutil.rmtree with ignore_errors=True while file handles may still be closing

This ensures the temp directory is cleaned up deterministically when the context manager exits, rather than deferring to program exit where timing of handle release is unreliable on Windows.