### PR TITLE
fix(stream): guard outer_text indexing when cols ends up empty

### DIFF
--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -182,13 +182,19 @@ class Stream(TextBaseParser):
                         ]
                     )
 
-                outer_text = [
-                    t
-                    for direction in self.t_bbox
-                    for t in self.t_bbox[direction]
-                    if t.x0 > cols[-1][1] or t.x1 < cols[0][0]
-                ]
-                inner_text.extend(outer_text)
-                cols = self._add_columns(cols, inner_text, self.row_tol)
-                cols = self._join_columns(cols, text_x_min, text_x_max)
+                # Guard against `cols` being empty: when no row in
+                # rows_grouped has exactly `ncols` columns, _merge_columns
+                # returns []. The outer_text comprehension below indexes
+                # cols[-1] and cols[0], which would IndexError. Reported
+                # as #390 (Lafayette/Concord/Orinda housing-element PDFs).
+                if cols:
+                    outer_text = [
+                        t
+                        for direction in self.t_bbox
+                        for t in self.t_bbox[direction]
+                        if t.x0 > cols[-1][1] or t.x1 < cols[0][0]
+                    ]
+                    inner_text.extend(outer_text)
+                    cols = self._add_columns(cols, inner_text, self.row_tol)
+                    cols = self._join_columns(cols, text_x_min, text_x_max)
         return cols, rows, None, None


### PR DESCRIPTION
`Stream._generate_columns_and_rows` can produce an empty `cols`: the list comprehension only keeps rows whose length equals the modal column count, and when no such row exists, the subsequent `_merge_columns([])` returns `[]`. The `outer_text` comprehension at the end then dereferences `cols[-1]` and `cols[0]`, raising `IndexError`.

Reported in #390 against the California housing-element PDFs (Lafayette / Concord / Orinda) with `flavor='stream'`. The crash happened deep inside `read_pdf` and was opaque from a caller perspective.

Guard the `outer_text` block (and the subsequent `_add_columns` / `_join_columns` calls) behind `if cols:`. When `cols` is empty, the function falls through with `cols=[]` and the calling `extract_tables` produces an empty result for that bbox — same behaviour as today's "no detection" path, just no exception.

Closes #390.