### PR TITLE
fix: drop bogus .pdf extension check on string filepaths

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -69,9 +69,6 @@ class PDFHandler:
             filepath = download_url(str(filepath))
         self.filepath: Path | str = filepath
 
-        if isinstance(filepath, str) and not filepath.lower().endswith(".pdf"):
-            raise NotImplementedError("File format not supported")
-
         if password is None:
             self.password = ""  # noqa: S105
         else:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -27,11 +27,18 @@ def test_input_kwargs(foo_pdf):
         camelot.read_pdf(foo_pdf, columns=["10,20,30,40"])
 
 
-def test_unsupported_format(testdir):
-    message = "File format not supported"
-    filename = os.path.join(testdir, "foo.csv")
-    with pytest.raises(NotImplementedError, match=message):
-        camelot.read_pdf(filename)
+def test_pdf_without_pdf_extension(testdir, tmp_path):
+    """Non-`.pdf` filenames containing valid PDF bytes are accepted (#646).
+
+    NamedTemporaryFile and similar producers commonly omit the suffix; the
+    file-extension check used to reject them even though the bytes parse
+    fine. Symmetric with the Path-arg path, which already bypassed it.
+    """
+    src = os.path.join(testdir, "foo.pdf")
+    dst = tmp_path / "no_extension"
+    dst.write_bytes(open(src, "rb").read())
+    tables = camelot.read_pdf(str(dst))
+    assert len(tables) == 1
 
 
 @skip_on_windows
@@ -143,11 +150,14 @@ def test_lattice_no_convert_method(foo_pdf):
 
 
 def test_invalid_url():
+    # `fttp://` is not a recognised URL scheme, so is_url returns False and
+    # the string is treated as a file path. Since no such file exists, a
+    # FileNotFoundError is raised (rather than the old extension-check
+    # NotImplementedError, which was removed in #646).
     url = "fttp://google.com/pdf"
-    message = "File format not supported"
-    with pytest.raises(Exception, match=message):
-        url = camelot.read_pdf(url)
     assert is_url(url) is False
+    with pytest.raises((FileNotFoundError, OSError)):
+        camelot.read_pdf(url)
 
 
 def test_pdfium_backend_import_error(testdir):


### PR DESCRIPTION
Removes the string-only `endswith(".pdf")` check in `PDFHandler.__init__`.

PDFs are content-identified by their `%PDF-` magic bytes, not by filename. The check was already asymmetric — `pathlib.Path("any_name")` bypassed it, only string callers got rejected — and broke legitimate inputs whose filename happened not to end in `.pdf`, most commonly `tempfile.NamedTemporaryFile`.

- Removed three offending lines in `handlers.py`.
- Replaced `test_unsupported_format` (which asserted the old check fired) with `test_pdf_without_pdf_extension`, which positively asserts a tempfile of valid PDF bytes parses.
- Updated `test_invalid_url` since `fttp://…` URLs now fall through to file-open and raise `FileNotFoundError`, not the old `NotImplementedError`.

Reported by @zhengliw in #646.

Closes #646.