### PR TITLE
docs: update pdfminer/pypdf references to playa-pdf

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -283,12 +283,12 @@ Let's get back to the *x* coordinates we got from plotting the text that exists 
     "NUMBER TYPE DBA NAME","","","LICENSEE NAME","ADDRESS","CITY","ST","ZIP","PHONE NUMBER","EXPIRES"
     "...","...","...","...","...","...","...","...","...","..."
 
-Ah! Since `PDFMiner <https://github.com/pdfminer/pdfminer.six>`_ merged the strings, "NUMBER", "TYPE" and "DBA NAME", all of them were assigned to the same cell. Let's see how we can fix this in the next section.
+Ah! Since `playa <https://pypi.org/project/playa-pdf/>`_ (the PDFMiner-compatible layout engine Camelot now uses) merged the strings, "NUMBER", "TYPE" and "DBA NAME", all of them were assigned to the same cell. Let's see how we can fix this in the next section.
 
 Split text along separators
 ---------------------------
 
-To deal with cases like the output from the previous section, you can pass ``split_text=True`` to :meth:`read_pdf() <camelot.read_pdf>`, which will split any strings that lie in different cells but have been assigned to a single cell (as a result of being merged together by `PDFMiner <https://github.com/pdfminer/pdfminer.six>`_).
+To deal with cases like the output from the previous section, you can pass ``split_text=True`` to :meth:`read_pdf() <camelot.read_pdf>`, which will split any strings that lie in different cells but have been assigned to a single cell (as a result of being merged together by `playa <https://pypi.org/project/playa-pdf/>`_, the PDFMiner-compatible layout engine).
 
 .. code-block:: pycon
   :class: full-width
@@ -635,9 +635,9 @@ We don't need anything else. Now, let's pass ``copy_text=['v']`` to copy text in
 Tweak layout generation
 -----------------------
 
-camelot is built on top of PDFMiner's functionality of grouping characters on a page into words and sentences. In some cases (such as `#170 <https://github.com/atlanhq/camelot/issues/170>`_ and `#215 <https://github.com/atlanhq/camelot/issues/215>`_), PDFMiner can group characters that should belong to the same sentence into separate sentences.
+Camelot is built on top of `playa <https://pypi.org/project/playa-pdf/>`_'s PDFMiner-compatible functionality for grouping characters on a page into words and sentences. In some cases (such as `#170 <https://github.com/atlanhq/camelot/issues/170>`_ and `#215 <https://github.com/atlanhq/camelot/issues/215>`_), the layout engine can group characters that should belong to the same sentence into separate sentences.
 
-To deal with such cases, you can tweak PDFMiner's `LAParams kwargs <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ to improve layout generation, by passing the keyword arguments as a dict using ``layout_kwargs`` in :meth:`read_pdf() <camelot.read_pdf>`. To know more about the parameters you can tweak, you can check out `PDFMiner docs <https://pdfminersix.rtfd.io/en/latest/reference/composable.html>`_.
+To deal with such cases, you can tweak the layout engine's `LAParams kwargs <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ to improve layout generation, by passing the keyword arguments as a dict using ``layout_kwargs`` in :meth:`read_pdf() <camelot.read_pdf>`. ``playa.miner`` mirrors PDFMiner.six's ``LAParams``, so the upstream `PDFMiner.six docs <https://pdfminersix.rtfd.io/en/latest/reference/composable.html>`_ still describe what each parameter does.
 
 .. code-block:: pycon
 

--- a/docs/user/how-it-works.rst
+++ b/docs/user/how-it-works.rst
@@ -19,7 +19,7 @@ Where *Hybrid* is a combination of the *Network* and *Lattice* parser.
 Stream
 ------
 
-Stream can be used to parse tables that have whitespaces between cells to simulate a table structure. It is built on top of PDFMiner's functionality of grouping characters on a page into words and sentences, using `margins <https://pdfminersix.readthedocs.io/en/latest/reference/commandline.html>`_.
+Stream can be used to parse tables that have whitespaces between cells to simulate a table structure. It is built on top of `playa <https://pypi.org/project/playa-pdf/>`_'s PDFMiner-compatible functionality for grouping characters on a page into words and sentences, using `margins <https://pdfminersix.readthedocs.io/en/latest/reference/commandline.html>`_.
 
 1. Words on the PDF page are grouped into text rows based on their *y* axis overlaps.
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -121,7 +121,7 @@ To extract tables from encrypted PDF files you must provide a password when call
 
         $ camelot --password userpass lattice foo.pdf
 
-Camelot supports PDFs with all encryption types supported by `pypdf`_. This might require installing PyCryptodome. An exception is thrown if the PDF cannot be read. This may be due to no password being provided, an incorrect password, or an unsupported encryption algorithm.
+Camelot supports PDFs with all encryption types supported by `playa`_. This might require installing PyCryptodome. An exception is thrown if the PDF cannot be read. This may be due to no password being provided, an incorrect password, or an unsupported encryption algorithm.
 
 Further encryption support may be added in future, however in the meantime if your PDF files are using unsupported encryption algorithms you are advised to remove encryption before calling :meth:`read_pdf() <camelot.read_pdf>`. This can been successfully achieved with third-party tools such as `QPDF`_.
 
@@ -129,7 +129,7 @@ Further encryption support may be added in future, however in the meantime if yo
 
     $ qpdf --password=<PASSWORD> --decrypt input.pdf output.pdf
 
-.. _pypdf: https://pypdf.readthedocs.io/en/latest/user/pdf-version-support.html
+.. _playa: https://pypi.org/project/playa-pdf/
 .. _QPDF: https://www.github.com/qpdf/qpdf
 
 ----


### PR DESCRIPTION
The PDF backend migrated from `pypdf` + `pdfminer.six` to [`playa-pdf`](https://pypi.org/project/playa-pdf/), which exposes a PDFMiner-compatible layout engine as `playa.miner`. The user docs still described the old backend.

- `advanced.rst`: the 'merged-strings' explanation and the LAParams tweak section now point to playa-pdf. The upstream pdfminer.six LAParams reference is retained for parameter semantics (playa.miner mirrors them).
- `how-it-works.rst`: same swap in the Stream section.
- `quickstart.rst`: encryption support now reads via playa, not pypdf. RST link alias updated.