### PR TITLE
ci: publish pre-releases to TestPyPI, stable releases to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - master
   release:
-    types: [published]
+    # `published`   — stable release => PyPI
+    # `prereleased` — GitHub "this is a pre-release" checkbox => TestPyPI
+    types: [published, prereleased]
 
 jobs:
   release-drafter:
@@ -28,8 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     environment:
-      name: pypi
-      url: https://pypi.org/p/camelot-py
+      # Pre-releases go to test.pypi.org; stable releases to pypi.org.
+      # The two GitHub-environment names ("testpypi" / "pypi") are also the
+      # PyPI Trusted Publisher environment names — register each side once on
+      # the corresponding PyPI account.
+      name: ${{ github.event.release.prerelease && 'testpypi' || 'pypi' }}
+      url: ${{ github.event.release.prerelease && 'https://test.pypi.org/p/camelot-py' || 'https://pypi.org/p/camelot-py' }}
     permissions:
       id-token: write
       contents: write
@@ -69,7 +75,15 @@ jobs:
       - name: Remove Sigstore files
         run: rm -f dist/*.sig dist/*.crt dist/*.sigstore.json
 
+      - name: Publish Python 🐍 distribution 📦 to TestPyPI
+        if: github.event.release.prerelease
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: "dist"
+          repository-url: https://test.pypi.org/legacy/
+
       - name: Publish Python 🐍 distribution 📦 to PyPI
+        if: ${{ !github.event.release.prerelease }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: "dist"


### PR DESCRIPTION
Adds a TestPyPI pre-release publish path alongside the existing PyPI stable publish in `release.yml`. The release-drafter job above is untouched.

### How it works

| GitHub Release marked as | Publish target |
|---|---|
| **Pre-release** (`release.prerelease == true`) | https://test.pypi.org/p/camelot-py |
| **Latest release** | https://pypi.org/p/camelot-py |

Mechanics:

- `on.release.types` extended with `prereleased` so the workflow fires on both.
- `environment.name` / `environment.url` switch between `testpypi` and `pypi` based on the event. Same separation lets you put different secrets / approval rules per environment.
- Two publish-to-PyPI steps, mutually exclusive on `release.prerelease`. The build / Sigstore / GitHub-release-upload steps **above** the publish are unchanged — pre-releases get the same signed artifacts attached to the GitHub Release page that stable ones do.

### One-time setup required on TestPyPI side

Camelot's PyPI Trusted Publisher needs to be mirrored on TestPyPI:

1. Go to https://test.pypi.org/manage/account/publishing/
2. Add a Trusted Publisher with:
   - Owner = `camelot-dev`
   - Repository = `camelot`
   - Workflow filename = `release.yml`
   - Environment name = `testpypi`
3. The first pre-release that triggers will then be allowed to publish.

Until that registration exists, the workflow runs successfully through build + Sigstore + GitHub-release-upload, and only the *Publish to TestPyPI* step fails. **Stable PyPI publishing is unaffected** because it's a different conditional step + a different Trusted Publisher.

### How to cut a pre-release

1. Push a tag like `v2.0.0a1` (alpha) or `v2.0.0rc1` (release candidate) — PEP 440 pre-release suffix matters.
2. Create a GitHub Release from that tag and check **Set as a pre-release**.
3. This workflow fires with `release.prerelease == true` and publishes to TestPyPI.
