### PR TITLE
fix(network): defensive guards in TextNetworks / Network (#619 split 1/3)

### DIFF
--- a/camelot/parsers/network.py
+++ b/camelot/parsers/network.py
@@ -256,7 +256,8 @@ def search_header_from_body_bbox(
             merged_zones = _merge_zones(zones)
 
             max_spread = max(
-                column_spread(zone[0], zone[1], col_anchors) for zone in merged_zones
+                (column_spread(zone[0], zone[1], col_anchors) for zone in merged_zones),
+                default=0,
             )
 
             # Accept textlines that cross columns boundaries, as long as they
@@ -526,6 +527,9 @@ class TextNetworks(TextAlignments):
             [x0, y0, x1, y1] or None if not enough textlines are found.
         """
         most_aligned_tl = self.most_connected_textline()
+        if most_aligned_tl is None:
+            # No connected textlines — nothing to grow a body bbox from.
+            return None
         max_h_gap, max_v_gap = gaps_hv
 
         parse_details_search: dict[str, Any] | None = None


### PR DESCRIPTION
Splits out the no-controversy half of the year-old #619 (bosd-fix585-attempt) so it can land cleanly. The behaviour-changing gap-formula tweak is held back for a separate PR with fixture recalibration; the new test fixture lands in PR 2/3.

### Defensive fixes (real crash-path bugs)

- **`TextNetworks.search_table_body`** now returns `None` early when `most_connected_textline()` has nothing to return. Previously it dereferenced `None` on the next line and crashed.
- **`TextNetworks.search_header_from_body_bbox`**: `max(..., default=0)` on the merged-zones generator so an empty `zones` list no longer raises `ValueError: max() arg is an empty sequence`.

### Refactor (no behaviour change, just structure)

- **`Network._generate_table_bbox`** splits the user-provided-`table_areas` and discovery code paths into two clear branches. The previous shape conflated them inside a single `while` loop with several `break` paths; the new shape makes each case trivially auditable and was already where #619 left it.

### Deliberately NOT in this PR

The gap-formula change (`h_textlines[i].x0 - h_textlines[i - 1].x1` instead of `.x0 - .x0`, plus the `v_textlines` equivalent) is semantically more correct but shifts column boundaries on every existing `test_network` fixture. That belongs in a 3rd follow-up PR with the assertion-coord recalibration, so review focus stays on the one decision.

PR 2/3 (the fixture + tests with `xfail` markers) follows immediately.

Plan:

| | what | risk |
|---|---|---|
| 1/3 (this) | defensive guards + refactor | none — existing tests untouched |
| 2/3 | `good_energy.pdf` + `test_issue_585` x2 with `pytest.xfail` | low — additive, xfailed |
| 3/3 | gap-formula change + fixture-assertion recalibration | medium — needs local test runs |

Once 1/3 and 2/3 land, 3/3 becomes a small 5-line + N-fixture-line PR.