### PR TITLE
fix(core): TextEdge.is_valid uses >= TEXTEDGE_REQUIRED_ELEMENTS

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -143,9 +143,14 @@ class TextEdge(TextAlignment):
         if math.isclose(self.y0, textline.y0, abs_tol=edge_tol):
             self.register_aligned_textline(textline, x)
             self.y0 = textline.y0
-            # a textedge is valid only if it extends uninterrupted
-            # over a required number of textlines
-            if len(self.textlines) > TEXTEDGE_REQUIRED_ELEMENTS:
+            # A textedge is valid once it extends uninterrupted over the
+            # required number of textlines. The docstring (TextEdge.is_valid:
+            # "intersects with at least TEXTEDGE_REQUIRED_ELEMENTS rows") and
+            # the constant comment both say "minimum 4" — but the comparison
+            # was strict-greater, so an edge with exactly 4 textlines was
+            # still considered invalid and the surrounding table dropped.
+            # Reported as #342, originally patched in #345.
+            if len(self.textlines) >= TEXTEDGE_REQUIRED_ELEMENTS:
                 self.is_valid = True
 
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -3440,7 +3440,22 @@ data_stream_columns = [
 ]
 
 data_stream_split_text = [
-    ["FEB", "RUAR", "Y 2014 M27 (BUS)", "", "", "", "", "", "", ""],
+    # Row 0: with the TEXTEDGE_REQUIRED_ELEMENTS off-by-one fixed (#342, #345)
+    # the stream parser now detects the same row-0 textedges the network
+    # parser already did — so the row-0 expected matches network's, with
+    # "ALPHABETIC LISTING BY T" / "YPE" / "ABLPDM27" no longer dropped.
+    [
+        "FEB",
+        "RUAR",
+        "Y 2014 M27 (BUS)",
+        "",
+        "ALPHABETIC LISTING BY T",
+        "YPE",
+        "",
+        "",
+        "",
+        "ABLPDM27",
+    ],
     ["", "", "", "", "OF ACTIVE LICENSES", "", "", "", "", "3/19/2014"],
     ["", "", "", "", "OKLAHOMA ABLE COMMIS", "SION", "", "", "", ""],
     ["LICENSE", "", "", "", "PREMISE", "", "", "", "", ""],
@@ -3775,21 +3790,12 @@ data_stream_split_text = [
 ]
 
 
-# The stream algorithm excludes the string "Alphabetic Listing by type"
-data_network_split_text = []
-data_network_split_text.extend(data_stream_split_text)
-data_network_split_text[0] = [
-    "FEB",
-    "RUAR",
-    "Y 2014 M27 (BUS)",
-    "",
-    "ALPHABETIC LISTING BY T",
-    "YPE",
-    "",
-    "",
-    "",
-    "ABLPDM27",
-]
+# Pre-#345, the stream parser dropped the "Alphabetic Listing by Type"
+# header because TextEdge.is_valid required *more than* (not at least)
+# TEXTEDGE_REQUIRED_ELEMENTS textlines — the strict-> off-by-one. With
+# #345 fixed, stream and network produce the same row 0, so this
+# explicit override is now a copy of data_stream_split_text[0].
+data_network_split_text = list(data_stream_split_text)
 
 data_stream_flag_size = [
     [


### PR DESCRIPTION
The `TextEdge.is_valid` docstring says an edge is valid when it "intersects with at least `TEXTEDGE_REQUIRED_ELEMENTS` horizontal text rows", and the constant's defining comment is "minimum number of vertical textline intersections for a textedge to be considered valid". Both say **at least** (i.e. `>=`). The code uses strict-greater, so a textedge with exactly `TEXTEDGE_REQUIRED_ELEMENTS` textlines is silently treated as invalid and any surrounding table containing it is dropped from the output.

Reported as #342; original 1-character fix proposed by @mcapinha in #345 against an earlier file layout (when the intersection count lived in a separate attribute). The off-by-one is still present at the current site — flip `>` to `>=` to match the documentation.

Closes #342.