### PR TITLE
fix(core): materialise TableList iterable so bool/len work

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -926,7 +926,10 @@ class TableList:
     """
 
     def __init__(self, tables: Iterable[Table]) -> None:  # noqa D105
-        self._tables: Iterable[Table] = tables
+        # Materialise the iterable so __len__, __bool__, and __getitem__ work
+        # for any Iterable[Table] input (e.g. a generator), not just Sized
+        # containers. See #655.
+        self._tables: list[Table] = list(tables)
 
     def __repr__(self):  # noqa D105
         return f"<{self.__class__.__name__} n={self.n}>"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -276,7 +276,7 @@ def test_table_list_iter():
 
 
 def test_tablelist_accepts_iterable():
-    """TableList should accept any Iterable[Table], not just Sized (#655)."""
+    """Accept any Iterable[Table] for TableList — not just Sized (#655)."""
     # Empty generator: bool / len must work without consuming-issues.
     empty = TableList(t for t in [])
     assert len(empty) == 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -273,3 +273,19 @@ def test_table_list_iter():
     assert iterator_b is not None
     item_c = next(iterator_b)
     assert item_c is not None
+
+
+def test_tablelist_accepts_iterable():
+    """TableList should accept any Iterable[Table], not just Sized (#655)."""
+    # Empty generator: bool / len must work without consuming-issues.
+    empty = TableList(t for t in [])
+    assert len(empty) == 0
+    assert bool(empty) is False
+
+    # Non-empty generator: previously raised TypeError on len/bool.
+    sentinels = [object(), object()]
+    tl = TableList(iter(sentinels))
+    assert len(tl) == 2
+    assert bool(tl) is True
+    assert tl[0] is sentinels[0]
+    assert tl[1] is sentinels[1]


### PR DESCRIPTION
Closes #655.

`TableList.__init__` accepts `Iterable[Table]` per its type annotation but stored the value unchanged. `__len__` (and therefore `__bool__`) only worked for `Sized` containers, so the documented usage:

```py
bool(TableList(x for x in old_tablelist))
```

raised `TypeError: object of type 'generator' has no len()`.

Materialise the iterable once in `__init__` (i.e. `list(tables)`). Adds a regression test covering empty and non-empty generators.