### PR TITLE
perf(utils): vectorised row search in get_table_index (~1.5x on top of #727)

### DIFF
--- a/bench/bench_get_table_index.py
+++ b/bench/bench_get_table_index.py
@@ -1,0 +1,259 @@
+"""Microbenchmark + correctness check for ``get_table_index`` vectorisation.
+
+Not a pytest test - run directly with ``python bench/bench_get_table_index.py``.
+
+This script:
+
+* Builds the legacy Python-loop implementation of ``get_table_index`` (copied
+  verbatim from the post-#727 master version) for an apples-to-apples
+  comparison against the new NumPy implementation in :mod:`camelot.utils`.
+* Generates a synthetic 50 rows x 10 cols table plus 200 random text-like
+  objects, then asserts the two implementations return bit-identical results.
+* Times both versions over many repetitions and prints
+  ``old=X ms new=Y ms speedup=Zx``.
+
+The text-like objects use ``__slots__`` so attribute access cost is
+representative of PDFMiner ``LTTextLine`` instances.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import time
+import warnings
+from pathlib import Path
+
+# Ensure we import the in-tree camelot package even when run from anywhere.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from camelot.core import Table  # noqa: E402
+from camelot.utils import calculate_assignment_error  # noqa: E402,F401
+from camelot.utils import flag_font_size  # noqa: E402
+from camelot.utils import get_table_index as get_table_index_new  # noqa: E402
+from camelot.utils import split_textline  # noqa: E402
+from camelot.utils import text_strip  # noqa: E402
+
+
+class FakeTextLine:
+    """Minimal stand-in for ``pdfminer.layout.LTTextLine``."""
+
+    __slots__ = ("x0", "y0", "x1", "y1", "_text", "_objs")
+
+    def __init__(self, x0, y0, x1, y1, text="x"):
+        self.x0 = x0
+        self.y0 = y0
+        self.x1 = x1
+        self.y1 = y1
+        self._text = text
+        self._objs = []
+
+    def get_text(self):  # noqa: D102
+        return self._text
+
+
+# ---------------------------------------------------------------------------
+# Legacy implementation (post-#727, pre-vectorisation) for the head-to-head.
+# Kept inline so the benchmark survives future changes to the package code.
+# ---------------------------------------------------------------------------
+def get_table_index_old(  # noqa: C901, D103
+    table, t, direction, split_text=False, flag_size=False, strip_text=""
+):
+    y_mid = (t.y0 + t.y1) / 2.0
+    t_x0, t_x1 = t.x0, t.x1
+    rows = table.rows
+    cols = table.cols
+
+    r_idx, c_idx = -1, -1
+    for r, (y_top, y_bot) in enumerate(rows):
+        if y_mid >= y_top:
+            break
+        if y_mid <= y_bot:
+            continue
+        best_overlap = -1.0
+        best_c = -1
+        any_hit = False
+        for cidx, (c_left, c_right) in enumerate(cols):
+            if c_left <= t_x1 and c_right >= t_x0:
+                left = t_x0 if c_left <= t_x0 else c_left
+                right = t_x1 if c_right >= t_x1 else c_right
+                ov = abs(left - right) / abs(c_left - c_right)
+                any_hit = True
+                if ov > best_overlap:
+                    best_overlap = ov
+                    best_c = cidx
+        if not any_hit:
+            text = t.get_text().strip("\n")
+            text_range = (t_x0, t_x1)
+            col_range = (cols[0][0], cols[-1][1])
+            warnings.warn(
+                f"{text} {text_range} does not lie in column range {col_range}",
+                stacklevel=1,
+            )
+        r_idx = r
+        c_idx = best_c
+        break
+    if r_idx == -1:
+        return [], 1.0
+
+    error = calculate_assignment_error(t, table, r_idx, c_idx)
+
+    if split_text:
+        return (
+            split_textline(
+                table, t, direction, flag_size=flag_size, strip_text=strip_text
+            ),
+            error,
+        )
+    if flag_size:
+        return [
+            (r_idx, c_idx, flag_font_size(t._objs, direction, strip_text=strip_text))
+        ], error
+    return [(r_idx, c_idx, text_strip(t.get_text(), strip_text))], error
+
+
+# ---------------------------------------------------------------------------
+# Fixture generation
+# ---------------------------------------------------------------------------
+def make_table(n_rows=50, n_cols=10, page_w=600.0, page_h=800.0):
+    """Build a Table with ``n_rows`` x ``n_cols`` evenly spaced cells.
+
+    Rows are returned descending by ``y_top`` to match the parser convention.
+    """
+    row_h = page_h / n_rows
+    col_w = page_w / n_cols
+    # Descending y_top.
+    rows = [(page_h - i * row_h, page_h - (i + 1) * row_h) for i in range(n_rows)]
+    cols = [(i * col_w, (i + 1) * col_w) for i in range(n_cols)]
+    return Table(cols, rows)
+
+
+def make_table_overlapping(n_rows=50, n_cols=10, page_w=600.0, page_h=800.0):
+    """Build a Table whose rows deliberately overlap each other.
+
+    Used to exercise the bit-identity fallback path that handles
+    non-disjoint row partitions (which the production parsers never
+    emit but a downstream consumer could construct by hand).
+    """
+    row_h = page_h / n_rows
+    col_w = page_w / n_cols
+    overlap = row_h * 0.4
+    rows = [
+        (page_h - i * row_h + overlap, page_h - (i + 1) * row_h - overlap)
+        for i in range(n_rows)
+    ]
+    cols = [(i * col_w, (i + 1) * col_w) for i in range(n_cols)]
+    return Table(cols, rows)
+
+
+def make_textlines(n, page_w=600.0, page_h=800.0, seed=0xCAFE10):
+    """Generate ``n`` random text-like objects across the page."""
+    rng = random.Random(seed)  # noqa: S311
+    out = []
+    for _ in range(n):
+        x0 = rng.uniform(-20.0, page_w + 20.0)  # some out-of-range too
+        y0 = rng.uniform(-20.0, page_h + 20.0)
+        w = rng.uniform(5.0, 60.0)
+        h = rng.uniform(5.0, 20.0)
+        out.append(FakeTextLine(x0, y0, x0 + w, y0 + h, text="t"))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Correctness verification
+# ---------------------------------------------------------------------------
+def assert_bit_identical(n_tables=8, n_textlines=200, n_rows=50, n_cols=10):
+    """Compare old vs new outputs on many random tables/textlines.
+
+    Exercises both the common non-overlapping row layout and the
+    fallback path for overlapping rows that the new implementation has
+    to handle to stay bit-identical with the previous Python loop.
+    """
+    rng = random.Random(0xBEEFCAFE)  # noqa: S311
+    mismatches = 0
+    factories = (("disjoint", make_table), ("overlapping", make_table_overlapping))
+    for k in range(n_tables):
+        # Vary the page size to exercise different row/col widths.
+        page_w = rng.uniform(300.0, 800.0)
+        page_h = rng.uniform(400.0, 1100.0)
+        for label, factory in factories:
+            table_old = factory(n_rows, n_cols, page_w, page_h)
+            table_new = factory(n_rows, n_cols, page_w, page_h)
+            textlines = make_textlines(n_textlines, page_w, page_h, seed=0xCAFE10 + k)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                for t in textlines:
+                    old = get_table_index_old(table_old, t, "horizontal")
+                    new = get_table_index_new(table_new, t, "horizontal")
+                    if old != new:
+                        mismatches += 1
+                        if mismatches < 5:
+                            print(
+                                f"MISMATCH [{label}] table={k} "
+                                f"t=({t.x0:.2f},{t.y0:.2f},"
+                                f"{t.x1:.2f},{t.y1:.2f})"
+                                f"\n  old={old}\n  new={new}"
+                            )
+    if mismatches:
+        raise AssertionError(f"{mismatches} mismatches between old and new")
+    print(
+        f"correctness: OK ({n_tables} tables x {n_textlines} textlines "
+        f"x {len(factories)} row layouts)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+def bench(n_rows=50, n_cols=10, n_textlines=200, reps=500):
+    """Time both implementations head-to-head."""
+    table_old = make_table(n_rows, n_cols)
+    table_new = make_table(n_rows, n_cols)
+    # Warm the lazy numpy cache so we measure only the steady-state cost.
+    _ = table_new._rows_np
+    _ = table_new._cols_np
+    textlines = make_textlines(n_textlines)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+
+        # Warm-up
+        for t in textlines:
+            get_table_index_old(table_old, t, "horizontal")
+            get_table_index_new(table_new, t, "horizontal")
+
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            for t in textlines:
+                get_table_index_old(table_old, t, "horizontal")
+        t1 = time.perf_counter()
+        for _ in range(reps):
+            for t in textlines:
+                get_table_index_new(table_new, t, "horizontal")
+        t2 = time.perf_counter()
+
+    old_ms = (t1 - t0) * 1000.0
+    new_ms = (t2 - t1) * 1000.0
+    speedup = old_ms / new_ms if new_ms > 0 else float("inf")
+    print(
+        f"rows={n_rows} cols={n_cols} textlines={n_textlines} reps={reps} "
+        f"-> old={old_ms:.1f} ms  new={new_ms:.1f} ms  "
+        f"speedup={speedup:.2f}x"
+    )
+    return old_ms, new_ms, speedup
+
+
+def main():  # noqa: D103
+    assert_bit_identical()
+    # Headline numbers: the size used by the perf report in PR #727
+    # (50 rows x 10 cols x 200 textlines x 500 reps).
+    bench()
+    # Scaling sweep - the vectorised row search shines as n_rows grows.
+    print("scaling (rows varied, cols=10, textlines=200, reps=200):")
+    for n_rows in (10, 25, 50, 100, 200, 500):
+        bench(n_rows=n_rows, reps=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -14,6 +14,7 @@ from typing import Iterable
 from typing import Iterator
 
 import cv2
+import numpy as np
 import pandas as pd
 
 if sys.version_info >= (3, 11):
@@ -556,6 +557,79 @@ class Table:
 
         self._image = None
         self._image_path = None  # Temporary file to hold an image of the pdf
+
+        # NumPy / Python-list mirrors of ``rows`` and ``cols`` used by the
+        # hot inner loop in :func:`camelot.utils.get_table_index`. Built
+        # lazily by :meth:`_build_search_caches` on first call so that
+        # constructing a ``Table`` that is never searched (e.g. in
+        # unit-test fixtures) pays nothing for these. All are private and
+        # the public list-of-tuples API (``table.rows[r][0]``) keeps
+        # working unchanged. See PERF in the perf report.
+        self._rows_np_cache = None
+        self._cols_np_cache = None
+        # Ascending ``-y_top`` Python list. ``bisect.bisect_left`` on a
+        # plain Python list is markedly faster than ``np.searchsorted``
+        # for the per-call (scalar) lookup at the table sizes Camelot
+        # typically deals with (tens of rows).
+        self._neg_y_tops_list = None
+        # Pre-computed column widths (``|x_left - x_right|``) as a Python
+        # list, used by the column-overlap loop in ``get_table_index``.
+        self._col_widths_list = None
+        # ``True`` once the row partition has been verified to be
+        # non-overlapping (``rows[i].y_bot >= rows[i+1].y_top``) — the
+        # invariant Camelot's parsers maintain. ``False`` until the cache
+        # has been built or when the rows really do overlap.
+        self._rows_disjoint = False
+
+    def _build_search_caches(self):
+        """Populate the search caches used by ``get_table_index``.
+
+        Idempotent: callers may invoke this every call (it short-circuits
+        on the first attribute that is already populated). The NumPy
+        arrays are part of the private interface and kept available so
+        future call sites can do their own bulk processing.
+        """
+        if self._rows_np_cache is None:
+            rows = self.rows
+            self._rows_np_cache = np.asarray(rows, dtype=np.float64).reshape(-1, 2)
+            # ``-y_top`` is ascending because ``rows`` is descending by
+            # ``y_top``; that's what ``bisect.bisect_left`` needs.
+            self._neg_y_tops_list = [-r[0] for r in rows]
+            # Are the rows non-overlapping? When they are (the only case
+            # produced by Camelot's parsers), ``get_table_index`` can use
+            # a constant-time row lookup; otherwise it falls back to the
+            # full linear scan to preserve bit-identical semantics with
+            # the previous Python-loop implementation.
+            self._rows_disjoint = all(
+                rows[i][1] >= rows[i + 1][0] for i in range(len(rows) - 1)
+            )
+        if self._cols_np_cache is None:
+            cols = self.cols
+            self._cols_np_cache = np.asarray(cols, dtype=np.float64).reshape(-1, 2)
+            self._col_widths_list = [abs(c[0] - c[1]) for c in cols]
+
+    @property
+    def _rows_np(self):
+        """Return rows as an ``(n_rows, 2)`` float64 NumPy array.
+
+        Lazily constructed on first access and cached. Each row is
+        ``(y_top, y_bot)`` and rows preserve their original descending
+        ``y_top`` order.
+        """
+        if self._rows_np_cache is None:
+            self._build_search_caches()
+        return self._rows_np_cache
+
+    @property
+    def _cols_np(self):
+        """Return cols as an ``(n_cols, 2)`` float64 NumPy array.
+
+        Lazily constructed on first access and cached. Each column is
+        ``(x_left, x_right)``.
+        """
+        if self._cols_np_cache is None:
+            self._build_search_caches()
+        return self._cols_np_cache
 
     def __repr__(self):
         """Return a string representation of the class .

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -11,6 +11,7 @@ import shutil
 import string
 import tempfile
 import warnings
+from bisect import bisect_left
 from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
@@ -1198,49 +1199,99 @@ def get_table_index(  # noqa: C901  - cyclomatic complexity is inherent to the r
         |       |
         +-------+
     """
-    # Cache the textline mid-Y once; the old code recomputed it twice per row
-    # iteration. table.rows is sorted descending by y_top, so we can also
-    # stop as soon as we walk past the target row band. Track the best
-    # column overlap inline instead of building a list and doing
-    # `index(max(...))` (two passes). See PERF 2 in the perf report.
-    y_mid = (t.y0 + t.y1) / 2.0
-    t_x0, t_x1 = t.x0, t.x1
+    # Vectorised row/column search. ``table._rows_np`` and
+    # ``table._cols_np`` are built lazily on first access (see
+    # ``core.Table``) so they're available to any caller that needs an
+    # ndarray view of the table geometry, while the hot inner loop uses
+    # the companion ``-y_top`` Python list with :mod:`bisect` to find
+    # the row band in O(log rows) and a tight pre-computed loop over the
+    # columns for the per-column overlap.
+    #
+    # Rationale (see ``bench/bench_get_table_index.py``): at Camelot's
+    # table sizes (~tens of rows, ~tens of columns) the per-call dispatch
+    # overhead of ``np.searchsorted``, ``np.argmax`` etc. is several
+    # hundred ns — comparable to or larger than the actual work —
+    # whereas ``bisect.bisect_left`` is a pure-C builtin on a Python list
+    # with negligible per-call overhead. The numpy arrays remain the
+    # source of truth so callers downstream can lift the bulk-search
+    # work into NumPy when batching many textlines at once.
+    #
+    # Semantics match the previous Python-loop implementation bit-for-bit,
+    # including the "first index with the max overlap" tie-break and the
+    # ``c_idx = -1`` fallback when no column overlaps the textline. See
+    # PERF in the perf report.
+    y_mid = (t.y0 + t.y1) * 0.5
+    t_x0 = t.x0
+    t_x1 = t.x1
     rows = table.rows
     cols = table.cols
 
-    r_idx, c_idx = -1, -1
-    for r, (y_top, y_bot) in enumerate(rows):
-        if y_mid >= y_top:
-            # Past the row band (rows are descending by y_top).
-            break
-        if y_mid <= y_bot:
-            continue
-        # Row hit — compute per-column overlap, tracking best inline.
-        best_overlap = -1.0
-        best_c = -1
-        any_hit = False
-        for cidx, (c_left, c_right) in enumerate(cols):
-            if c_left <= t_x1 and c_right >= t_x0:
-                left = t_x0 if c_left <= t_x0 else c_left
-                right = t_x1 if c_right >= t_x1 else c_right
-                ov = abs(left - right) / abs(c_left - c_right)
-                any_hit = True
-                if ov > best_overlap:
-                    best_overlap = ov
-                    best_c = cidx
-        if not any_hit:
-            text = t.get_text().strip("\n")
-            text_range = (t_x0, t_x1)
-            col_range = (cols[0][0], cols[-1][1])
-            warnings.warn(
-                f"{text} {text_range} does not lie in column range {col_range}",
-                stacklevel=1,
-            )
-        r_idx = r
-        c_idx = best_c
-        break
-    if r_idx == -1:
-        return [], 1.0  # Return early if no valid row is found
+    # Direct attribute access is materially cheaper than the
+    # ``_rows_np``/``_cols_np`` property dance for the 100k-calls-per-page
+    # hot path. Populate on first call only.
+    neg_tops = table._neg_y_tops_list
+    if neg_tops is None:
+        table._build_search_caches()
+        neg_tops = table._neg_y_tops_list
+        if not neg_tops:
+            return [], 1.0
+
+    # Row band lookup. Rows are sorted descending by ``y_top``, so the
+    # previous Python loop ``break``s as soon as ``y_mid >= y_top``. That
+    # means only rows with ``y_top > y_mid`` (equivalently
+    # ``-y_top < -y_mid``) are candidates. ``bisect_left`` on the ascending
+    # ``-y_top`` list gives that candidate count in O(log n).
+    r_end = bisect_left(neg_tops, -y_mid)
+    if r_end == 0:
+        return [], 1.0  # textline mid-Y is at or above every row's top edge
+
+    # Among the ``[0, r_end)`` candidate rows the original loop returns
+    # the *first* one (in iteration order) whose ``y_bot < y_mid`` —
+    # critical for bit-identity when rows overlap. When the table was
+    # built by Camelot's parsers the rows are non-overlapping (verified
+    # in ``_build_search_caches``) and the hit is always ``r_end - 1``,
+    # so we shortcut. Synthetic inputs with overlapping rows fall through
+    # to the original ``for``-scan.
+    if table._rows_disjoint:
+        last = r_end - 1
+        if rows[last][1] < y_mid:
+            r_idx = last
+        else:
+            return [], 1.0
+    else:
+        r_idx = -1
+        for r in range(r_end):
+            if rows[r][1] < y_mid:
+                r_idx = r
+                break
+        if r_idx == -1:
+            return [], 1.0
+
+    # Per-column overlap. The width of each column is pre-computed once
+    # at Table construction (cached on ``table._col_widths_list``), so the
+    # hot loop is a single subtraction + division per column. Tie-break:
+    # first index with the maximum overlap. ``best_c`` doubles as the
+    # "any column hit" flag — it stays ``-1`` iff no column overlapped.
+    widths = table._col_widths_list
+    best_overlap = -1.0
+    best_c = -1
+    for cidx, (c_left, c_right) in enumerate(cols):
+        if c_left <= t_x1 and c_right >= t_x0:
+            left = t_x0 if c_left <= t_x0 else c_left
+            right = t_x1 if c_right >= t_x1 else c_right
+            ov = abs(left - right) / widths[cidx]
+            if ov > best_overlap:
+                best_overlap = ov
+                best_c = cidx
+    if best_c == -1:
+        text = t.get_text().strip("\n")
+        text_range = (t_x0, t_x1)
+        col_range = (cols[0][0], cols[-1][1])
+        warnings.warn(
+            f"{text} {text_range} does not lie in column range {col_range}",
+            stacklevel=1,
+        )
+    c_idx = best_c
 
     error = calculate_assignment_error(t, table, r_idx, c_idx)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,21 +87,23 @@ def test_text_in_bbox_filters_and_discards_overlaps():
 # --- Coverage for #733: get_table_index NumPy / bisect refactor -------------
 
 
-def _make_textline(x0, y0, x1, y1, text="x"):
+class _TextlineStub:
     """Minimal stand-in for a PDFMiner LTTextLine sufficient for get_table_index."""
 
-    class _TL:
-        __slots__ = ("x0", "y0", "x1", "y1", "_objs", "_text")
+    __slots__ = ("x0", "y0", "x1", "y1", "_objs", "_text")
 
-        def __init__(self_, x0, y0, x1, y1, text):
-            self_.x0, self_.y0, self_.x1, self_.y1 = x0, y0, x1, y1
-            self_._objs = []
-            self_._text = text
+    def __init__(self, x0, y0, x1, y1, text="x"):
+        self.x0, self.y0, self.x1, self.y1 = x0, y0, x1, y1
+        self._objs = []
+        self._text = text
 
-        def get_text(self_):
-            return self_._text + "\n"
+    def get_text(self):
+        return self._text + "\n"
 
-    return _TL(x0, y0, x1, y1, text)
+
+def _make_textline(x0, y0, x1, y1, text="x"):
+    """Build a _TextlineStub — kept as a thin helper for call-site readability."""
+    return _TextlineStub(x0, y0, x1, y1, text)
 
 
 def test_get_table_index_lazy_caches():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,3 +82,94 @@ def test_text_in_bbox_filters_and_discards_overlaps():
 
     # Empty input — empty output, no crash.
     assert text_in_bbox((0, 0, 100, 100), []) == []
+
+
+# --- Coverage for #733: get_table_index NumPy / bisect refactor -------------
+
+
+def _make_textline(x0, y0, x1, y1, text="x"):
+    """Minimal stand-in for a PDFMiner LTTextLine sufficient for get_table_index."""
+
+    class _TL:
+        __slots__ = ("x0", "y0", "x1", "y1", "_objs", "_text")
+
+        def __init__(self_, x0, y0, x1, y1, text):
+            self_.x0, self_.y0, self_.x1, self_.y1 = x0, y0, x1, y1
+            self_._objs = []
+            self_._text = text
+
+        def get_text(self_):
+            return self_._text + "\n"
+
+    return _TL(x0, y0, x1, y1, text)
+
+
+def test_get_table_index_lazy_caches():
+    """Table search caches are populated on first get_table_index call only."""
+    from camelot.core import Table
+    from camelot.utils import get_table_index
+
+    rows = [(100.0, 90.0), (90.0, 80.0), (80.0, 70.0)]
+    cols = [(0.0, 50.0), (50.0, 100.0)]
+    table = Table(cols, rows)
+    # caches empty initially
+    assert table._rows_np_cache is None
+    assert table._cols_np_cache is None
+    assert table._neg_y_tops_list is None
+    assert table._col_widths_list is None
+
+    # Trigger the lookup
+    textline = _make_textline(10.0, 84.0, 40.0, 86.0)
+    indices, _err = get_table_index(table, textline, direction="horizontal")
+    # exactly one (r, c, text) tuple
+    assert len(indices) == 1
+    r_idx, c_idx, text = indices[0]
+    assert r_idx == 1  # row band (90, 80) contains y_mid=85
+    assert c_idx == 0  # x_mid=25 is in column (0, 50)
+
+    # caches now populated
+    assert table._rows_np_cache is not None
+    assert table._cols_np_cache is not None
+    assert table._neg_y_tops_list == [-100.0, -90.0, -80.0]
+    assert table._col_widths_list == [50.0, 50.0]
+    assert table._rows_disjoint is True  # the disjoint fast-path triggered
+
+
+def test_get_table_index_rows_overlap_fallback():
+    """Overlapping rows force the linear-scan fallback (still bit-identical)."""
+    from camelot.core import Table
+    from camelot.utils import get_table_index
+
+    # Deliberately overlap: y_bot of row 0 (85) < y_top of row 1 (90), so the
+    # disjoint invariant rows[i].y_bot >= rows[i+1].y_top fails.
+    rows = [(100.0, 85.0), (90.0, 75.0)]
+    cols = [(0.0, 100.0)]
+    table = Table(cols, rows)
+    # Build caches and confirm we did NOT mark the rows disjoint
+    table._build_search_caches()
+    assert table._rows_disjoint is False
+
+    # Textline mid-Y = 87.5 lies in both rows; the original code returns the
+    # *first* matching row (index 0). The fallback path must do the same.
+    textline = _make_textline(10.0, 86.0, 40.0, 89.0)
+    indices, _err = get_table_index(table, textline, direction="horizontal")
+    assert len(indices) == 1
+    r_idx, c_idx, _text = indices[0]
+    assert r_idx == 0
+    assert c_idx == 0
+
+
+def test_get_table_index_text_outside_any_row():
+    """Textline whose mid-Y is outside every row band returns (empty, 1.0)."""
+    from camelot.core import Table
+    from camelot.utils import get_table_index
+
+    rows = [(100.0, 90.0), (90.0, 80.0)]
+    cols = [(0.0, 100.0)]
+    table = Table(cols, rows)
+
+    # mid-Y = 50 is below every row band
+    textline = _make_textline(10.0, 49.0, 40.0, 51.0)
+    indices, err = get_table_index(table, textline, direction="horizontal")
+    assert indices == []
+    assert err == 1.0


### PR DESCRIPTION
## Summary

PR #727 cleaned up `get_table_index` at the Python level (early break on the descending row band, single-pass best-overlap tracking) for a ~2.1x gain. This PR rewires the row lookup itself to be O(log rows) instead of O(rows) and pre-computes the per-column width once at Table construction, amortising work that was previously redone on every textline.

## Implementation

* Adds three lazy caches to `Table` populated on first search:
  * `_rows_np` / `_cols_np` — the NumPy mirrors the perf brief asked for, kept available so future bulk callers can lift work into NumPy.
  * `_neg_y_tops_list` — companion `-y_top` Python list used with `bisect`.
  * `_col_widths_list` — pre-computed column widths used in the inner loop.
* Rewrites `get_table_index` to look up the row band with `bisect.bisect_left` (pure-C builtin, faster than `np.searchsorted` for the scalar-on-tens-of-elements case our profiling showed) and a short scan over the candidate band. When the rows are non-overlapping — the invariant Camelot's `lattice` / `stream` / `network` parsers maintain via `_join_rows` — the candidate band has length 1 and the scan exits in one comparison. Overlapping-row inputs fall back to the original `for`-scan so the result stays **bit-identical** to the previous implementation.
* Adds `bench/bench_get_table_index.py`, a standalone (non-pytest) microbenchmark that asserts bit-identity against the post-#727 Python implementation on both disjoint **and** overlapping random tables before reporting headline + scaling numbers.

### Why `bisect` instead of `np.searchsorted`?

The brief specifically called out `np.searchsorted` + `np.argmax`. I prototyped that first; at the 50-row scale the per-call dispatch overhead of the NumPy Python wrappers (and even the bound `ndarray` methods) dominates the actual work — the implementation came in **slower** than the post-#727 baseline. `bisect.bisect_left` on the pre-computed `-y_top` Python list is the same algorithm (O(log n) binary search, no allocations) but with negligible per-call cost. The NumPy arrays still exist on the `Table` and are part of the private interface so a future batched call site (e.g. assigning many textlines in one shot) can do the bulk math in NumPy where it actually wins.

## Benchmarks

`python bench/bench_get_table_index.py` on a quiet machine. "old" is the post-#727 implementation reproduced inline in the bench script; "new" is the implementation in this PR. The headline number uses the same fixture as the perf report in #727.

```
correctness: OK (8 tables x 200 textlines x 2 row layouts)
rows=50 cols=10 textlines=200 reps=500 -> old=446.7 ms  new=257.4 ms  speedup=1.74x
scaling (rows varied, cols=10, textlines=200, reps=200):
rows=10  cols=10 textlines=200 reps=200 -> speedup=1.08x
rows=25  cols=10 textlines=200 reps=200 -> speedup=1.23x
rows=50  cols=10 textlines=200 reps=200 -> speedup=1.52x
rows=100 cols=10 textlines=200 reps=200 -> speedup=2.06x
rows=200 cols=10 textlines=200 reps=200 -> speedup=3.05x
rows=500 cols=10 textlines=200 reps=200 -> speedup=6.56x
```

Stacked on PR #727's ~2.1x that puts the total speedup vs the pre-#727 master at **~3x** for the 50x10 reference size and growing super-linearly for taller tables.

## Correctness

* `bench/bench_get_table_index.py` asserts bit-identity across 8 random tables x 200 random textlines x **two** row layouts (disjoint and overlapping) before timing — overlapping rows exercise the fallback that preserves the original "first-in-iteration-order" tie-break.
* All parser/utility tests pass locally (`tests/test_lattice.py`, `tests/test_stream.py`, `tests/test_network.py`, `tests/test_hybrid.py`, `tests/test_utils.py`, `tests/test_errors.py` — 71 passed).
* `pre-commit run --files camelot/core.py camelot/utils.py bench/bench_get_table_index.py` is clean (black + flake8 + isort + pyupgrade).

## Notes

* No new dependencies (NumPy is already a hard dep; `bisect` is stdlib).
* The public API of `Table` is unchanged — only the private `_*` caches were added, accessible via lazy properties (`_rows_np` / `_cols_np`) and direct attributes for the hot path.
* `# noqa: C901` is kept on `get_table_index` — the cyclomatic complexity is still inherent to the row/column scan + warning branch.
