### PR TITLE
fix(utils): TemporaryDirectory cleans up on __exit__ (Windows PermissionError)

### DIFF
--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -223,7 +223,15 @@ class TemporaryDirectory:
         traceback : [type]
             [description]
         """
-        pass
+        # Unregister the atexit callback so we don't try to clean up twice.
+        # Then immediately delete the temp directory. This fixes PermissionError
+        # on Windows when processing multiple PDFs, where pdfium/pypdf file
+        # handles may still be open when atexit runs at program exit.
+        try:
+            atexit.unregister(shutil.rmtree)
+        except ValueError:
+            pass
+        shutil.rmtree(self.name, ignore_errors=True)
 
 
 def build_file_path_in_temp_dir(filename, extension=None):


### PR DESCRIPTION
Closes #678.

Cherry-pick of @AmSach's commit from #702 (author preserved) onto current master. The original PR branched from the pre-playa-pdf migration so a full rebase would conflict in every file; the substantive change (8 lines in `TemporaryDirectory.__exit__`) applies cleanly to today's master.

### What it fixes
On Windows + Python 3.13+, parsing multiple PDFs raised `PermissionError` during the atexit cleanup of temp directories: pdfium/pypdfium2 file handles were still open when the global atexit handler tried `shutil.rmtree`. Unregistering the atexit callback in `__exit__` and removing the directory immediately (with `ignore_errors=True`) avoids the race.

Supersedes #702 — closing that with credit to @AmSach.