### PR TITLE
chore(types): annotate TableList.__getitem__ return type

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -934,8 +934,11 @@ class TableList:
     def __len__(self):  # noqa D105
         return len(self._tables)
 
-    def __getitem__(self, idx):  # noqa D105
-        return self._tables[idx]
+    def __getitem__(self, idx: int) -> Table:  # noqa D105
+        # _tables is currently typed as Iterable[Table]; #710 materialises it
+        # to list[Table] which will let this index without the ignore. Until
+        # that lands, silence mypy's (correct) complaint here.
+        return self._tables[idx]  # type: ignore[index]
 
     def __iter__(self) -> Iterator[Table]:  # noqa D105
         return iter(self._tables)


### PR DESCRIPTION
Re-applies the 1-line type annotation from @16dprice's #477, which sat unmerged for 5 years and bit-rotted. Lets type checkers and IDEs know that `TableList[idx]` yields a `Table`, so `tables[0].df` autocompletes correctly.

Supersedes #477. Closing that as part of merging this.