### PR TITLE
fix(pdfium): close document and image handles via try-finally

### DIFF
--- a/camelot/backends/pdfium_backend.py
+++ b/camelot/backends/pdfium_backend.py
@@ -41,8 +41,12 @@ class PdfiumBackend(ConversionBackend):
         if not self.installed():
             raise OSError(f"pypdfium2 is not available: {PDFIUM_EXC!r}")
         doc = pdfium.PdfDocument(pdf_path)
-        doc.init_forms()
-        image = doc[page - 1].render(scale=resolution / 72).to_pil()
-        image.save(png_path)
-        image.close()
-        doc.close()
+        try:
+            doc.init_forms()
+            image = doc[page - 1].render(scale=resolution / 72).to_pil()
+            try:
+                image.save(png_path)
+            finally:
+                image.close()
+        finally:
+            doc.close()


### PR DESCRIPTION
Closes #660.

Cherry-pick of @Mohataseem89's commit from #661 (author preserved) onto current master, with the conflict against `#614`'s addition of the `page` parameter resolved (`doc[page - 1]` retained, wrapped in try-finally).

Ensures `PdfDocument` and the rendered PIL image are released even if rendering or saving raises, preventing the open-handle leak observed in PyPI installs.

Supersedes #661. Closing that as part of merging this.