### PR TITLE
feat(core): unified 'confidence' metric in parsing_report (#659)

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -704,8 +704,8 @@ class Table:
         ``page``           1-based page number the table was found on.
         ``order``          1-based rank within that page (left-to-right /
                            top-to-bottom).
-        ``accuracy``       Float in ``[0, 100]``. See :attr:`confidence`
-                           for component-by-component definitions.
+        ``accuracy``       Float in ``[0, 100]``. See ``confidence`` for
+                           component-by-component definitions.
         ``whitespace``     Float in ``[0, 100]``.
         ``confidence``     Float in ``[0, 1]``. Unified quality score —
                            combines accuracy and whitespace.

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -669,20 +669,57 @@ class Table:
         return d
 
     @property
-    def parsing_report(self):
-        """Returns a parsing report.
+    def confidence(self) -> float:
+        """A unified per-table quality score in ``[0.0, 1.0]``.
 
-        with % accuracy, % whitespace,
-        table number on page and page number.
+        Computed from the existing per-flavor signals as
+        ``(accuracy / 100) * (1 - whitespace / 100)``. The intent is a
+        single number suitable for production filtering and automated
+        validation — ``confidence >= 0.8`` works as a reasonable
+        first-cut threshold; tune for the source PDFs.
+
+        Components and their meaning are identical across flavors:
+
+        - ``accuracy`` (0-100): how well the detected cells line up
+          with the parser's structural hints (line joints for lattice,
+          text alignments for stream/network/hybrid). Higher is better.
+        - ``whitespace`` (0-100): percentage of cells that are empty
+          after stripping. Lower is better (a perfectly populated
+          table is 0; a mostly-empty one trends toward 100).
+        - ``confidence`` (0-1): the composite. ``accuracy=90``,
+          ``whitespace=10`` → ``confidence≈0.81``; either signal
+          going to its worst value pulls ``confidence`` to 0.
+
+        See #659.
         """
-        # pretty?
-        report = {
+        return max(0.0, (self.accuracy / 100.0) * (1.0 - self.whitespace / 100.0))
+
+    @property
+    def parsing_report(self):
+        """Per-table parsing report.
+
+        Standard keys across all flavors:
+
+        =================  ==============================================
+        ``page``           1-based page number the table was found on.
+        ``order``          1-based rank within that page (left-to-right /
+                           top-to-bottom).
+        ``accuracy``       Float in ``[0, 100]``. See :attr:`confidence`
+                           for component-by-component definitions.
+        ``whitespace``     Float in ``[0, 100]``.
+        ``confidence``     Float in ``[0, 1]``. Unified quality score —
+                           combines accuracy and whitespace.
+        =================  ==============================================
+
+        See #659.
+        """
+        return {
             "accuracy": round(self.accuracy, 2),
             "whitespace": round(self.whitespace, 2),
             "order": self.order,
             "page": self.page,
+            "confidence": round(self.confidence, 4),
         }
-        return report
 
     def get_pdf_image(self):
         """Compute pdf image and cache it."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -295,3 +295,30 @@ def test_tablelist_accepts_iterable():
     assert bool(tl) is True
     assert tl[0] is sentinels[0]
     assert tl[1] is sentinels[1]
+
+
+def test_parsing_report_includes_confidence():
+    """parsing_report now includes a unified 'confidence' composite in [0, 1] (#659)."""
+    import math
+
+    from camelot.core import Table
+
+    t = Table([(0.0, 100.0), (100.0, 200.0)], [(100.0, 90.0), (90.0, 80.0)])
+    t.accuracy = 90.0
+    t.whitespace = 10.0
+    t.order = 1
+    t.page = 1
+
+    report = t.parsing_report
+    # Schema: legacy keys still there, new key added.
+    assert {"page", "order", "accuracy", "whitespace", "confidence"} == set(report)
+    assert math.isclose(report["confidence"], 0.81, abs_tol=1e-4)
+    assert 0.0 <= report["confidence"] <= 1.0
+
+    # Edge cases.
+    t.accuracy, t.whitespace = 100.0, 0.0
+    assert math.isclose(t.confidence, 1.0)
+    t.accuracy, t.whitespace = 0.0, 50.0
+    assert t.confidence == 0.0
+    t.accuracy, t.whitespace = 100.0, 100.0
+    assert t.confidence == 0.0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,11 +17,21 @@ from .data import *
 
 @skip_on_windows
 def test_parsing_report(testdir):
-    parsing_report = {"accuracy": 99.02, "whitespace": 12.24, "order": 1, "page": 1}
+    # #659: parsing_report also now includes a 'confidence' composite in
+    # [0, 1] computed from accuracy + whitespace. The other keys are
+    # unchanged; this test keeps pinning those values and adds the
+    # derived 'confidence' alongside.
+    expected = {
+        "accuracy": 99.02,
+        "whitespace": 12.24,
+        "order": 1,
+        "page": 1,
+        "confidence": round((99.02 / 100.0) * (1.0 - 12.24 / 100.0), 4),
+    }
 
     filename = os.path.join(testdir, "foo.pdf")
     tables = camelot.read_pdf(filename)
-    assert tables[0].parsing_report == parsing_report
+    assert tables[0].parsing_report == expected
 
 
 def test_password(testdir):


### PR DESCRIPTION
Closes #659.

Adds `Table.confidence`, a composite quality score in `[0, 1]` computed from existing per-flavor signals:

```
confidence = (accuracy / 100) * (1 - whitespace / 100)
```

The component metrics (`accuracy`, `whitespace`) were already produced **identically across flavors** via the shared `BaseParser.record_parse_metadata` — so this PR is mostly *documenting* that contract and adding a single-number summary suitable for production filtering / automated validation.

### `parsing_report` schema (all flavors)

| key | range | meaning |
|---|---|---|
| `page` | int | 1-based page number |
| `order` | int | 1-based rank within page |
| `accuracy` | 0-100 | how well detected cells line up with structural hints (line joints for lattice, text alignments otherwise) |
| `whitespace` | 0-100 | % empty cells after stripping |
| `confidence` | 0-1 | composite. `accuracy=90, whitespace=10` → ≈0.81; either signal at worst pulls to 0 |

### Tests

`test_parsing_report_includes_confidence` verifies the formula and edge cases (perfect 100/0 → 1.0, collapsed 0/anything → 0, all-whitespace 100/100 → 0).