### PR TITLE
fix(stream): clamp columns index when more tables than column specs

### DIFF
--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -230,12 +230,22 @@ class BaseParser:
         _tables = []
         # sort tables based on y-coord
         for table_idx, bbox in enumerate(self.table_bboxes()):
-            if self.columns is not None and self.columns[table_idx] != "":
+            # Re-use the last user-supplied column spec when more tables are
+            # discovered than column specs were supplied (#112). The previous
+            # behaviour raised IndexError on the second extra table, which
+            # is the wrong failure mode when the columns are meant to apply
+            # to "however many tables match this layout".
+            if self.columns is not None and self.columns:
+                col_idx = table_idx if table_idx < len(self.columns) else -1
+                col_spec = self.columns[col_idx]
+            else:
+                col_spec = ""
+            if col_spec != "":
                 # user has to input boundary columns too
                 # take (0, pdf_width) by default
                 # similar to else condition
                 # len can't be 1
-                user_cols = self.columns[table_idx].split(",")
+                user_cols = col_spec.split(",")
                 user_cols = [float(c) for c in user_cols]
             else:
                 user_cols = None

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -126,3 +126,20 @@ def test_stream_inner_outer_columns(testdir):
         flavor="stream",
     )
     assert_frame_equal(df, tables[0].df)
+
+
+def test_stream_fewer_columns_than_tables(testdir):
+    """One column spec applied to a multi-table page no longer crashes (#112).
+
+    Previously, supplying a `columns=` list shorter than the number of
+    auto-detected tables raised IndexError on the second table. The last
+    entry is now reused as a fallback so the call returns a result for
+    every detected table.
+    """
+    filename = os.path.join(testdir, "tabula/12s0324.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="stream",
+        columns=["72,95,209,327,442,520"],
+    )
+    assert len(tables) == 2


### PR DESCRIPTION
When the parser auto-discovers more tables than `columns=` entries were supplied, `BaseParser.extract_tables` previously raised `IndexError` on the second extra table — the wrong failure mode for the common case where the caller knows the column layout and wants it applied to every detected table on the page.

Reuse the last column spec as a fallback when `table_idx >= len(self.columns)`. The 1:1 mapping is preserved when the lengths align; only the over-flow case behaves differently.

Added a regression test (`test_stream_fewer_columns_than_tables`) that supplies one column spec to the two-table fixture `tabula/12s0324.pdf` and asserts both tables come back.

Original fix proposed by @JosePVB in #112; ported forward since the parser layout has shifted.

Closes #112.