### PR TITLE
feat(cli): camelot-py alias, infer --format from --output ext, document the output template

### DIFF
--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -1,6 +1,7 @@
 """Implementation of the command line interface."""
 
 import logging
+import os
 
 import click
 
@@ -48,6 +49,34 @@ class Config:
 pass_config = click.make_pass_decorator(Config)
 
 
+# Map of output filename extension -> --format value. Used by every
+# subcommand to make --format optional when the user already gave a clear
+# extension via --output. See #639.
+_OUTPUT_FORMAT_BY_EXT = {
+    ".csv": "csv",
+    ".xlsx": "excel",
+    ".xls": "excel",
+    ".html": "html",
+    ".htm": "html",
+    ".json": "json",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".sqlite": "sqlite",
+    ".sqlite3": "sqlite",
+    ".db": "sqlite",
+}
+
+
+def _infer_format(output, explicit):
+    """Pick the output format. Honour an explicit --format; else infer from output ext."""
+    if explicit is not None:
+        return explicit
+    if output is None:
+        return None
+    _, ext = os.path.splitext(output)
+    return _OUTPUT_FORMAT_BY_EXT.get(ext.lower())
+
+
 @click.group(name="camelot")
 @click.version_option(version=__version__)
 @click.pass_context
@@ -75,7 +104,14 @@ def cli(ctx, *args, **kwargs):
     help="Read pdf pages in parallel using all CPU cores.",
 )
 @click.option("-pw", "--password", help="Password for decryption.")
-@click.option("-o", "--output", help="Output file path.")
+@click.option(
+    "-o",
+    "--output",
+    help="Output file path. Treated as a template — each detected table is "
+    "written to '<output_stem>-page-<P>-table-<T>.<ext>'. If --format is "
+    "omitted, the format is inferred from the path's extension "
+    "(.csv, .xlsx, .html, .json, .md, .sqlite, etc.).",
+)
 @click.option(
     "-f",
     "--format",
@@ -203,7 +239,7 @@ def lattice(c, *args, **kwargs):
     """Use lines between text to parse the table."""
     pages = kwargs.pop("pages")
     output = kwargs.pop("output")
-    f = kwargs.pop("format")
+    f = _infer_format(output, kwargs.pop("format"))
     compress = kwargs.pop("zip")
     quiet = kwargs.pop("quiet")
     plot_type = kwargs.pop("plot_type")
@@ -255,7 +291,14 @@ def lattice(c, *args, **kwargs):
     help="Read pdf pages in parallel using all CPU cores.",
 )
 @click.option("-pw", "--password", help="Password for decryption.")
-@click.option("-o", "--output", help="Output file path.")
+@click.option(
+    "-o",
+    "--output",
+    help="Output file path. Treated as a template — each detected table is "
+    "written to '<output_stem>-page-<P>-table-<T>.<ext>'. If --format is "
+    "omitted, the format is inferred from the path's extension "
+    "(.csv, .xlsx, .html, .json, .md, .sqlite, etc.).",
+)
 @click.option(
     "-f",
     "--format",
@@ -342,7 +385,7 @@ def stream(c, *args, **kwargs):
     """Use spaces between text to parse the table."""
     pages = kwargs.pop("pages")
     output = kwargs.pop("output")
-    f = kwargs.pop("format")
+    f = _infer_format(output, kwargs.pop("format"))
     compress = kwargs.pop("zip")
     quiet = kwargs.pop("quiet")
     plot_type = kwargs.pop("plot_type")
@@ -409,7 +452,14 @@ def stream(c, *args, **kwargs):
     help="Read pdf pages in parallel using all CPU cores.",
 )
 @click.option("-pw", "--password", help="Password for decryption.")
-@click.option("-o", "--output", help="Output file path.")
+@click.option(
+    "-o",
+    "--output",
+    help="Output file path. Treated as a template — each detected table is "
+    "written to '<output_stem>-page-<P>-table-<T>.<ext>'. If --format is "
+    "omitted, the format is inferred from the path's extension "
+    "(.csv, .xlsx, .html, .json, .md, .sqlite, etc.).",
+)
 @click.option(
     "-f",
     "--format",
@@ -496,7 +546,7 @@ def hybrid(c, *args, **kwargs):
     """Combines the strengths of both the Network and the Lattice parser."""
     pages = kwargs.pop("pages")
     output = kwargs.pop("output")
-    f = kwargs.pop("format")
+    f = _infer_format(output, kwargs.pop("format"))
     compress = kwargs.pop("zip")
     quiet = kwargs.pop("quiet")
     plot_type = kwargs.pop("plot_type")
@@ -547,7 +597,14 @@ def hybrid(c, *args, **kwargs):
     help="Read pdf pages in parallel using all CPU cores.",
 )
 @click.option("-pw", "--password", help="Password for decryption.")
-@click.option("-o", "--output", help="Output file path.")
+@click.option(
+    "-o",
+    "--output",
+    help="Output file path. Treated as a template — each detected table is "
+    "written to '<output_stem>-page-<P>-table-<T>.<ext>'. If --format is "
+    "omitted, the format is inferred from the path's extension "
+    "(.csv, .xlsx, .html, .json, .md, .sqlite, etc.).",
+)
 @click.option(
     "-f",
     "--format",
@@ -634,7 +691,7 @@ def network(c, *args, **kwargs):
     """Use text alignments to parse the table."""
     pages = kwargs.pop("pages")
     output = kwargs.pop("output")
-    f = kwargs.pop("format")
+    f = _infer_format(output, kwargs.pop("format"))
     compress = kwargs.pop("zip")
     quiet = kwargs.pop("quiet")
     plot_type = kwargs.pop("plot_type")

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -8,5 +8,40 @@ Camelot comes with a command-line interface.
 You can print the help for the interface by typing ``camelot --help`` in your favorite terminal program, as shown below.
 Furthermore, you can print the help for each command by typing ``camelot <command> --help``. Try it out!
 
+Running without installing (uvx)
+--------------------------------
+
+If you only want to use the CLI ad-hoc, `uvx <https://docs.astral.sh/uv/concepts/tools/>`_ lets you run it without installing Camelot into the current environment::
+
+    $ uvx camelot-py lattice --output tables.csv document.pdf
+
+The ``camelot-py`` console script is an alias for ``camelot`` matching the PyPI package name, so the older ``uvx --from camelot-py camelot …`` invocation also still works.
+
+Format inference
+----------------
+
+``--format`` is optional — when omitted, Camelot infers the format from the ``--output`` path's extension. Supported extensions:
+
+================ ===========
+Extension        Format
+================ ===========
+``.csv``         csv
+``.xlsx``/``.xls`` excel
+``.html``/``.htm`` html
+``.json``        json
+``.md``/``.markdown`` markdown
+``.sqlite``/``.sqlite3``/``.db`` sqlite
+================ ===========
+
+So this works::
+
+    $ camelot-py lattice --output tables.xlsx document.pdf
+    # equivalent to: camelot-py lattice --format excel --output tables.xlsx document.pdf
+
+Output is a template
+--------------------
+
+``--output`` is treated as a *template* — each detected table is written to ``<output_stem>-page-<P>-table-<T>.<ext>``. So ``--output report.csv`` on a document with 2 tables on page 1 and 1 table on page 3 produces ``report-page-1-table-1.csv``, ``report-page-1-table-2.csv``, ``report-page-3-table-1.csv``.
+
 .. click:: camelot.cli:cli
   :prog: camelot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dev = [
 
 [project.scripts]
 camelot = "camelot.__main__:main"
+# Alias matching the PyPI package name so `uvx camelot-py …` works without
+# the `--from camelot-py` prefix. See #639.
+camelot-py = "camelot.__main__:main"
 
 [tool.coverage.paths]
 source = ["camelot", "*\\camelot", "*/site-packages"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,17 @@ def test_cli_lattice(testdir):
         output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
 
+        # #639: with --format omitted but --output carrying a known extension
+        # (.csv here), the format is inferred — the run succeeds rather than
+        # bailing out with "Please specify output file format using --format".
         result = runner.invoke(cli, ["lattice", "--output", outfile, infile])
-        format_error = "Please specify output file format using --format"
-        assert format_error in result.output
+        assert result.exit_code == 0, result.output
+        assert "Found 1 tables" in result.output
+
+        # When the --output extension is unknown, the format error still fires.
+        unknown_out = os.path.join(tempdir, "foo")
+        result = runner.invoke(cli, ["lattice", "--output", unknown_out, infile])
+        assert "Please specify output file format using --format" in result.output
 
 
 def test_cli_stream(testdir):
@@ -62,9 +70,10 @@ def test_cli_stream(testdir):
         output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
 
+        # #639: --format inferred from .csv extension when --output is given.
         result = runner.invoke(cli, ["stream", "--output", outfile, infile])
-        format_error = "Please specify output file format using --format"
-        assert format_error in result.output
+        assert result.exit_code == 0, result.output
+        assert "Found 1 tables" in result.output
 
         result = runner.invoke(
             cli,
@@ -141,9 +150,10 @@ def test_cli_hybrid(testdir):
         output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
 
+        # #639: --format inferred from .csv extension when --output is given.
         result = runner.invoke(cli, ["hybrid", "--output", outfile, infile])
-        format_error = "Please specify output file format using --format"
-        assert format_error in result.output
+        assert result.exit_code == 0, result.output
+        assert "Found 1 tables" in result.output
 
 
 def test_cli_network(testdir):
@@ -159,9 +169,10 @@ def test_cli_network(testdir):
         result = runner.invoke(cli, ["network", "--format", "csv", infile])
         output_error = "Error: Please specify output file path using --output"
         assert output_error in result.output
+        # #639: --format inferred from .csv extension when --output is given.
         result = runner.invoke(cli, ["network", "--output", outfile, infile])
-        format_error = "Please specify output file format using --format"
-        assert format_error in result.output
+        assert result.exit_code == 0, result.output
+        assert "Found 1 tables" in result.output
 
 
 def test_cli_password(testdir):


### PR DESCRIPTION
Closes #639.

Three usability improvements requested by @Lucas-C in #639:

### `camelot-py` script alias

`uvx camelot-py …` now works directly. `camelot-py` is an alias for the same entry point as `camelot` — matches the PyPI package name, so users don't have to remember the longer `uvx --from camelot-py camelot …` form.

### `--format` inferred from `--output` extension

`--format` is now optional. Each subcommand calls a shared `_infer_format(output, explicit)` helper that:

- Honours an explicit `--format` (no behaviour change).
- Else maps the `--output` extension to a known format (`.csv`/`.xlsx`/`.xls`/`.html`/`.htm`/`.json`/`.md`/`.markdown`/`.sqlite`/`.sqlite3`/`.db`).
- Else returns `None`, falling through to the existing "specify --format" error.

So this works:
```
camelot-py lattice --output tables.xlsx document.pdf
# equivalent to: camelot-py lattice --format excel --output tables.xlsx document.pdf
```

### `--output` documented as a template

The `name-page-{P}-table-{T}.{ext}` rule was always there but undocumented; surprising for new users. The option help now says so explicitly, and a dedicated docs section in `docs/user/cli.rst` shows the produced file pattern with a worked example.

### What I deliberately did NOT do

- The fourth request (`camelot lattice --output … file.pdf` shape: options on the subcommand) **already works as of #614**. No change needed.
- The fifth request (make `hybrid` the default flavor) is a behaviour change that affects every existing CLI script. Deferred for an explicit follow-up issue if there's appetite — that one is *not* small.

Thanks @Lucas-C for the focused feedback.