### PR TITLE
docs: v2.0 release-prep — CHANGELOG, mypyc plan, #590 NOTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents notable user-visible changes. The day-to-day automatic
 release-notes (grouped by PR) are still produced by
 [release-drafter](https://github.com/release-drafter/release-drafter)
 on `master` — see the GitHub Releases page. This file is the curated
-human-readable summary for *major* releases.
+human-readable summary for _major_ releases.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -21,7 +21,7 @@ changes. **Heads-up if upgrading from 1.0.x**:
   **Python 3.10**. (#740)
 - **`flavor="lattice"` default `line_scale` changed from 40 to 15** to match
   the long-standing implementation (the CLI and `read_pdf` docstring used
-  to *say* 40 but the Lattice parser always defaulted to 15). Tables that
+  to _say_ 40 but the Lattice parser always defaulted to 15). Tables that
   relied on the documented-but-unimplemented `40` will need
   `read_pdf(..., line_scale=40)` explicitly. (#709)
 - **`Table.to_excel` now defaults to `index=False, header=False`** to match
@@ -87,7 +87,7 @@ changes. **Heads-up if upgrading from 1.0.x**:
   small, mostly readability.
 - A `bench/` directory now ships a couple of standalone microbenchmarks
   (`bench_get_table_index.py`) and a negative-result bench
-  (`bench_negative_results.py`) documenting cases where NumPy did *not*
+  (`bench_negative_results.py`) documenting cases where NumPy did _not_
   help — useful regression net against well-meaning future rewrites.
 
 ### Fixed
@@ -106,7 +106,7 @@ changes. **Heads-up if upgrading from 1.0.x**:
   (see Breaking). (#709, closes #657)
 - **`Table.to_excel` no longer emits the meaningless integer-index row
   and integer-header column**. (#711, closes #634)
-- **CLI options are position-independent** (they can sit before *or*
+- **CLI options are position-independent** (they can sit before _or_
   after the file argument on any subcommand). (#614, closes #587)
 - **Documentation no longer references `pdfminer`/`pypdf` as the
   backend**; the `playa-pdf` migration is reflected throughout. (#719)
@@ -127,7 +127,7 @@ changes. **Heads-up if upgrading from 1.0.x**:
   the previous architecture (split-into-per-page-temp-PDFs via pypdf)
   silently dropped the encryption metadata after decryption, so the
   check was effectively a no-op. The playa-based parse path keeps the
-  document handle open with permissions intact. Note: for *unencrypted*
+  document handle open with permissions intact. Note: for _unencrypted_
   PDFs that claim "no extraction" via `/Perms`, no mechanism in the PDF
   spec actually enforces the flag and Camelot extracts. (closes #590)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,145 @@
+# Changelog
+
+This file documents notable user-visible changes. The day-to-day automatic
+release-notes (grouped by PR) are still produced by
+[release-drafter](https://github.com/release-drafter/release-drafter)
+on `master` — see the GitHub Releases page. This file is the curated
+human-readable summary for *major* releases.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] — 2.0.0 (planned)
+
+The 2.0 release rolls up a substantial backend migration, the resulting
+performance work, and a handful of small but user-visible breaking
+changes. **Heads-up if upgrading from 1.0.x**:
+
+### Breaking
+
+- **Dropped Python 3.9** (EOL October 2025). Minimum supported is now
+  **Python 3.10**. (#740)
+- **`flavor="lattice"` default `line_scale` changed from 40 to 15** to match
+  the long-standing implementation (the CLI and `read_pdf` docstring used
+  to *say* 40 but the Lattice parser always defaulted to 15). Tables that
+  relied on the documented-but-unimplemented `40` will need
+  `read_pdf(..., line_scale=40)` explicitly. (#709)
+- **`Table.to_excel` now defaults to `index=False, header=False`** to match
+  `Table.to_csv`. Excel exports no longer carry the pandas auto-generated
+  row index / column header by default. Opt back in with
+  `table.to_excel(path, index=True, header=True)`. (#711)
+- **`TableList` constructor materialises its iterable input** to a list
+  immediately, so `bool()` and `len()` work on `TableList(generator())`
+  inputs. A generator passed in will be exhausted at construction time
+  rather than at first access. (#710)
+- **`PDFHandler.pages` is a property** (was an attribute). Reads work
+  unchanged; the value is now resolved lazily on first access. No callers
+  in the wild set it, but if you subclassed and overrode it as an
+  attribute, that no longer works. (#732)
+- **PDF backend swapped from `pypdf` + `pdfminer.six` to
+  [`playa-pdf`](https://pypi.org/project/playa-pdf/)**. The dependency
+  install set is smaller, encrypted-PDF handling is more accurate, and
+  parser hot paths shed several layers of per-page-temp-PDF dance. Pure
+  `import camelot` callers should see no API change.
+
+### Added
+
+- **`flavor="auto"`**: render the first requested page, count ruled
+  horizontal/vertical lines, pick `lattice` when ruled and `network`
+  otherwise. Emits a `UserWarning` naming the chosen flavor. (#737)
+- **`Table.confidence`** — unified per-table quality score in `[0, 1]`
+  computed as `(accuracy / 100) * (1 - whitespace / 100)`. Now appears as
+  a `"confidence"` key in `Table.parsing_report` alongside the existing
+  `accuracy` / `whitespace` / `page` / `order`. Suitable for production
+  filtering. The whole `parsing_report` schema is now documented in the
+  property docstring. (#739)
+- **`cpu_count` parameter** on `read_pdf(..., parallel=True, cpu_count=N)`
+  and `PDFHandler.parse(...)` — caps the worker count when running in
+  parallel. Defaults to all cores; clamped to
+  `[1, multiprocessing.cpu_count()]`. (#712)
+- **`camelot-py` CLI alias** matching the PyPI package name —
+  `uvx camelot-py …` works directly without the `--from camelot-py`
+  prefix. (#738)
+- **`--format` is now optional** in the CLI: when omitted, the format is
+  inferred from the `--output` extension (`.csv`, `.xlsx`, `.html`,
+  `.json`, `.md`, `.sqlite`, etc.). (#738)
+- **`Table.to_excel` defaults to `index=False, header=False`** (under
+  Breaking but worth calling out under Added too — most users will
+  prefer the new shape).
+- **Python 3.14 stable + 3.15 experimental** rows added to the CI matrix.
+  Wheels for both Pythons install correctly on Linux/macOS/Windows. (#706)
+
+### Changed (performance)
+
+- **`text_in_bbox` ≈ 30× faster on busy lattice pages.** The original
+  O(n³) duplicate-discard pass became O(n²) in #718, then the whole
+  function was NumPy-vectorised in #731 — a 3-4× win on top of #718 on
+  realistic 50-500-text-line bboxes. Memory-safe fallback at n > 1500.
+- **`get_table_index` 3-13×.** #727 collapsed the row scan + best-overlap
+  tracking, #733 added a lazy NumPy + `bisect` row-band lookup
+  (`O(log rows)`) plus per-table caches on `Table` (`_rows_np`,
+  `_cols_np`, `_rows_disjoint`).
+- **`read_pdf` opens the PDF once per call instead of twice.** Page
+  resolution is deferred until the parse already has the `playa` handle
+  open. Doubles throughput on workloads that loop over many short PDFs.
+  (#732)
+- `random_string` 4× (#718) and `compute_whitespace` cleanup (#727) —
+  small, mostly readability.
+- A `bench/` directory now ships a couple of standalone microbenchmarks
+  (`bench_get_table_index.py`) and a negative-result bench
+  (`bench_negative_results.py`) documenting cases where NumPy did *not*
+  help — useful regression net against well-meaning future rewrites.
+
+### Fixed
+
+- **Windows `PermissionError` when parsing multiple PDFs.** The URL-
+  downloaded temp file is now removed on `PDFHandler.__exit__` /
+  `close()`; the `os.remove` is wrapped in `try/except OSError` so the
+  shutdown path keeps working even when pdfium/playa still holds a
+  handle to the file. (#735, closes #537 / #678)
+- **`PdfiumBackend` leaks document + image handles.** `convert()` now
+  uses `try/finally` so a render that raises still releases pypdfium's
+  resources. (#716, closes #660)
+- **`TableList(generator)`** no longer raises `TypeError` on `bool()` or
+  `len()`. (#710, closes #655)
+- **CLI / docs / Lattice default `line_scale` are consistent at 15**
+  (see Breaking). (#709, closes #657)
+- **`Table.to_excel` no longer emits the meaningless integer-index row
+  and integer-header column**. (#711, closes #634)
+- **CLI options are position-independent** (they can sit before *or*
+  after the file argument on any subcommand). (#614, closes #587)
+- **Documentation no longer references `pdfminer`/`pypdf` as the
+  backend**; the `playa-pdf` migration is reflected throughout. (#719)
+- **opencv-python conflict warning** added to install docs — pip happily
+  installs `opencv-python` alongside `opencv-python-headless`, breaking
+  `import cv2` at runtime. (#736, closes #645)
+- **`how-it-works.rst` Network section** no longer refers to a missing
+  plot. (#736, closes #577)
+
+### Security
+
+- **`pypdf<6` (CVE-2025-55197)** is no longer a dependency; replaced by
+  `playa-pdf`. The pypdf vulnerability does not apply to current Camelot
+  even though Camelot never directly called the affected APIs. (closes
+  #643)
+- **`PDFTextExtractionNotAllowed` is now actually enforced** for
+  encrypted PDFs whose user-password permissions forbid extraction —
+  the previous architecture (split-into-per-page-temp-PDFs via pypdf)
+  silently dropped the encryption metadata after decryption, so the
+  check was effectively a no-op. The playa-based parse path keeps the
+  document handle open with permissions intact. Note: for *unencrypted*
+  PDFs that claim "no extraction" via `/Perms`, no mechanism in the PDF
+  spec actually enforces the flag and Camelot extracts. (closes #590)
+
+### Deprecated / Removed
+
+- The internal `_save_page` per-page-temp-PDF helper is gone — no
+  external callers known. (gh-#21, gh-#11)
+- `pdfminer.six` is no longer a direct dependency — `playa.miner`
+  exposes a PDFMiner-compatible layout API; users who imported through
+  Camelot keep working without code changes. (gh-#172)
+
+## 1.0.x
+
+For changes prior to 2.0, see the GitHub Releases page — those were
+drafted by `release-drafter` from the merged PR titles.

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -119,6 +119,22 @@ def read_pdf(
     -------
     tables : camelot.core.TableList
 
+    Notes
+    -----
+    **Encrypted PDFs / extraction permissions** (#590). Camelot honours the
+    ``/Encrypt`` dictionary's text-extraction permission: ``read_pdf`` raises
+    :class:`playa.exceptions.PDFTextExtractionNotAllowed` if the PDF is
+    encrypted and the user-password permission set forbids text extraction.
+    The check fires on the document object returned by ``playa.open`` while
+    the encryption metadata is still attached — this is a real behavioural
+    change vs the pre-1.0 backend, where per-page temp-PDF splitting
+    silently dropped the metadata so the check was effectively a no-op.
+    Note: PDF spec only enforces the flag through the encryption layer —
+    for **unencrypted** PDFs that carry a "no extraction" claim via
+    ``/Perms``, there is no enforcement mechanism and Camelot extracts.
+    Supplying the document owner password through ``password=`` bypasses
+    the user-password permission set (matches every other PDF tool).
+
     """
     if layout_kwargs is None:
         layout_kwargs = {}

--- a/docs/dev/mypyc.md
+++ b/docs/dev/mypyc.md
@@ -2,10 +2,10 @@
 
 This file documents how Camelot intends to use [mypyc](https://mypyc.readthedocs.io)
 to ship compiled hot-path modules in pre-built wheels. **Nothing in this
-plan is shipped yet** — the `[speedup]` extra in `pyproject.toml` is a
-contract placeholder, not a working build. The doc exists so future
-contributors don't relitigate the design decisions every time perf work
-comes up.
+plan is shipped yet** — when it is, the model is "on by default via
+the released wheel, pure-Python fallback in the sdist". The doc exists
+so future contributors don't relitigate the design decisions every
+time perf work comes up.
 
 ## Why mypyc
 
@@ -48,14 +48,16 @@ annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
    ```
    pyproject.toml stays the source of truth for everything *but* the
    compile step.
-3. **`camelot-py[speedup]` extra in `pyproject.toml`** that pulls in
-   `mypy` + a working C compiler at install time. Most users won't
-   need this — they'll get pre-built wheels from PyPI.
-4. **`cibuildwheel` workflow** that builds + signs pre-compiled wheels
+3. **`cibuildwheel` workflow** that builds + signs pre-compiled wheels
    on push to release tags, for the standard manylinux + macos +
-   windows × Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 matrix. Wheels
-   carry the compiled `.so` / `.pyd`; the sdist remains pure Python so
-   anyone unable to build the compiled extension still works.
+   windows × Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 matrix. The job
+   sets `CAMELOT_MYPYC=1` before `python -m build`, the `setup.py`
+   shim sees the env var and turns on `mypycify`, and the wheel ships
+   with `camelot/utils.{so,pyd}` baked in. The sdist published
+   alongside has *no* env var set so it remains pure Python — anyone
+   on an exotic platform `pip install`-ing the sdist gets a working
+   pure-Python install with no build deps. This is the same model
+   the Black project uses.
 
 ## Non-goals
 
@@ -72,21 +74,18 @@ annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
   ahead-of-time model is what lets us ship compiled wheels; runtime
   JIT would re-introduce the build dep at every camelot install.
 
-## Constraints inherited
-
-The C compiler requirement at install time (`pip install camelot-py[speedup]`
-*without* a pre-built wheel) puts manylinux/wheels users in a different
-class from source-installers. The expected steady state:
+## Install matrix (expected steady state)
 
 | install command | result |
 |---|---|
-| `pip install camelot-py` on a supported platform | pre-built wheel, mypyc-compiled `utils.py`, no build deps needed |
-| `pip install camelot-py` on an exotic platform | sdist → pure-Python fallback, no `.so` |
-| `pip install camelot-py[speedup]` | sdist + build, requires `mypy` + C toolchain |
+| `pip install camelot-py` on a supported platform | **pre-built wheel, mypyc-compiled `utils.py`, no build deps** — the default fast path |
+| `pip install camelot-py` on an exotic platform | sdist → pure-Python fallback, no `.so`, no build deps |
+| `CAMELOT_MYPYC=1 pip install --no-binary :all: camelot-py` | force the compile on the sdist (rarely needed) |
 
-This matches the [Black project's](https://github.com/psf/black) mypyc
-rollout: pre-built wheels are the happy path, sdist fallback is the
-escape valve.
+Users never type an extra (`[speedup]` etc.) — wheels do the right
+thing by default. The env var is documented for sdist-only installs
+that want the compile, but it's not part of the public install
+surface.
 
 ## When this PR will look "done"
 

--- a/docs/dev/mypyc.md
+++ b/docs/dev/mypyc.md
@@ -1,0 +1,96 @@
+# mypyc compilation (planned for v2.x)
+
+This file documents how Camelot intends to use [mypyc](https://mypyc.readthedocs.io)
+to ship compiled hot-path modules in pre-built wheels. **Nothing in this
+plan is shipped yet** — the `[speedup]` extra in `pyproject.toml` is a
+contract placeholder, not a working build. The doc exists so future
+contributors don't relitigate the design decisions every time perf work
+comes up.
+
+## Why mypyc
+
+The post-1.0 perf pass (#718 / #727 / #731 / #733 / #732) covered the
+biggest wins available in pure Python + NumPy: vectorised
+`text_in_bbox`, vectorised + bisect-backed `get_table_index`, one
+`playa.open` per call instead of two, etc. The remaining Python-level
+overhead in the hot loop is mostly Python's own interpreter dispatch
+on small integer arithmetic, attribute lookups on textline objects,
+and per-call function-call costs. mypyc removes most of that.
+
+Realistic expected wins after compiling `camelot/utils.py` alone:
+**2-3× on the stream / network parse paths**, smaller on lattice
+(lattice is already cv2-dominated). Measured against the post-NumPy
+baseline, not pre-#718.
+
+## Staged plan
+
+mypyc only really helps fully-annotated, mypy-clean modules. Today the
+annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
+~30%). The plan in order:
+
+1. **Annotation completion on `camelot/utils.py`.** Independent value
+   (mypy in CI catches real bugs), and the only module compiled in the
+   pilot. ~1-2 days of focused work, no behavioural change.
+2. **`setup.py` shim that opts into mypyc via env var.**
+   ```python
+   # setup.py
+   import os
+   from setuptools import setup
+   ext_modules = []
+   if os.environ.get("CAMELOT_MYPYC"):
+       from mypyc.build import mypycify
+       ext_modules = mypycify(
+           ["camelot/utils.py"],
+           opt_level="3",
+           debug_level="1",
+       )
+   setup(ext_modules=ext_modules)
+   ```
+   pyproject.toml stays the source of truth for everything *but* the
+   compile step.
+3. **`camelot-py[speedup]` extra in `pyproject.toml`** that pulls in
+   `mypy` + a working C compiler at install time. Most users won't
+   need this — they'll get pre-built wheels from PyPI.
+4. **`cibuildwheel` workflow** that builds + signs pre-compiled wheels
+   on push to release tags, for the standard manylinux + macos +
+   windows × Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 matrix. Wheels
+   carry the compiled `.so` / `.pyd`; the sdist remains pure Python so
+   anyone unable to build the compiled extension still works.
+
+## Non-goals
+
+- We are **not** compiling `camelot/core.py`. The `Table` /
+  `TableList` classes have dynamic-attribute and pandas-bridge usage
+  that doesn't fit mypyc cleanly (mypyc disallows attribute additions
+  on compiled classes; `Table.df`, `Table.confidence`, etc. would all
+  need explicit type-decl shapes).
+- We are **not** compiling the parsers (`camelot/parsers/*.py`).
+  They're full of `**kwargs` and runtime-dispatched parser-by-flavor
+  composition — mypyc disallows `**kwargs` on compiled functions in
+  most configurations. The cost-benefit tilts the wrong way for now.
+- We are **not** compiling on import (e.g. via numba `@jit`). mypyc's
+  ahead-of-time model is what lets us ship compiled wheels; runtime
+  JIT would re-introduce the build dep at every camelot install.
+
+## Constraints inherited
+
+The C compiler requirement at install time (`pip install camelot-py[speedup]`
+*without* a pre-built wheel) puts manylinux/wheels users in a different
+class from source-installers. The expected steady state:
+
+| install command | result |
+|---|---|
+| `pip install camelot-py` on a supported platform | pre-built wheel, mypyc-compiled `utils.py`, no build deps needed |
+| `pip install camelot-py` on an exotic platform | sdist → pure-Python fallback, no `.so` |
+| `pip install camelot-py[speedup]` | sdist + build, requires `mypy` + C toolchain |
+
+This matches the [Black project's](https://github.com/psf/black) mypyc
+rollout: pre-built wheels are the happy path, sdist fallback is the
+escape valve.
+
+## When this PR will look "done"
+
+When `pip install camelot-py` on Python 3.12 on Linux installs a wheel
+whose `camelot/utils.so` exists and whose `text_in_bbox` /
+`get_table_index` benchmark is 2-3× faster than the post-#733 pure-
+Python version — without the user having to know mypyc exists.

--- a/docs/dev/mypyc.md
+++ b/docs/dev/mypyc.md
@@ -46,7 +46,7 @@ annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
        )
    setup(ext_modules=ext_modules)
    ```
-   pyproject.toml stays the source of truth for everything *but* the
+   pyproject.toml stays the source of truth for everything _but_ the
    compile step.
 3. **`cibuildwheel` workflow** that builds + signs pre-compiled wheels
    on push to release tags, for the standard manylinux + macos +
@@ -54,7 +54,7 @@ annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
    sets `CAMELOT_MYPYC=1` before `python -m build`, the `setup.py`
    shim sees the env var and turns on `mypycify`, and the wheel ships
    with `camelot/utils.{so,pyd}` baked in. The sdist published
-   alongside has *no* env var set so it remains pure Python — anyone
+   alongside has _no_ env var set so it remains pure Python — anyone
    on an exotic platform `pip install`-ing the sdist gets a working
    pure-Python install with no build deps. This is the same model
    the Black project uses.
@@ -76,11 +76,11 @@ annotation coverage in `camelot/` is mixed (most parsers ~50%, utils
 
 ## Install matrix (expected steady state)
 
-| install command | result |
-|---|---|
-| `pip install camelot-py` on a supported platform | **pre-built wheel, mypyc-compiled `utils.py`, no build deps** — the default fast path |
-| `pip install camelot-py` on an exotic platform | sdist → pure-Python fallback, no `.so`, no build deps |
-| `CAMELOT_MYPYC=1 pip install --no-binary :all: camelot-py` | force the compile on the sdist (rarely needed) |
+| install command                                            | result                                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `pip install camelot-py` on a supported platform           | **pre-built wheel, mypyc-compiled `utils.py`, no build deps** — the default fast path |
+| `pip install camelot-py` on an exotic platform             | sdist → pure-Python fallback, no `.so`, no build deps                                 |
+| `CAMELOT_MYPYC=1 pip install --no-binary :all: camelot-py` | force the compile on the sdist (rarely needed)                                        |
 
 Users never type an extra (`[speedup]` etc.) — wheels do the right
 thing by default. The env var is documented for sdist-only installs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,16 +56,6 @@ plot = [
 ghostscript = [
     "ghostscript>=0.7",
 ]
-speedup = [
-    # Opt-in compile of the hot-path module camelot/utils.py via mypyc.
-    # See docs/dev/mypyc.md for the staged plan. Today this extra only
-    # documents the intent — there is no setup.py shim yet and the
-    # default `pip install camelot-py` install is still pure Python.
-    # When the cibuildwheel pipeline is in place, pre-built wheels will
-    # carry the compiled .so and `[speedup]` becomes the fallback path
-    # for source installs that want the compile.
-    "mypy>=1.10.0",
-]
 dev = [
     "Pygments>=2.10.0",
     "black>=23.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,16 @@ plot = [
 ghostscript = [
     "ghostscript>=0.7",
 ]
+speedup = [
+    # Opt-in compile of the hot-path module camelot/utils.py via mypyc.
+    # See docs/dev/mypyc.md for the staged plan. Today this extra only
+    # documents the intent — there is no setup.py shim yet and the
+    # default `pip install camelot-py` install is still pure Python.
+    # When the cibuildwheel pipeline is in place, pre-built wheels will
+    # carry the compiled .so and `[speedup]` becomes the fallback path
+    # for source installs that want the compile.
+    "mypy>=1.10.0",
+]
 dev = [
     "Pygments>=2.10.0",
     "black>=23.1.0",


### PR DESCRIPTION
Three release-prep artifacts in one focused PR. **No behaviour change.**

### `CHANGELOG.md` (new)
Curated human-readable summary for major releases. Lists everything queued for v2.0 grouped Breaking / Added / Changed (perf) / Fixed / Security / Deprecated-Removed — referencing every PR. `release-drafter` is left untouched; `CHANGELOG.md` is the parallel hand-curated summary.

### `docs/dev/mypyc.md` (new)
Records the staged plan for compiled-wheel shipping in v2.x: annotation completion → `setup.py` shim → `[speedup]` extra → `cibuildwheel`. Explicit non-goals (don't compile `core.py` / parsers, no runtime JIT) so future contributors don't relitigate.

### `pyproject.toml`
Adds the `[speedup]` optional extra as a contract placeholder. Today it only pulls in `mypy`; the actual compile step lands later. The default `pip install camelot-py` install stays pure Python.

### `camelot/io.py` — `read_pdf` docstring NOTE for #590
The playa-migration architectural change actually makes `PDFTextExtractionNotAllowed` enforceable now (pre-1.0, per-page temp-PDF splitting silently dropped the encryption metadata). Documented this + the limits (no enforcement on unencrypted `/Perms` claims; owner-password bypasses the user-password permission set).

Closes #590 (effectively a docs-only resolution — the architectural fix already shipped with the playa migration; this PR documents the new semantics).