### PR TITLE
fix(docs): drop explicit pydata-sphinx-theme pin breaking RTD builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,5 @@ ghostscript==0.8.1
 opencv-python-headless==4.13.0.92
 matplotlib==3.10.9
 accessible-pygments==0.0.5
-pydata-sphinx-theme==0.17.1
 sphinx-copybutton==0.5.2
 sphinx-prompt==1.10.2


### PR DESCRIPTION
ReadTheDocs has been failing since [942d26a](https://github.com/camelot-dev/camelot/commit/942d26a) — the dependabot bump that took `pydata-sphinx-theme` from `0.16.1` to `0.17.1`. Today's RTD log:

```
ERROR: Cannot install -r docs/requirements.txt (line 2) and
pydata-sphinx-theme==0.17.1 because these package versions have
conflicting dependencies.
The user requested pydata-sphinx-theme==0.17.1
sphinx-book-theme 1.2.0 depends on pydata-sphinx-theme==0.16.1
```

The latest `sphinx-book-theme` (1.2.0, no newer release exists on PyPI) hard-pins `pydata-sphinx-theme==0.16.1`, so the explicit `0.17.1` line in `docs/requirements.txt` makes the resolver unsatisfiable.

`pydata-sphinx-theme` is a transitive of `sphinx-book-theme`; we don't need to pin it ourselves and shouldn't. Drop the line. Verified with `pip install --dry-run -r docs/requirements.txt`: clean resolution, installs `pydata-sphinx-theme-0.16.1` transitively.

This also stops dependabot from re-proposing the same conflicting bump, since the entry isn't in the lock file any more.