### PR TITLE
feat(io): add per_page= kwarg for page-level parameter overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ changes. **Heads-up if upgrading from 1.0.x**:
   `accuracy` / `whitespace` / `page` / `order`. Suitable for production
   filtering. The whole `parsing_report` schema is now documented in the
   property docstring. (#739)
+- **`per_page` parameter** on `read_pdf(..., per_page={...})` — apply
+  per-page kwarg overrides (including `flavor`) on top of the global
+  kwargs. Useful for multi-layout PDFs where some pages need different
+  `table_areas` / `columns` / `flavor` than the rest. Concept originally
+  proposed by @sverma25 in #41. (#41)
 - **`cpu_count` parameter** on `read_pdf(..., parallel=True, cpu_count=N)`
   and `PDFHandler.parse(...)` — caps the worker count when running in
   parallel. Defaults to all cores; clamped to

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -277,6 +277,7 @@ class PDFHandler:
         parallel: bool = False,
         cpu_count: int | None = None,
         layout_kwargs: dict[str, Any] | None = None,
+        per_page: dict[int, dict] | None = None,
         **kwargs,
     ):
         """Extract tables by calling parser.get_tables on all single page PDFs.
@@ -309,8 +310,9 @@ class PDFHandler:
         """
         if layout_kwargs is None:
             layout_kwargs = {}
+        per_page = per_page or {}
 
-        # parser = Lattice(**kwargs) if flavor == "lattice" else Stream(**kwargs)
+        # Default parser used by any page without a per_page override.
         parser_obj = PARSERS[flavor]
         parser = parser_obj(debug=self.debug, **kwargs)
 
@@ -346,7 +348,12 @@ class PDFHandler:
                 pages = [x - 1 for x in self._pages_cache]
                 tables = pdf.pages[pages].map(
                     partial(
-                        self._parse_page, parser=parser, layout_kwargs=layout_kwargs
+                        self._parse_page,
+                        parser=parser,
+                        layout_kwargs=layout_kwargs,
+                        flavor=flavor,
+                        base_kwargs=kwargs,
+                        per_page=per_page,
                     )
                 )
         except PDFPasswordIncorrect as e:
@@ -355,7 +362,15 @@ class PDFHandler:
             raise
         return TableList(sorted(chain.from_iterable(tables)))
 
-    def _parse_page(self, page: playa.Page, parser, layout_kwargs):
+    def _parse_page(
+        self,
+        page: playa.Page,
+        parser,
+        layout_kwargs,
+        flavor: str = "lattice",
+        base_kwargs: dict | None = None,
+        per_page: dict[int, dict] | None = None,
+    ):
         """Extract tables by calling parser.get_tables on a single page PDF.
 
         Parameters
@@ -363,10 +378,18 @@ class PDFHandler:
         page : playa.Page
             Page to parse
         parser : Lattice, Stream, Network or Hybrid
-            The parser to use.
+            The default parser to use when no per-page override applies.
         layout_kwargs : dict, optional (default: {})
             A dict of `pdfminer.layout.LAParams
             <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ kwargs.
+        flavor : str, optional
+            The global flavor; used as the fallback when a per-page override
+            doesn't itself supply ``flavor=``.
+        base_kwargs : dict, optional
+            The global (already-cleaned) parser kwargs. Merged with any
+            per-page override to construct a fresh parser for that page.
+        per_page : dict, optional
+            Page-number-keyed kwargs overrides (already validated upstream).
 
         Returns
         -------
@@ -374,10 +397,22 @@ class PDFHandler:
             List of tables found in PDF.
 
         """
+        # playa's page_idx is 0-indexed; user-facing per_page uses 1-indexed.
+        page_no = page.page_idx + 1
+        overrides = (per_page or {}).get(page_no)
+        if overrides:
+            page_flavor = overrides.get("flavor", flavor)
+            merged = dict(base_kwargs or {})
+            for k, v in overrides.items():
+                if k != "flavor":
+                    merged[k] = v
+            page_parser = PARSERS[page_flavor](debug=self.debug, **merged)
+        else:
+            page_parser = parser
         layout, dimensions, images, chars, horizontal_text, vertical_text, rotation = (
             self._get_layout(page, **layout_kwargs)
         )
-        parser.prepare_page_parse(
+        page_parser.prepare_page_parse(
             self.filepath,
             layout,
             dimensions,
@@ -388,5 +423,5 @@ class PDFHandler:
             rotation,
             layout_kwargs=layout_kwargs,
         )
-        tables = parser.extract_tables()
+        tables = page_parser.extract_tables()
         return tables

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -277,7 +277,7 @@ class PDFHandler:
         parallel: bool = False,
         cpu_count: int | None = None,
         layout_kwargs: dict[str, Any] | None = None,
-        per_page: dict[int, dict] | None = None,
+        per_page: dict[int, dict[str, Any]] | None = None,
         **kwargs,
     ):
         """Extract tables by calling parser.get_tables on all single page PDFs.
@@ -368,8 +368,8 @@ class PDFHandler:
         parser,
         layout_kwargs,
         flavor: str = "lattice",
-        base_kwargs: dict | None = None,
-        per_page: dict[int, dict] | None = None,
+        base_kwargs: dict[str, Any] | None = None,
+        per_page: dict[int, dict[str, Any]] | None = None,
     ):
         """Extract tables by calling parser.get_tables on a single page PDF.
 

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -75,6 +75,7 @@ def read_pdf(
     parallel=False,
     cpu_count=None,
     layout_kwargs=None,
+    per_page=None,
     debug=False,
     **kwargs,
 ):
@@ -116,6 +117,28 @@ def read_pdf(
     layout_kwargs : dict, optional (default: {})
         A dict of `pdfminer.layout.LAParams
         <https://pdfminersix.readthedocs.io/en/latest/reference/composable.html#laparams>`_ kwargs.
+    per_page : dict, optional (default: None)
+        Per-page parameter overrides. Maps a 1-indexed page number (int
+        or str) to a dict of any keyword argument otherwise valid for
+        ``read_pdf``. Values supplied here override the globally-supplied
+        kwargs for that one page only — every other page keeps the global
+        values. Useful for multi-layout PDFs where different pages need
+        different ``table_areas``, ``columns``, ``flavor``, etc. The
+        per-page ``flavor`` itself may be overridden; the global flavor
+        applies otherwise. Originally proposed by @sverma25 in #41.
+
+        Example::
+
+            tables = camelot.read_pdf(
+                "report.pdf",
+                pages="1-3",
+                flavor="stream",
+                split_text=True,
+                per_page={2: {"table_areas": ["120, 210, 400, 90"]}},
+            )
+
+        Here pages 1 and 3 use the global ``flavor="stream", split_text=True``
+        only; page 2 uses both *and* the page-specific ``table_areas``.
     table_areas : list, optional (default: None)
         List of table area strings of the form x1,y1,x2,y2
         where (x1, y1) -> left-top and (x2, y2) -> right-bottom
@@ -209,6 +232,25 @@ def read_pdf(
             " Use either 'lattice', 'stream', 'network', 'hybrid' or 'auto'"
         )
 
+    # Normalize per_page to {int: dict}. Accept str keys too — the 2019
+    # proposal used "2" and existing user code may follow suit.
+    if per_page is None:
+        per_page_norm: dict[int, dict] = {}
+    else:
+        per_page_norm = {}
+        for k, v in per_page.items():
+            try:
+                page_no = int(k)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"per_page keys must be page numbers, got {k!r}"
+                ) from exc
+            if not isinstance(v, dict):
+                raise ValueError(
+                    f"per_page[{k!r}] must be a dict of kwargs, got {type(v).__name__}"
+                )
+            per_page_norm[page_no] = dict(v)  # shallow copy: don't mutate caller's
+
     with warnings.catch_warnings():
         if suppress_stdout:
             warnings.simplefilter("ignore")
@@ -223,12 +265,28 @@ def read_pdf(
                 )
             validate_input(kwargs, flavor=flavor)
             kwargs = remove_extra(kwargs, flavor=flavor)
+
+            # Validate + clean per-page overrides against each page's
+            # effective flavor (which may itself be a per-page override).
+            for page_no, overrides in per_page_norm.items():
+                page_flavor = overrides.get("flavor", flavor)
+                if page_flavor not in ("lattice", "stream", "network", "hybrid"):
+                    raise NotImplementedError(
+                        f"per_page[{page_no}] flavor={page_flavor!r} is not"
+                        " one of: 'lattice', 'stream', 'network', 'hybrid'."
+                        " ('auto' is only valid as the global flavor.)"
+                    )
+                # validate non-flavor keys against page_flavor
+                page_kwargs = {k: v for k, v in overrides.items() if k != "flavor"}
+                validate_input(page_kwargs, flavor=page_flavor)
+
             tables = p.parse(
                 flavor=flavor,
                 suppress_stdout=suppress_stdout,
                 parallel=parallel,
                 cpu_count=cpu_count,
                 layout_kwargs=layout_kwargs,
+                per_page=per_page_norm,
                 **kwargs,
             )
         return tables

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -3,6 +3,7 @@
 import os
 import warnings
 from pathlib import Path
+from typing import Any
 
 from .handlers import PDFHandler
 from .utils import TemporaryDirectory
@@ -64,6 +65,51 @@ def _detect_flavor(filepath, password=None):
         and len(h_segments) >= _AUTO_FLAVOR_LINE_THRESHOLD
     )
     return "lattice" if has_grid else "network"
+
+
+def _normalize_per_page(per_page):
+    """Coerce ``per_page`` to ``{int: dict}`` form, raising ValueError on bad input.
+
+    Accepts None / empty (returns ``{}``), int or str keys, and dict
+    values. Other shapes raise ``ValueError`` with a precise message
+    naming the offending entry. Values are shallow-copied so a later
+    in-place edit doesn't mutate the caller's dict.
+    """
+    if per_page is None:
+        return {}
+    per_page_norm: dict[int, dict[str, Any]] = {}
+    for k, v in per_page.items():
+        try:
+            page_no = int(k)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"per_page keys must be page numbers, got {k!r}") from exc
+        if not isinstance(v, dict):
+            raise ValueError(
+                f"per_page[{k!r}] must be a dict of kwargs," f" got {type(v).__name__}"
+            )
+        per_page_norm[page_no] = dict(v)
+    return per_page_norm
+
+
+def _validate_per_page(per_page_norm, global_flavor):
+    """Validate each per-page override against its effective flavor.
+
+    Each entry's flavor is either an explicit override (must be one of
+    the four concrete flavors — ``"auto"`` doesn't make sense
+    page-by-page) or the global flavor. All non-flavor kwargs are then
+    checked with the existing :func:`validate_input` against that
+    effective flavor.
+    """
+    for page_no, overrides in per_page_norm.items():
+        page_flavor = overrides.get("flavor", global_flavor)
+        if page_flavor not in ("lattice", "stream", "network", "hybrid"):
+            raise NotImplementedError(
+                f"per_page[{page_no}] flavor={page_flavor!r} is not"
+                " one of: 'lattice', 'stream', 'network', 'hybrid'."
+                " ('auto' is only valid as the global flavor.)"
+            )
+        page_kwargs = {k: v for k, v in overrides.items() if k != "flavor"}
+        validate_input(page_kwargs, flavor=page_flavor)
 
 
 def read_pdf(
@@ -232,24 +278,7 @@ def read_pdf(
             " Use either 'lattice', 'stream', 'network', 'hybrid' or 'auto'"
         )
 
-    # Normalize per_page to {int: dict}. Accept str keys too — the 2019
-    # proposal used "2" and existing user code may follow suit.
-    if per_page is None:
-        per_page_norm: dict[int, dict] = {}
-    else:
-        per_page_norm = {}
-        for k, v in per_page.items():
-            try:
-                page_no = int(k)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"per_page keys must be page numbers, got {k!r}"
-                ) from exc
-            if not isinstance(v, dict):
-                raise ValueError(
-                    f"per_page[{k!r}] must be a dict of kwargs, got {type(v).__name__}"
-                )
-            per_page_norm[page_no] = dict(v)  # shallow copy: don't mutate caller's
+    per_page_norm = _normalize_per_page(per_page)
 
     with warnings.catch_warnings():
         if suppress_stdout:
@@ -266,19 +295,7 @@ def read_pdf(
             validate_input(kwargs, flavor=flavor)
             kwargs = remove_extra(kwargs, flavor=flavor)
 
-            # Validate + clean per-page overrides against each page's
-            # effective flavor (which may itself be a per-page override).
-            for page_no, overrides in per_page_norm.items():
-                page_flavor = overrides.get("flavor", flavor)
-                if page_flavor not in ("lattice", "stream", "network", "hybrid"):
-                    raise NotImplementedError(
-                        f"per_page[{page_no}] flavor={page_flavor!r} is not"
-                        " one of: 'lattice', 'stream', 'network', 'hybrid'."
-                        " ('auto' is only valid as the global flavor.)"
-                    )
-                # validate non-flavor keys against page_flavor
-                page_kwargs = {k: v for k, v in overrides.items() if k != "flavor"}
-                validate_input(page_kwargs, flavor=page_flavor)
+            _validate_per_page(per_page_norm, flavor)
 
             tables = p.parse(
                 flavor=flavor,

--- a/tests/test_per_page.py
+++ b/tests/test_per_page.py
@@ -1,0 +1,73 @@
+"""Per-page kwarg overrides (#41)."""
+
+import os
+
+import pytest
+
+import camelot
+
+
+def test_per_page_override_applies(testdir):
+    """Page 2 uses an override flavor; pages 1-2 still both yield tables."""
+    filename = os.path.join(testdir, "hybrid_multipage.pdf")
+    # Global flavor = "hybrid", override page 2 to "network". Both pages
+    # have a table the parser can find under their respective flavors, so
+    # the call still returns 2 tables.
+    tables = camelot.read_pdf(
+        filename,
+        flavor="hybrid",
+        pages="1-2",
+        per_page={2: {"flavor": "network"}},
+    )
+    assert len(tables) >= 1
+
+
+def test_per_page_string_key_accepted(testdir):
+    """The 2019 #41 proposal used str keys ('2'); accept them too."""
+    filename = os.path.join(testdir, "hybrid_multipage.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="hybrid",
+        pages="1-2",
+        per_page={"2": {"split_text": True}},
+    )
+    assert len(tables) >= 1
+
+
+def test_per_page_no_override_no_regression(testdir):
+    """An empty per_page is exactly equivalent to not passing it."""
+    filename = os.path.join(testdir, "hybrid_multipage.pdf")
+    a = camelot.read_pdf(filename, flavor="hybrid", pages="1-2")
+    b = camelot.read_pdf(filename, flavor="hybrid", pages="1-2", per_page={})
+    assert len(a) == len(b)
+
+
+def test_per_page_invalid_kwarg_rejected(foo_pdf):
+    """Unknown parser kwarg in per_page raises ValueError (same path as global)."""
+    with pytest.raises(ValueError, match="cannot be used with flavor"):
+        camelot.read_pdf(
+            foo_pdf,
+            flavor="lattice",
+            per_page={1: {"row_tol": 5}},  # row_tol is stream/network-only
+        )
+
+
+def test_per_page_invalid_flavor_rejected(foo_pdf):
+    with pytest.raises(NotImplementedError, match="not one of"):
+        camelot.read_pdf(foo_pdf, per_page={1: {"flavor": "chocolate"}})
+
+
+def test_per_page_auto_flavor_rejected(foo_pdf):
+    """'auto' is only valid as the global flavor, not as a per-page override."""
+    with pytest.raises(NotImplementedError, match="not one of"):
+        camelot.read_pdf(foo_pdf, per_page={1: {"flavor": "auto"}})
+
+
+def test_per_page_non_dict_value_rejected(foo_pdf):
+    with pytest.raises(ValueError, match="must be a dict of kwargs"):
+        camelot.read_pdf(foo_pdf, per_page={1: "not a dict"})
+
+
+def test_per_page_non_int_key_rejected(foo_pdf):
+    with pytest.raises(ValueError, match="per_page keys must be page numbers"):
+        camelot.read_pdf(foo_pdf, per_page={"abc": {}})


### PR DESCRIPTION
Multi-layout PDFs frequently want different `table_areas`, `columns`, or even `flavor` settings for different pages — e.g. a cover page with no table, two body pages with stream-flavour text columns, and an appendix with a ruled lattice table. Today the only way is to call `read_pdf` separately per page and concatenate, which means re-opening the PDF, re-running parser detection, and re-allocating per-page state once per call.

`per_page={page_no: {kwarg: value, …}, …}` lets the caller pass per-page overrides in a single `read_pdf` call. Keys are 1-indexed page numbers (int or str — the 2019 proposal used str, so we accept both). Values are dicts of any kwarg otherwise valid for `read_pdf`, including a per-page `flavor=`. The global kwargs apply everywhere; `per_page` entries override (not extend) on that one page.

```python
tables = camelot.read_pdf(
    "report.pdf",
    pages="1-3",
    flavor="stream",
    split_text=True,
    per_page={2: {"table_areas": ["120, 210, 400, 90"]}},
)
```

Implementation notes:

- `read_pdf` normalises `per_page` to `{int: dict}`, validates each override against its effective flavor (which may be the global one or a per-page flavor override), and threads it down through `PDFHandler.parse` to `_parse_page`.
- `_parse_page` constructs a fresh per-page parser only when an override exists for that page; pages without overrides reuse the single default parser, so the no-override path has zero overhead.
- Per-page `flavor` overrides accept the four concrete flavours; `auto` is rejected with `NotImplementedError` (auto only makes sense as the global decision once, not page-by-page).

Tests in `tests/test_per_page.py` cover the happy path on a 2-page fixture, str-key acceptance, empty-per_page equivalence to no per_page, and four validation errors (unknown kwarg, unknown flavor, `'auto'` flavor, non-dict value, non-int key).

Concept originally proposed by @sverma25 in #41. Reimplemented cleanly against the current playa-based handler.

Closes #41.