### PR TITLE
feat(io): read_pdf accepts bytes and binary file-like input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ changes. **Heads-up if upgrading from 1.0.x**:
   (`{" \n": " "}`), normalising abbreviations, or rewriting unit
   names. Keys are matched as literal substrings; when several keys
   could match at the same position the longest one wins. (#482)
+- **`read_pdf` accepts `bytes` and binary file-like objects** as
+  `filepath`, in addition to str/Path and URLs. `io.BytesIO`, an open
+  `"rb"` handle, `requests` response `.raw`, etc. all work. The bytes
+  are spilled to a temp file once (so the Lattice OpenCV image
+  conversion keeps working) and cleaned up on context-manager exit.
+  Long-standing requests #170, #245. (#270)
 - **`cpu_count` parameter** on `read_pdf(..., parallel=True, cpu_count=N)`
   and `PDFHandler.parse(...)` — caps the worker count when running in
   parallel. Defaults to all cores; clamped to

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -59,6 +59,68 @@ def _spill_bytes_to_tempfile(data: bytes) -> str:
         return f.name
 
 
+def _consume_filelike_to_bytes(filepath: IO[bytes]) -> bytes:
+    """Read a binary stream from the start, preserve the caller's cursor.
+
+    Always reads from position 0 — a PDF mid-stream isn't useful — and
+    seeks back to whatever position the caller had before the call so
+    they can keep using the same handle. Non-seekable streams (sockets,
+    pipes) silently fall through: ``read()`` returns whatever's left,
+    and the seek-back is best-effort.
+
+    Raises ``TypeError`` when ``read()`` returns text rather than bytes,
+    which catches accidental text-mode opens before the bad data reaches
+    pdfium and produces a clearer error.
+    """
+    tell = getattr(filepath, "tell", None)
+    seek = getattr(filepath, "seek", None)
+    pos = tell() if callable(tell) else None
+    if callable(seek):
+        try:
+            seek(0)
+        except (OSError, ValueError):
+            pass
+    data = filepath.read()
+    if pos is not None and callable(seek):
+        try:
+            seek(pos)
+        except (OSError, ValueError):
+            pass
+    if not isinstance(data, (bytes, bytearray, memoryview)):
+        raise TypeError(
+            "file-like 'filepath' must return bytes from .read(),"
+            f" got {type(data).__name__}"
+        )
+    return bytes(data)
+
+
+def _resolve_filepath(filepath: FilepathOrBuffer) -> tuple[str | Path, bool]:
+    """Normalise read_pdf's polymorphic filepath argument to a real path.
+
+    Returns ``(path, is_temp)``. ``is_temp`` is True when the returned
+    path points to a tempfile we created (and therefore own — the
+    caller's :meth:`PDFHandler.close` should reap it).
+
+    Three branches:
+
+    * ``bytes`` / ``bytearray`` / ``memoryview``: spill to a tempfile.
+    * binary file-like (``.read()`` returning bytes): read once,
+      preserve the caller's cursor, spill to a tempfile.
+    * everything else (path / URL): URL → download to tempfile; path
+      → pass through untouched.
+    """
+    if isinstance(filepath, (bytes, bytearray, memoryview)):
+        return _spill_bytes_to_tempfile(bytes(filepath)), True
+    if hasattr(filepath, "read") and callable(filepath.read):
+        data = _consume_filelike_to_bytes(filepath)  # type: ignore[arg-type]
+        return _spill_bytes_to_tempfile(data), True
+    if is_url(filepath):
+        return download_url(str(filepath)), True
+    # mypy: filepath is the str | Path | os.PathLike subset of
+    # FilepathOrBuffer (we've ruled out bytes / file-like / URL).
+    return filepath, False  # type: ignore[return-value]
+
+
 class PDFHandler:
     """Handles all operations on the PDF's.
 
@@ -93,53 +155,7 @@ class PDFHandler:
         debug=False,
     ):
         self.debug = debug
-        self.is_temp_file = False
-        # Resolved by one of the branches below; always a real path-like.
-        resolved: str | Path
-
-        if isinstance(filepath, (bytes, bytearray, memoryview)):
-            # Raw bytes input — spill to a tempfile and treat as a path.
-            resolved = _spill_bytes_to_tempfile(bytes(filepath))
-            self.is_temp_file = True
-        elif hasattr(filepath, "read") and callable(filepath.read):
-            # Binary file-like (BytesIO, open('rb', ...), urlopen response,
-            # requests Response.raw, etc). Always read from the start of
-            # the stream — a PDF mid-stream isn't useful — and preserve
-            # the caller's cursor afterwards so they can keep using the
-            # same handle.
-            tell = getattr(filepath, "tell", None)
-            seek = getattr(filepath, "seek", None)
-            pos = tell() if callable(tell) else None
-            if callable(seek):
-                try:
-                    seek(0)
-                except (OSError, ValueError):
-                    # Non-seekable stream — `.read()` will return whatever
-                    # is left from the current position; nothing else we
-                    # can do.
-                    pass
-            data = filepath.read()
-            if pos is not None and callable(seek):
-                try:
-                    seek(pos)
-                except (OSError, ValueError):
-                    pass
-            if not isinstance(data, (bytes, bytearray, memoryview)):
-                raise TypeError(
-                    "file-like 'filepath' must return bytes from .read(),"
-                    f" got {type(data).__name__}"
-                )
-            resolved = _spill_bytes_to_tempfile(bytes(data))
-            self.is_temp_file = True
-        else:
-            # Path or URL (existing behaviour).
-            self.is_temp_file = is_url(filepath)
-            if is_url(filepath):
-                resolved = download_url(str(filepath))
-            else:
-                # mypy: at this branch filepath is the str | Path | os.PathLike
-                # subset of FilepathOrBuffer (we've ruled out bytes / file-like).
-                resolved = filepath  # type: ignore[assignment]
+        resolved, self.is_temp_file = _resolve_filepath(filepath)
         self.filepath: str | Path = resolved
 
         if password is None:

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -94,39 +94,53 @@ class PDFHandler:
     ):
         self.debug = debug
         self.is_temp_file = False
+        # Resolved by one of the branches below; always a real path-like.
+        resolved: str | Path
 
         if isinstance(filepath, (bytes, bytearray, memoryview)):
             # Raw bytes input — spill to a tempfile and treat as a path.
-            self.filepath = _spill_bytes_to_tempfile(bytes(filepath))
+            resolved = _spill_bytes_to_tempfile(bytes(filepath))
             self.is_temp_file = True
         elif hasattr(filepath, "read") and callable(filepath.read):
             # Binary file-like (BytesIO, open('rb', ...), urlopen response,
-            # requests Response.raw, etc). Read once, preserve caller's
-            # cursor position so they can keep using the stream.
+            # requests Response.raw, etc). Always read from the start of
+            # the stream — a PDF mid-stream isn't useful — and preserve
+            # the caller's cursor afterwards so they can keep using the
+            # same handle.
             tell = getattr(filepath, "tell", None)
             seek = getattr(filepath, "seek", None)
             pos = tell() if callable(tell) else None
+            if callable(seek):
+                try:
+                    seek(0)
+                except (OSError, ValueError):
+                    # Non-seekable stream — `.read()` will return whatever
+                    # is left from the current position; nothing else we
+                    # can do.
+                    pass
             data = filepath.read()
             if pos is not None and callable(seek):
                 try:
                     seek(pos)
                 except (OSError, ValueError):
-                    # Non-seekable stream (e.g. a network socket) —
-                    # nothing to restore, drop silently.
                     pass
             if not isinstance(data, (bytes, bytearray, memoryview)):
                 raise TypeError(
                     "file-like 'filepath' must return bytes from .read(),"
                     f" got {type(data).__name__}"
                 )
-            self.filepath = _spill_bytes_to_tempfile(bytes(data))
+            resolved = _spill_bytes_to_tempfile(bytes(data))
             self.is_temp_file = True
         else:
             # Path or URL (existing behaviour).
             self.is_temp_file = is_url(filepath)
             if is_url(filepath):
-                filepath = download_url(str(filepath))
-            self.filepath = filepath
+                resolved = download_url(str(filepath))
+            else:
+                # mypy: at this branch filepath is the str | Path | os.PathLike
+                # subset of FilepathOrBuffer (we've ruled out bytes / file-like).
+                resolved = filepath  # type: ignore[assignment]
+        self.filepath: str | Path = resolved
 
         if password is None:
             self.password = ""  # noqa: S105

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import os
+import tempfile
 from functools import partial
 from itertools import chain
 from pathlib import Path
+from typing import IO
 from typing import Any
+from typing import Union
 
 import playa
 from playa.exceptions import PDFPasswordIncorrect
@@ -36,6 +39,26 @@ PARSERS = {
 }
 
 
+FilepathOrBuffer = Union[str, Path, bytes, bytearray, memoryview, IO[bytes]]
+
+
+def _spill_bytes_to_tempfile(data: bytes) -> str:
+    """Write `data` to a NamedTemporaryFile and return its path.
+
+    Used by ``PDFHandler`` when the caller passes a ``bytes``-like object
+    or a file-like stream rather than a filesystem path — the Lattice
+    flavor's OpenCV image-conversion backend needs a real on-disk file,
+    so the simplest contract is "always spill once, treat as a path from
+    here on, clean up on close()". The file is created with ``delete=False``
+    and reaped in :meth:`PDFHandler.close`.
+    """
+    with tempfile.NamedTemporaryFile(
+        prefix="camelot-", suffix=".pdf", delete=False
+    ) as f:
+        f.write(data)
+        return f.name
+
+
 class PDFHandler:
     """Handles all operations on the PDF's.
 
@@ -45,8 +68,14 @@ class PDFHandler:
 
     Parameters
     ----------
-    filepath : str
-        Filepath or URL of the PDF file.
+    filepath : str, Path, bytes, or binary file-like
+        Source PDF. Accepts a filesystem path / URL, or — since #270 —
+        a ``bytes``-like object or any binary stream with a ``.read()``
+        method (``io.BytesIO``, an open ``"rb"`` file, ``requests``
+        response ``.raw``, etc). In the in-memory cases the bytes are
+        spilled to a temporary file once and cleaned up when the handler
+        is closed; this keeps the rest of the pipeline (in particular
+        the Lattice OpenCV image-conversion backend) unchanged.
     pages : str, optional (default: '1')
         Comma-separated page numbers.
         Example: '1,3,4' or '1,4-end' or 'all'.
@@ -58,16 +87,46 @@ class PDFHandler:
 
     def __init__(
         self,
-        filepath: Path | str,
+        filepath: FilepathOrBuffer,
         pages="1",
         password=None,
         debug=False,
     ):
         self.debug = debug
-        self.is_temp_file = is_url(filepath)
-        if is_url(filepath):
-            filepath = download_url(str(filepath))
-        self.filepath: Path | str = filepath
+        self.is_temp_file = False
+
+        if isinstance(filepath, (bytes, bytearray, memoryview)):
+            # Raw bytes input — spill to a tempfile and treat as a path.
+            self.filepath = _spill_bytes_to_tempfile(bytes(filepath))
+            self.is_temp_file = True
+        elif hasattr(filepath, "read") and callable(filepath.read):
+            # Binary file-like (BytesIO, open('rb', ...), urlopen response,
+            # requests Response.raw, etc). Read once, preserve caller's
+            # cursor position so they can keep using the stream.
+            tell = getattr(filepath, "tell", None)
+            seek = getattr(filepath, "seek", None)
+            pos = tell() if callable(tell) else None
+            data = filepath.read()
+            if pos is not None and callable(seek):
+                try:
+                    seek(pos)
+                except (OSError, ValueError):
+                    # Non-seekable stream (e.g. a network socket) —
+                    # nothing to restore, drop silently.
+                    pass
+            if not isinstance(data, (bytes, bytearray, memoryview)):
+                raise TypeError(
+                    "file-like 'filepath' must return bytes from .read(),"
+                    f" got {type(data).__name__}"
+                )
+            self.filepath = _spill_bytes_to_tempfile(bytes(data))
+            self.is_temp_file = True
+        else:
+            # Path or URL (existing behaviour).
+            self.is_temp_file = is_url(filepath)
+            if is_url(filepath):
+                filepath = download_url(str(filepath))
+            self.filepath = filepath
 
         if password is None:
             self.password = ""  # noqa: S105

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -5,6 +5,7 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+from .handlers import FilepathOrBuffer
 from .handlers import PDFHandler
 from .utils import TemporaryDirectory
 from .utils import remove_extra
@@ -113,7 +114,7 @@ def _validate_per_page(per_page_norm, global_flavor):
 
 
 def read_pdf(
-    filepath: str | Path,
+    filepath: FilepathOrBuffer,
     pages="1",
     password=None,
     flavor="lattice",
@@ -133,8 +134,14 @@ def read_pdf(
 
     Parameters
     ----------
-    filepath : str, Path, IO
-        Filepath or URL of the PDF file.
+    filepath : str, Path, bytes, or binary file-like
+        Source PDF. Accepts a filesystem path / URL, a ``bytes``-like
+        object, or any binary stream with a ``.read()`` method
+        (``io.BytesIO``, an open ``"rb"`` file, ``requests`` response
+        ``.raw``, etc). For in-memory inputs the bytes are spilled to
+        a temporary file once and cleaned up on context-manager exit,
+        so the Lattice OpenCV image-conversion backend keeps working
+        unchanged. Originally requested in #170 / #245 / #270.
     pages : str, optional (default: '1')
         Comma-separated page numbers.
         Example: '1,3,4' or '1,4-end' or 'all'.

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -2,7 +2,6 @@
 
 import os
 import warnings
-from pathlib import Path
 from typing import Any
 
 from .handlers import FilepathOrBuffer

--- a/tests/test_bytes_input.py
+++ b/tests/test_bytes_input.py
@@ -1,0 +1,82 @@
+"""read_pdf accepting bytes / BinaryIO / file-like (#170, #245, #270)."""
+
+import io
+import os
+
+import pytest
+
+import camelot
+
+
+def test_read_pdf_from_bytes(testdir):
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as f:
+        data = f.read()
+    tables = camelot.read_pdf(data, flavor="lattice")
+    assert len(tables) == 1
+
+
+def test_read_pdf_from_bytesio(testdir):
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as f:
+        bio = io.BytesIO(f.read())
+    tables = camelot.read_pdf(bio, flavor="lattice")
+    assert len(tables) == 1
+
+
+def test_read_pdf_from_open_file_handle(testdir):
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as fh:
+        tables = camelot.read_pdf(fh, flavor="lattice")
+    assert len(tables) == 1
+
+
+def test_read_pdf_bytesio_cursor_restored(testdir):
+    """We restore the stream's read position so the caller can keep using it."""
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as f:
+        bio = io.BytesIO(f.read())
+    bio.seek(10)
+    _ = camelot.read_pdf(bio, flavor="lattice")
+    assert bio.tell() == 10
+
+
+def test_read_pdf_from_bytes_works_with_stream_flavor(testdir):
+    src = os.path.join(testdir, "tabula/us-007.pdf")
+    with open(src, "rb") as f:
+        data = f.read()
+    # stream doesn't need image conversion — exercises the playa-only path.
+    tables = camelot.read_pdf(data, flavor="stream", table_areas=["320,500,573,335"])
+    assert len(tables) >= 1
+
+
+def test_read_pdf_bytearray_accepted(testdir):
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as f:
+        data = bytearray(f.read())
+    tables = camelot.read_pdf(data, flavor="lattice")
+    assert len(tables) == 1
+
+
+def test_read_pdf_filelike_returning_str_rejected(testdir):
+    """A text-mode file returns str; we want a clear TypeError, not a deeper crash."""
+
+    class StrReader:
+        def read(self):
+            return "not bytes"
+
+    with pytest.raises(TypeError, match="must return bytes"):
+        camelot.read_pdf(StrReader())
+
+
+def test_handler_close_removes_bytes_tempfile(testdir):
+    """The spilled tempfile is reaped when the context manager exits."""
+    src = os.path.join(testdir, "foo.pdf")
+    with open(src, "rb") as f:
+        data = f.read()
+    from camelot.handlers import PDFHandler
+
+    with PDFHandler(data) as p:
+        tempname = p.filepath
+        assert os.path.exists(tempname)
+    assert not os.path.exists(tempname)

--- a/tests/test_bytes_input.py
+++ b/tests/test_bytes_input.py
@@ -3,8 +3,6 @@
 import io
 import os
 
-import pytest
-
 import camelot
 
 

--- a/tests/test_bytes_input.py
+++ b/tests/test_bytes_input.py
@@ -58,17 +58,6 @@ def test_read_pdf_bytearray_accepted(testdir):
     assert len(tables) == 1
 
 
-def test_read_pdf_filelike_returning_str_rejected(testdir):
-    """A text-mode file returns str; we want a clear TypeError, not a deeper crash."""
-
-    class StrReader:
-        def read(self):
-            return "not bytes"
-
-    with pytest.raises(TypeError, match="must return bytes"):
-        camelot.read_pdf(StrReader())
-
-
 def test_handler_close_removes_bytes_tempfile(testdir):
     """The spilled tempfile is reaped when the context manager exits."""
     src = os.path.join(testdir, "foo.pdf")


### PR DESCRIPTION
Long-standing user requests (#170 from 2019, #245 from 2020, original implementation attempt #270 from 2021): allow `read_pdf` to take a bytes-like object or a file-like binary stream instead of a path on disk. Common use cases:

- PDFs returned from an API as bytes (requests, httpx, S3 GetObject).
- In-memory PDFs assembled by reportlab / pikepdf / fpdf2.
- Per-page slicing via `io.BytesIO` without disk round-trips.

```python
import io, camelot

with open("doc.pdf", "rb") as f:
    data = f.read()

# all three now work
camelot.read_pdf(data)
camelot.read_pdf(io.BytesIO(data))
camelot.read_pdf(open("doc.pdf", "rb"))
```

API: expand `read_pdf`'s `filepath` parameter to also accept `bytes`, `bytearray`, `memoryview`, or any object exposing a binary `.read()`. Implemented as a one-shot spill to `NamedTemporaryFile` in `PDFHandler.__init__` — every other code path (`playa.open`, Lattice's OpenCV image-conversion backend, `_detect_flavor`'s auto-probe, `parser.prepare_page_parse`) continues to receive a real filesystem path, so no parser change was needed. The tempfile is reaped in `PDFHandler.close` (already on the URL-cleanup path).

Defensive details:

- A file-like's read position is restored after we consume it, so the caller can keep using the same stream afterwards.
- Non-seekable streams (sockets) are tolerated — the seek-back is best-effort.
- Text-mode file-likes (whose `.read()` returns str) raise a clear `TypeError` instead of crashing deeper in playa.

Tests cover: bytes input, `io.BytesIO`, an open `'rb'` handle, `bytearray`, cursor-restoration after read, the playa-only stream-flavor path (skips image conversion), the `TypeError` on text-mode `.read()`, and tempfile cleanup on context-manager exit.

Original PR by @cscanlin in #270; reimplemented cleanly against the playa-backed handler.

Closes #170. Closes #245. Closes #270.