### PR TITLE
fix(core): suppress pandas auto-header/index in to_excel by default

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -848,7 +848,12 @@ class Table:
             Output filepath.
 
         """
-        kw = {"encoding": "utf-8"}
+        # Mirror to_csv defaults: suppress pandas' auto-generated integer
+        # row index and column header. Camelot's DataFrame uses positional
+        # indices (0, 1, 2, …) for rows and columns, which leak into the
+        # Excel output as a meaningless extra row and column. See #634.
+        # Users can override by passing index=True / header=True.
+        kw = {"encoding": "utf-8", "index": False, "header": False}
         sheet_name = f"page-{self.page}-table-{self.order}"
         kw.update(kwargs)
         writer = pd.ExcelWriter(path)


### PR DESCRIPTION
Closes #634.

Camelot DataFrames use positional integer row/column indices, so `pd.to_excel` writes an extra meaningless row and column. `to_csv` has long defaulted to `index=False, header=False` for this exact reason; `to_excel` did not — inconsistent across formats.

Bring `to_excel` in line with `to_csv`. Users can opt back in with `table.to_excel(path, index=True, header=True)`.