### PR TITLE
feat(parallel): add cpu_count cap for parallel parsing

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -225,7 +225,9 @@ class PDFHandler:
         max_cpus = mp.cpu_count()
         if parallel and len(self.pages) > 1 and max_cpus > 1:
             # Clamp the caller's cpu_count to [1, max_cpus]; default to all.
-            cpu_count = max_cpus if cpu_count is None else max(1, min(cpu_count, max_cpus))
+            cpu_count = (
+                max_cpus if cpu_count is None else max(1, min(cpu_count, max_cpus))
+            )
         else:
             cpu_count = 1
         try:

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -183,6 +183,7 @@ class PDFHandler:
         flavor: str = "lattice",
         suppress_stdout: bool = False,
         parallel: bool = False,
+        cpu_count: int | None = None,
         layout_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ):
@@ -197,6 +198,11 @@ class PDFHandler:
             Suppress logs and warnings.
         parallel : bool (default: False)
             Process pages in parallel using all available cpu cores.
+        cpu_count : int, optional (default: None)
+            Maximum number of worker processes to use when ``parallel`` is
+            True. ``None`` (default) uses all available cores. Values are
+            clamped to ``[1, multiprocessing.cpu_count()]``. Ignored when
+            ``parallel`` is False.
         layout_kwargs : dict, optional (default: {})
             A dict of `pdfminer.layout.LAParams
             <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ kwargs.
@@ -216,9 +222,10 @@ class PDFHandler:
         parser_obj = PARSERS[flavor]
         parser = parser_obj(debug=self.debug, **kwargs)
 
-        cpu_count = mp.cpu_count()
-        if parallel and len(self.pages) > 1 and cpu_count > 1:
-            pass
+        max_cpus = mp.cpu_count()
+        if parallel and len(self.pages) > 1 and max_cpus > 1:
+            # Clamp the caller's cpu_count to [1, max_cpus]; default to all.
+            cpu_count = max_cpus if cpu_count is None else max(1, min(cpu_count, max_cpus))
         else:
             cpu_count = 1
         try:

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -16,6 +16,7 @@ def read_pdf(
     flavor="lattice",
     suppress_stdout=False,
     parallel=False,
+    cpu_count=None,
     layout_kwargs=None,
     debug=False,
     **kwargs,
@@ -42,6 +43,11 @@ def read_pdf(
         Print all logs and warnings.
     parallel : bool, optional (default: False)
         Process pages in parallel using all available cpu cores.
+    cpu_count : int, optional (default: None)
+        Maximum number of worker processes when ``parallel=True``. ``None``
+        (default) uses all available cores. Values are clamped to
+        ``[1, multiprocessing.cpu_count()]``. Ignored when
+        ``parallel=False``.
     layout_kwargs : dict, optional (default: {})
         A dict of `pdfminer.layout.LAParams
         <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ kwargs.
@@ -133,6 +139,7 @@ def read_pdf(
             flavor=flavor,
             suppress_stdout=suppress_stdout,
             parallel=parallel,
+            cpu_count=cpu_count,
             layout_kwargs=layout_kwargs,
             **kwargs,
         )


### PR DESCRIPTION
Closes #562.

`read_pdf(parallel=True)` (and `PDFHandler.parse`) saturated every core via `multiprocessing.cpu_count()`, with no way for callers to cap it. This adds an optional `cpu_count` parameter to both APIs.

Semantics:
- `cpu_count=None` (default): use all available cores — unchanged behaviour.
- `cpu_count=N`: clamp to `[1, mp.cpu_count()]`.
- Ignored when `parallel=False`.