### PR TITLE
chore(codecov): replace strict 100% targets with realistic auto/90% ones

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,17 @@ coverage:
   status:
     project:
       default:
-        target: "100"
+        # Don't lower overall project coverage. The previous strict "100"
+        # target failed every PR — the project has never been at 100 %, so
+        # the check was permanently red. "auto" means "do not regress vs
+        # base"; a 1 % threshold absorbs unavoidable noise from added or
+        # removed files.
+        target: auto
+        threshold: 1%
     patch:
       default:
-        target: "100"
+        # Keep new code held to the high bar — anything a PR touches
+        # should be exercised by tests. Use a small threshold so a single
+        # uncovered branch in a large diff doesn't fail outright.
+        target: 90%
+        threshold: 5%


### PR DESCRIPTION
Both `project` and `patch` targets in `codecov.yml` were set to 100, so:

- **codecov/project** failed on **every** PR, including ones that *increased* coverage, because the project has never been at 100 %.
- **codecov/patch** failed whenever a diff had even one uncovered line, including pure refactors with no semantic change.

Move to the conventional setup:

| status | old | new | meaning |
|---|---|---|---|
| project | target=100 | target=auto, threshold=1 % | don't regress vs base; absorb noise |
| patch | target=100 | target=90 %, threshold=5 % | new code still held high, but one uncovered branch in a large diff is OK |

This restores the check as a useful signal rather than a permanent red on every PR.

If you want stricter, the right knob is to bump `patch.target` (e.g. 95 %); leaving `project.target=auto` is the standard 'don't make it worse' rule that most active OSS projects use.