### PR TITLE
feat(utils): strip_text accepts list/tuple of whole substrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ changes. **Heads-up if upgrading from 1.0.x**:
   kwargs. Useful for multi-layout PDFs where some pages need different
   `table_areas` / `columns` / `flavor` than the rest. Concept originally
   proposed by @sverma25 in #41. (#41)
+- **`strip_text=` now accepts a list/tuple of substrings** alongside the
+  long-standing per-character `str` form. `strip_text=["[1]", "[2]"]`
+  strips those footnote markers as whole substrings;
+  `strip_text="[]"` keeps the existing per-character behaviour. (#484)
 - **`cpu_count` parameter** on `read_pdf(..., parallel=True, cpu_count=N)`
   and `PDFHandler.parse(...)` — caps the worker count when running in
   parallel. Defaults to all cores; clamped to

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -197,9 +197,14 @@ def read_pdf(
     flag_size : bool, optional (default: False)
         Flag text based on font size. Useful to detect
         super/subscripts. Adds <s></s> around flagged text.
-    strip_text : str, optional (default: '')
-        Characters that should be stripped from a string before
-        assigning it to a cell.
+    strip_text : str or sequence of str, optional (default: '')
+        Characters or substrings to strip from each cell before
+        assignment. A ``str`` strips per-character — every character in
+        the string is removed wherever it appears (e.g. ``" \\n"`` drops
+        all spaces and newlines). A list/tuple of ``str`` strips whole
+        substrings (e.g. ``["[1]", "[2]"]`` removes those footnote
+        markers but leaves bare ``[``/``]`` alone). Whole-substring
+        mode requested in #484.
     row_tol^ : int, optional (default: 2)
         Tolerance parameter used to combine text vertically,
         to generate rows.

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -125,7 +125,7 @@ def read_pdf(
     debug=False,
     **kwargs,
 ):
-    """Read PDF and return extracted tables.
+    r"""Read PDF and return extracted tables.
 
     Note: kwargs annotated with ^ can only be used with flavor='stream' or flavor='network'
     and kwargs annotated with * can only be used with flavor='lattice'.

--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -28,9 +28,10 @@ class Hybrid(BaseParser):
     flag_size : bool, optional (default: False)
         Flag text based on font size. Useful to detect
         super/subscripts. Adds <s></s> around flagged text.
-    strip_text : str, optional (default: '')
-        Characters that should be stripped from a string before
-        assigning it to a cell.
+    strip_text : str or sequence of str, optional (default: '')
+        Characters or substrings to strip from each cell. A ``str``
+        strips per-character; a list/tuple of ``str`` strips whole
+        substrings (#484).
     edge_tol : int, optional (default: 50)
         Tolerance parameter for extending textedges vertically.
     row_tol : int, optional (default: 2)

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -969,14 +969,20 @@ def merge_close_lines(ar, line_tol=2):
 
 
 def text_strip(text, strip=""):
-    """Strip any characters in `strip` that are present in `text`.
+    """Strip characters (or whole substrings) from `text`.
 
     Parameters
     ----------
     text : str
         Text to process and strip.
-    strip : str, optional (default: '')
-        Characters that should be stripped from `text`.
+    strip : str or sequence of str, optional (default: '')
+        If a ``str``: every occurrence of *any character* in `strip` is
+        removed from `text` (the long-standing behaviour).
+        If a list/tuple of ``str``: every occurrence of *each substring*
+        is removed from `text`. This is the request from #484 — the
+        whole-substring mode is opt-in by passing a sequence, so
+        existing callers passing a single string keep their per-character
+        semantics.
 
     Returns
     -------
@@ -985,6 +991,17 @@ def text_strip(text, strip=""):
     if not strip:
         return text
 
+    if isinstance(strip, (list, tuple)):
+        # Substring-strip mode: build an alternation of escaped pieces.
+        # Drop empties so users passing ["", "foo"] don't get "match the
+        # empty string everywhere" behaviour.
+        pieces = [s for s in strip if s]
+        if not pieces:
+            return text
+        pattern = "|".join(re.escape(s) for s in pieces)
+        return re.sub(pattern, "", text, flags=re.UNICODE)
+
+    # Backward-compatible character-class strip.
     stripped = re.sub(
         rf"[{''.join(map(re.escape, strip))}]", "", text, flags=re.UNICODE
     )

--- a/tests/test_text_strip.py
+++ b/tests/test_text_strip.py
@@ -1,0 +1,48 @@
+"""Unit tests for utils.text_strip — char + substring modes (#484)."""
+
+from camelot.utils import text_strip
+
+
+def test_text_strip_empty_returns_text_unchanged():
+    assert text_strip("hello", "") == "hello"
+
+
+def test_text_strip_str_is_per_character():
+    # "abc" means strip ANY of a, b, c — long-standing behaviour kept.
+    assert text_strip("cabbage and cake", "abc") == "ge nd ke"
+
+
+def test_text_strip_list_strips_whole_substrings():
+    # Substring mode: "[1]" goes, but bare "[" and "]" stay.
+    assert (
+        text_strip("Footnote [1] here and [2] there", ["[1]", "[2]"])
+        == "Footnote  here and  there"
+    )
+
+
+def test_text_strip_tuple_also_accepted():
+    assert text_strip("abXYcdXYef", ("XY",)) == "abcdef"
+
+
+def test_text_strip_list_with_overlapping_substrings():
+    # Alternation is left-greedy; "abc" matches before "ab" at the same
+    # position, but for non-overlapping inputs both strip cleanly.
+    assert text_strip("abc-ab-c", ["abc", "ab"]) == "--c"
+
+
+def test_text_strip_list_unicode():
+    assert text_strip("café crème — espresso", ["café", "crème"]) == " —  espresso"
+
+
+def test_text_strip_list_with_empty_entry_skipped():
+    # Empty strings would otherwise match everywhere; we drop them silently.
+    assert text_strip("hello world", ["", "world"]) == "hello "
+
+
+def test_text_strip_list_with_only_empties_is_noop():
+    assert text_strip("hello world", ["", ""]) == "hello world"
+
+
+def test_text_strip_list_regex_metacharacters_escaped():
+    # "." in the substring should match literal ".", not "any char".
+    assert text_strip("a.b.c xyz", [".b"]) == "a.c xyz"

--- a/tests/test_text_strip.py
+++ b/tests/test_text_strip.py
@@ -31,7 +31,10 @@ def test_text_strip_list_with_overlapping_substrings():
 
 
 def test_text_strip_list_unicode():
-    assert text_strip("café crème — espresso", ["café", "crème"]) == " —  espresso"
+    # Input has spaces around "café" and "crème"; stripping just the two
+    # words leaves those spaces in place: "[ ]café[ ]crème[ ]—[ ]espresso"
+    # becomes "[ ][ ]—[ ]espresso".
+    assert text_strip("café crème — espresso", ["café", "crème"]) == "  — espresso"
 
 
 def test_text_strip_list_with_empty_entry_skipped():


### PR DESCRIPTION
`text_strip(text, strip)` has always done a per-character strip: the `strip` argument is treated as a character class, so e.g. `strip_text='abc'` strips every occurrence of `a`, `b`, or `c`. The 2024 request in #484 wanted whole-substring stripping — strip `'Footnote [1]'` / `'Footnote [2]'` as whole sequences instead of shredding stray `[`, `]`, `1`, `2` characters from elsewhere in a cell.

Implemented as an opt-in mode keyed on type: pass a list or tuple of strings and `text_strip` builds an escaped alternation `(?:s1|s2|…)` and removes each whole substring. The single-string form keeps the long-standing per-character behaviour, so no existing caller changes meaning.

```python
# per-character (unchanged)
text_strip("cabbage", "abc") == "ge"

# whole-substring (new in 2.0)
text_strip("Footnote [1] here and [2] there", ["[1]", "[2]"]) \
    == "Footnote  here and  there"
```

Defensive details:

- Empty entries in the sequence are skipped (a literal empty pattern would otherwise match between every character).
- Each substring is `re.escape()`-d, so `.` / `(` / `\\` in user input is matched literally rather than as a regex metachar.
- A list/tuple containing only empty strings returns the text unchanged, matching the empty-str fast-path.

Updated the `read_pdf` and `Hybrid` docstrings to mention both forms. Added 9 unit tests covering: empty input, per-char default, substring mode (list and tuple), unicode, overlapping pieces, empty entries skipped, all-empty no-op, and regex-metachar escaping.

Requested by @gpkc in #484.

Closes #484.