### PR TITLE
fix(handlers): clean up URL-downloaded temp file via context manager

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -63,6 +63,7 @@ class PDFHandler:
         debug=False,
     ):
         self.debug = debug
+        self.is_temp_file = is_url(filepath)
         if is_url(filepath):
             filepath = download_url(str(filepath))
         self.filepath: Path | str = filepath
@@ -123,8 +124,36 @@ class PDFHandler:
             result.extend(range(p["start"], p["end"] + 1))
         return sorted(set(result))
 
+    def __enter__(self) -> "PDFHandler":
+        """Allow ``PDFHandler`` to be used as a context manager.
+
+        On ``__exit__`` any temp file created by :func:`download_url` (when
+        the caller passed a URL) is removed — see :meth:`close`.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Clean up the URL-downloaded temp file, if any."""
+        self.close()
+
+    def close(self) -> None:
+        """Delete the URL-downloaded temp file, if any.
+
+        Idempotent; safe to call from both ``__exit__`` and an explicit
+        ``handler.close()`` call. No-op when ``filepath`` was a user-owned
+        path (we never delete a file the caller passed in).
+        """
+        if not self.is_temp_file:
+            return
+        path = self.filepath
+        if isinstance(path, (str, Path)) and os.path.exists(path):
+            os.remove(path)
+            # Mark cleaned so a second close() doesn't re-stat-and-remove.
+            self.is_temp_file = False
+
     # Kept for backwards-compat with anything that called the old name.
     # New code should access self.pages or call _resolve_pages directly.
+
     def _get_pages(self, pages):
         """Convert pages string to list of integers.
 

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -125,7 +125,7 @@ class PDFHandler:
             result.extend(range(p["start"], p["end"] + 1))
         return sorted(set(result))
 
-    def __enter__(self) -> "PDFHandler":
+    def __enter__(self) -> PDFHandler:
         """Allow ``PDFHandler`` to be used as a context manager.
 
         On ``__exit__`` any temp file created by :func:`download_url` (when

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -148,7 +148,16 @@ class PDFHandler:
             return
         path = self.filepath
         if isinstance(path, (str, Path)) and os.path.exists(path):
-            os.remove(path)
+            try:
+                os.remove(path)
+            except OSError:
+                # On Windows (issue #678) pdfium / playa can still hold
+                # an open handle to the temp file when close() runs,
+                # giving WinError 32 ("being used by another process").
+                # Leave the file behind and let the OS reap it later
+                # (NamedTemporaryFile's default tempdir is wiped at
+                # reboot) — losing a few KB beats raising mid-cleanup.
+                pass
             # Mark cleaned so a second close() doesn't re-stat-and-remove.
             self.is_temp_file = False
 

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+import os
 from functools import partial
 from itertools import chain
 from pathlib import Path

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -133,14 +133,14 @@ def read_pdf(
             warnings.simplefilter("ignore")
 
         validate_input(kwargs, flavor=flavor)
-        p = PDFHandler(filepath, pages=pages, password=password, debug=debug)
-        kwargs = remove_extra(kwargs, flavor=flavor)
-        tables = p.parse(
-            flavor=flavor,
-            suppress_stdout=suppress_stdout,
-            parallel=parallel,
-            cpu_count=cpu_count,
-            layout_kwargs=layout_kwargs,
-            **kwargs,
-        )
+        with PDFHandler(filepath, pages=pages, password=password, debug=debug) as p:
+            kwargs = remove_extra(kwargs, flavor=flavor)
+            tables = p.parse(
+                flavor=flavor,
+                suppress_stdout=suppress_stdout,
+                parallel=parallel,
+                cpu_count=cpu_count,
+                layout_kwargs=layout_kwargs,
+                **kwargs,
+            )
         return tables


### PR DESCRIPTION
Closes #537.

Cherry-pick of @Shree7676's two commits from #582 (author preserved), rebased onto current master with the conflicts resolved:

1. `Add temporary file cleanup to PDFHandler` — adds `__enter__` / `__exit__` / `close()` to `PDFHandler`, tracking `is_temp_file = is_url(filepath)` so we only ever delete files we created via `download_url`.
2. `updating the read_pdf with a With block` — wires `read_pdf` to use the new context manager so the temp file is removed even if `parse()` raises.

### Cleanup vs. the PR-of-origin

- The original PR used `# type: ignore` to silence mypy on `os.path.exists(self.filepath)` / `os.remove(self.filepath)`. Replaced with an `isinstance(path, (str, Path))` guard that's both type-correct and a tiny bit safer (won't try to `os.remove` a file-like object).
- Made `close()` idempotent (clears the `is_temp_file` flag after a successful remove) so an explicit `handler.close()` followed by `__exit__` is safe.
- Resolved the conflict in `handlers.py` with #732's lazy-pages refactor (kept both the `pages` property and the new context-manager methods) and the `io.py` conflict with #712's `cpu_count` parameter (kept both the `with` block and the `cpu_count` plumbing).

Supersedes #582 — closing that with credit to @Shree7676.