### PR TITLE
fix(tests): use MagicMock(spec=Table) so typeguard accepts the sentinels

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -277,13 +277,19 @@ def test_table_list_iter():
 
 def test_tablelist_accepts_iterable():
     """Accept any Iterable[Table] for TableList — not just Sized (#655)."""
+    from unittest.mock import MagicMock
+
     # Empty generator: bool / len must work without consuming-issues.
     empty = TableList(t for t in [])
     assert len(empty) == 0
     assert bool(empty) is False
 
-    # Non-empty generator: previously raised TypeError on len/bool.
-    sentinels = [object(), object()]
+    # Non-empty generator: previously raised TypeError on len/bool. Use
+    # MagicMock(spec=Table) so the typeguard session is happy with
+    # __getitem__'s `-> Table` annotation; plain `object()` would trip
+    # `typeguard.TypeCheckError: the return value (object) is not an
+    # instance of camelot.core.Table`.
+    sentinels = [MagicMock(spec=Table), MagicMock(spec=Table)]
     tl = TableList(iter(sentinels))
     assert len(tl) == 2
     assert bool(tl) is True


### PR DESCRIPTION
Follow-up to #710 + #715.

The `test_tablelist_accepts_iterable` regression test (added by #710) used plain `object()` as TableList input. Once #715 landed the `__getitem__(...) -> Table` return-type annotation, the **typeguard** CI session started failing on every PR that runs against current master:

```
tests/test_common.py::test_tablelist_accepts_iterable
typeguard.TypeCheckError: the return value (object) is not an instance of camelot.core.Table
```

Swap the sentinels for `MagicMock(spec=Table)`. `isinstance(x, Table)` is True (via the spec), the identity assertions (`is`) still work, and typeguard is satisfied. The test still exercises the original bug (`bool(TableList(generator))` had raised `TypeError` pre-fix).

Currently red on **#718** typeguard run; will also unblock the other open PRs whose typeguard job runs against this same master.