### PR TITLE
feat!: drop Python 3.9 support (EOL October 2025)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
           - { python: "3.14", os: "ubuntu-latest", session: "tests" }
           - {
@@ -60,12 +59,11 @@ jobs:
           allow-prereleases: true
 
       - name: Upgrade pip
-        # The pip pin in constraints.txt does not work on every Python
-        # version in the matrix: pip>=26 dropped Python 3.9, and the
-        # earlier pip==25.0.1 relied on `typing.no_type_check_decorator`
-        # which Python 3.15 removed. Skip the explicit upgrade on those
-        # rows and rely on the pip shipped by setup-python.
-        if: matrix.python != '3.9' && matrix.python != '3.15'
+        # constraints.txt pins pip==26.x, which relies on
+        # `typing.no_type_check_decorator` that Python 3.15 removed.
+        # Skip the explicit upgrade on the 3.15 row and rely on the pip
+        # shipped by setup-python.
+        if: matrix.python != '3.15'
         run: |
           pip install --constraint=${PWD}/.github/workflows/constraints.txt pip
           pip --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         entry: pyupgrade
         language: system
         types: [python]
-        args: [--py38-plus]
+        args: [--py310-plus]
       - id: trailing-whitespace
         name: Trim Trailing Whitespace
         entry: trailing-whitespace-fixer

--- a/camelot/__init__.py
+++ b/camelot/__init__.py
@@ -6,7 +6,7 @@ from .io import read_pdf
 from .plotting import PlotMethods
 
 
-def get_version() -> Optional[str]:
+def get_version() -> str | None:
     """Retrieve the version number from package metadata."""
     try:
         return importlib.metadata.version("camelot-py")

--- a/camelot/backends/image_conversion.py
+++ b/camelot/backends/image_conversion.py
@@ -1,9 +1,6 @@
 """Classes and functions for the ImageConversionBackend backends."""
 
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Type
 
 from .base import ConversionBackend
 from .ghostscript_backend import GhostscriptBackend

--- a/camelot/backends/image_conversion.py
+++ b/camelot/backends/image_conversion.py
@@ -10,7 +10,7 @@ from .ghostscript_backend import GhostscriptBackend
 from .pdfium_backend import PdfiumBackend
 from .poppler_backend import PopplerBackend
 
-BACKENDS: Dict[str, Type[ConversionBackend]] = {
+BACKENDS: dict[str, type[ConversionBackend]] = {
     "pdfium": PdfiumBackend,
     "ghostscript": GhostscriptBackend,
     "poppler": PopplerBackend,
@@ -41,7 +41,7 @@ class ImageConversionBackend:
         """
         self.backend: ConversionBackend = self.get_backend(backend)
         self.use_fallback: bool = use_fallback
-        self.fallbacks: List[str] = list(
+        self.fallbacks: list[str] = list(
             filter(lambda x: isinstance(backend, str) and x != backend, BACKENDS.keys())
         )
 

--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -13,7 +13,6 @@ else:
     _HAS_MPL = True
 
 import importlib.metadata
-from typing import Optional
 
 from . import plot
 from . import read_pdf

--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("camelot")
 logger.setLevel(logging.INFO)
 
 
-def get_version() -> Optional[str]:
+def get_version() -> str | None:
     """Get the version information."""
     try:
         return importlib.metadata.version("camelot-py")

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -10,8 +10,8 @@ import tempfile
 import zipfile
 from operator import itemgetter
 from typing import Any
-from typing import Iterable
-from typing import Iterator
+from collections.abc import Iterable
+from collections.abc import Iterator
 
 import cv2
 import numpy as np

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -8,10 +8,10 @@ import sqlite3
 import sys
 import tempfile
 import zipfile
-from operator import itemgetter
-from typing import Any
 from collections.abc import Iterable
 from collections.abc import Iterator
+from operator import itemgetter
+from typing import Any
 
 import cv2
 import numpy as np

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -21,6 +21,9 @@ if sys.version_info >= (3, 11):
     from typing import TypedDict  # pylint: disable=no-name-in-module
     from typing import Unpack
 else:
+    # 3.10 is the floor (requires-python = ">=3.10"); typing_extensions
+    # remains the source of TypedDict/Unpack on 3.10 because Unpack only
+    # entered typing in 3.11.
     from typing_extensions import TypedDict, Unpack
 
 from .backends import ImageConversionBackend

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -2,7 +2,6 @@
 
 import warnings
 from pathlib import Path
-from typing import Union
 
 from .handlers import PDFHandler
 from .utils import remove_extra

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -10,7 +10,7 @@ from .utils import validate_input
 
 
 def read_pdf(
-    filepath: Union[str, Path],
+    filepath: str | Path,
     pages="1",
     password=None,
     flavor="lattice",

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -16,7 +16,7 @@ from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
 from typing import Any
-from typing import Callable
+from collections.abc import Callable
 from urllib.parse import urlparse as parse_url
 from urllib.parse import uses_netloc
 from urllib.parse import uses_params

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -12,11 +12,11 @@ import string
 import tempfile
 import warnings
 from bisect import bisect_left
+from collections.abc import Callable
 from itertools import groupby
 from operator import itemgetter
 from pathlib import Path
 from typing import Any
-from collections.abc import Callable
 from urllib.parse import urlparse as parse_url
 from urllib.parse import uses_netloc
 from urllib.parse import uses_params
@@ -226,7 +226,6 @@ class TemporaryDirectory:
         traceback : [type]
             [description]
         """
-        pass
 
 
 def build_file_path_in_temp_dir(filename, extension=None):

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -669,9 +669,8 @@ def text_in_bbox(bbox, text):
     keep = ~discard_any
 
     # keep is a boolean mask of length n derived from idx_in/t_bbox, so the
-    # two iterables are equal-length by construction; zip(strict=True) would
-    # be cleaner but is Python 3.10+ only and the project still supports 3.9.
-    return [t for t, k in zip(t_bbox, keep.tolist()) if k]  # noqa: B905
+    # two iterables are equal-length by construction.
+    return [t for t, k in zip(t_bbox, keep.tolist(), strict=True) if k]
 
 
 def text_in_bbox_per_axis(bbox, horizontal_text, vertical_text):

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ package = "camelot"
 # `experimental: true` / continue-on-error knob to keep the row non-blocking.
 # Note: uv's python download parser does not accept "3.15-dev" as a version,
 # so we use the bare "3.15" form here and in the matrix.
-python_versions = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+python_versions = ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",

--- a/noxfile.py
+++ b/noxfile.py
@@ -111,7 +111,7 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
                 break
 
 
-@session(name="pre-commit", python=python_versions[1])
+@session(name="pre-commit", python="3.10")
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
     args = session.posargs or [
@@ -138,7 +138,7 @@ def precommit(session: Session) -> None:
         activate_virtualenv_in_precommit_hooks(session)
 
 
-@session(python=python_versions[1])
+@session(python="3.10")
 def safety(session: Session) -> None:
     """Scan dependencies for insecure packages."""
     session.install(".")
@@ -213,7 +213,7 @@ def tests(session: Session) -> None:
             session.notify("coverage", posargs=[])
 
 
-@session(python=python_versions[1], reuse_venv=True)
+@session(python="3.10", reuse_venv=True)
 def coverage(session: Session) -> None:
     """Produce the coverage report."""
     args = session.posargs or ["report", "-i"]
@@ -226,7 +226,7 @@ def coverage(session: Session) -> None:
     session.run("coverage", *args)
 
 
-@session(python=python_versions[1])
+@session(python="3.10")
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
@@ -249,7 +249,7 @@ def xdoctest(session: Session) -> None:
     session.run("python", "-m", "xdoctest", *args)
 
 
-@session(name="docs-build", python=python_versions[4])
+@session(name="docs-build", python="3.13")
 def docs_build(session: Session) -> None:
     """Build the documentation."""
     args = session.posargs or ["docs", "docs/_build"]
@@ -275,7 +275,7 @@ def docs_build(session: Session) -> None:
     session.run("sphinx-build", *args)
 
 
-@session(python=python_versions[1])
+@session(python="3.10")
 def docs(session: Session) -> None:
     """Build and serve the documentation with live reloading on file changes."""
     args = session.posargs or ["--open-browser", "docs", "docs/_build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,21 +10,18 @@ readme = "README.md"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "click>=8.0.1",
-    "numpy>=1.24.4; python_version < '3.12'",
-    "numpy>=1.26.1; python_version >= '3.12'",
+    "numpy>=1.26.1",
     "openpyxl>=3.1.0",
-    "pandas>=1.5.3; python_version < '3.10'",
-    "pandas>=2.2.2; python_version >= '3.10'",
+    "pandas>=2.2.2",
     "tabulate>=0.9.0",
     "typing-extensions>=4.12.2; python_version < '3.11'",
     "opencv-python-headless>=4.7.0.68",
@@ -106,11 +103,11 @@ show_missing = true
 fail_under = 90
 
 [tool.black]
-# Match `requires-python = ">=3.9"`. Without this, modern Black auto-detects a
+# Match `requires-python = ">=3.10"`. Without this, modern Black auto-detects a
 # higher target and emits "Python 3.10 cannot parse code formatted for Python
 # 3.15" in the CI pre-commit job, because its AST safety check can't parse
 # newer syntax under the 3.10 runner.
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
BREAKING — Drops Python 3.9 from the supported set.

3.9 reached upstream EOL more than 6 months ago (October 2025). Dropping it:

* simplifies the `pyproject.toml` dep block — no python-version-conditional pandas / numpy / pillow ranges
* lets us use `zip(strict=True)` without a noqa fence in the hot `text_in_bbox` path
* updates pre-commit `pyupgrade` from `--py38-plus` to `--py310-plus` (this will rewrite a handful of `Optional[X]` → `X | None` and similar in a follow-up housekeeping pass; intentionally not bundled here so the diff stays focused)
* removes the pip-skip workaround for 3.9 from `tests.yml` (kept the 3.15 skip — pip 26 still doesn't run on the 3.15 pre-release)
* bumps black `target-version` from `py39` → `py310` + drops the matching trove classifier

`typing-extensions` is kept as a **3.10-only** dep (`Unpack` only entered `typing` in 3.11; we still need the back-port on 3.10).

Marked `feat!` with the leading bang — callers on 3.9 will see a hard install-time failure (`requires-python = ">=3.10"`).

Goes into the **next major release** (v2.0.0).