### PR TITLE
test(cli): cover Config.set_config and group wiring (#614 follow-up)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,3 +325,31 @@ def test_version_package_not_found():
         from camelot.cli import get_version
 
         assert get_version() is None
+
+
+def test_config_set_config():
+    """Config.set_config stores values for the cli group's kwargs handoff (#614).
+
+    Direct unit test — the group accepts no options of its own today, so this
+    code path isn't exercised by the subcommand integration tests.
+    """
+    from camelot.cli import Config
+
+    c = Config()
+    c.set_config("flag", True)
+    c.set_config("name", "lattice")
+    assert c.config == {"flag": True, "name": "lattice"}
+
+
+def test_cli_group_help_invokes_config():
+    """The group callback wires ctx.obj to a Config instance (#614)."""
+    from click.testing import CliRunner
+
+    from camelot.cli import cli
+
+    runner = CliRunner()
+    # Invoke a real subcommand with --help so we hit the group's body
+    # (setting ctx.obj) but stop before requiring positional args.
+    result = runner.invoke(cli, ["lattice", "--help"])
+    assert result.exit_code == 0
+    assert "lattice" in result.output.lower()


### PR DESCRIPTION
Follow-up to #614 — adds the coverage that codecov flagged as missing.

#614 moved every option off the `cli` group onto each subcommand, leaving the `Config` class and the `for key, value in kwargs.items(): ctx.obj.set_config(...)` loop reachable only via direct unit-testing (the subcommand integration tests pass no group-level kwargs).

Two small tests:
- `test_config_set_config` — direct unit test of `Config.set_config`.
- `test_cli_group_help_invokes_config` — invokes `lattice --help` to run the group's body and assert it returns 0.