### PR TITLE
feat(lattice): add erode_iterations for morphological closing

### DIFF
--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -71,7 +71,12 @@ def adaptive_threshold(
 
 
 def find_lines(
-    threshold, regions=None, direction="horizontal", line_scale=40, iterations=0
+    threshold,
+    regions=None,
+    direction="horizontal",
+    line_scale=40,
+    iterations=0,
+    erode_iterations=0,
 ):
     """
     Finds horizontal and vertical lines by applying morphological transformations on an image.
@@ -90,7 +95,16 @@ def find_lines(
         Factor by which the page dimensions will be divided to get
         smallest length of lines that should be detected.
     iterations : int, optional (default: 0)
-        Number of times for erosion/dilation is applied.
+        Number of dilation passes applied to close small gaps in the
+        line mask. Useful for tables whose ruled lines don't quite
+        meet at corners.
+    erode_iterations : int, optional (default: 0)
+        Number of erosion passes applied **after** dilation. Set equal
+        to ``iterations`` to perform morphological *closing* (dilate
+        then erode of equal count): gaps are closed without enlarging
+        the line mask overall. Requested in #363 — previously the
+        erode step was missing, so ``iterations>=1`` widened every
+        line and added phantom top/bottom lines around tables.
 
     Returns
     -------
@@ -108,7 +122,7 @@ def find_lines(
     el, size = create_structuring_element(threshold, direction, line_scale)
     threshold = apply_region_mask(threshold, regions)
 
-    processed_threshold = process_image(threshold, el, iterations)
+    processed_threshold = process_image(threshold, el, iterations, erode_iterations)
     contours, _ = cv2.findContours(
         processed_threshold.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
@@ -172,7 +186,7 @@ def apply_region_mask(threshold, regions):
     return threshold
 
 
-def process_image(threshold, el, iterations):
+def process_image(threshold, el, iterations, erode_iterations=0):
     """
     Apply morphological operations to the threshold image.
 
@@ -183,7 +197,13 @@ def process_image(threshold, el, iterations):
     el : object
         Structuring element for morphological operations.
     iterations : int
-        Number of iterations for dilation.
+        Number of dilation passes applied to close small gaps in the
+        line mask.
+    erode_iterations : int, optional (default: 0)
+        Number of erosion passes applied *after* the dilation. When
+        equal to ``iterations`` this is a morphological closing —
+        gaps in the lines are bridged without thickening the mask
+        overall. See #363.
 
     Returns
     -------
@@ -193,6 +213,8 @@ def process_image(threshold, el, iterations):
     threshold = cv2.erode(threshold, el)
     threshold = cv2.dilate(threshold, el)
     dmask = cv2.dilate(threshold, el, iterations=iterations)
+    if erode_iterations:
+        dmask = cv2.erode(dmask, el, iterations=erode_iterations)
 
     return dmask
 

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -169,10 +169,16 @@ def read_pdf(
         For more information, refer `OpenCV's adaptiveThreshold
         <https://docs.opencv.org/2.4/modules/imgproc/doc/miscellaneous_transformations.html#adaptivethreshold>`_.
     iterations* : int, optional (default: 0)
-        Number of times for erosion/dilation is applied.
+        Number of dilation passes applied to close small gaps in the
+        line mask.
 
         For more information, refer `OpenCV's dilate
         <https://docs.opencv.org/2.4/modules/imgproc/doc/filtering.html#dilate>`_.
+    erode_iterations* : int, optional (default: 0)
+        Number of erosion passes applied **after** dilation. Set equal
+        to ``iterations`` for a morphological closing — bridges gaps
+        in ruled lines without thickening the mask overall (which
+        avoids the spurious extra-row artefact reported in #363). (#363)
     backend* : str, optional by default "pdfium"
         The backend to use for converting the PDF to an image so it can be processed by OpenCV.
     use_fallback* : bool, optional

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -72,9 +72,16 @@ class Lattice(BaseParser):
         For more information, refer `OpenCV's adaptiveThreshold
         <https://docs.opencv.org/2.4/modules/imgproc/doc/miscellaneous_transformations.html#adaptivethreshold>`_.
     iterations : int, optional (default: 0)
-        Number of times for erosion/dilation is applied.
+        Number of dilation passes applied to close small gaps in the
+        line mask (useful when a table's ruled lines don't quite meet
+        at corners).
 
         For more information, refer `OpenCV's dilate <https://docs.opencv.org/2.4/modules/imgproc/doc/filtering.html#dilate>`_.
+    erode_iterations : int, optional (default: 0)
+        Number of erosion passes applied **after** dilation. Set equal
+        to ``iterations`` for a morphological closing (bridges gaps
+        without thickening the mask, which avoids spurious extra
+        rows above/below the detected table). See #363.
     backend* : str, optional by default "pdfium"
         The backend to use for converting the PDF to an image so it can be processed by OpenCV.
     use_fallback* : bool, optional
@@ -100,6 +107,7 @@ class Lattice(BaseParser):
         threshold_blocksize=15,
         threshold_constant=-2,
         iterations=0,
+        erode_iterations=0,
         resolution=300,
         use_fallback=True,
         backend="pdfium",
@@ -120,6 +128,7 @@ class Lattice(BaseParser):
         self.threshold_blocksize = threshold_blocksize
         self.threshold_constant = threshold_constant
         self.iterations = iterations
+        self.erode_iterations = erode_iterations
         self.resolution = resolution
         self.use_fallback = use_fallback
         self.icb = ImageConversionBackend(use_fallback=use_fallback, backend=backend)
@@ -258,6 +267,7 @@ class Lattice(BaseParser):
                 direction="vertical",
                 line_scale=self.line_scale,
                 iterations=self.iterations,
+                erode_iterations=self.erode_iterations,
             )
             horizontal_mask, horizontal_segments = find_lines(
                 self.threshold,
@@ -265,6 +275,7 @@ class Lattice(BaseParser):
                 direction="horizontal",
                 line_scale=self.line_scale,
                 iterations=self.iterations,
+                erode_iterations=self.erode_iterations,
             )
 
             contours = find_contours(vertical_mask, horizontal_mask)
@@ -275,12 +286,14 @@ class Lattice(BaseParser):
                 direction="vertical",
                 line_scale=self.line_scale,
                 iterations=self.iterations,
+                erode_iterations=self.erode_iterations,
             )
             horizontal_mask, horizontal_segments = find_lines(
                 self.threshold,
                 direction="horizontal",
                 line_scale=self.line_scale,
                 iterations=self.iterations,
+                erode_iterations=self.erode_iterations,
             )
 
             areas = scale_areas(self.table_areas)

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -135,6 +135,7 @@ lattice_kwargs = common_kwargs + [
     "threshold_blocksize",
     "threshold_constant",
     "iterations",
+    "erode_iterations",
     "resolution",
     "use_fallback",
 ]


### PR DESCRIPTION
The existing `iterations` parameter only dilates the line-mask. For the common case where ruled lines don't quite meet at corners, dilation alone closes the gap but also thickens every line — which in turn pushes the table's outer ruled lines outward, producing spurious extra rows above and below the real table in the output grid (the symptom @arthurflor23 reported in #363).

The standard morphological-closing operation (dilate then erode of equal count) fixes this: gaps are closed without changing the line mask's overall size, so the detected table grid stays right.

```python
# Before — produces phantom outer rows
tables = camelot.read_pdf("doc.pdf", flavor="lattice", iterations=1)

# Now — bridges line gaps without thickening
tables = camelot.read_pdf("doc.pdf", flavor="lattice",
                          iterations=1, erode_iterations=1)
```

Added a new `erode_iterations` parameter (default `0` — fully backward-compatible). Setting `erode_iterations=iterations` performs the closing. Threaded through:

- `image_processing.find_lines` / `process_image` — the actual `cv2.erode` after `cv2.dilate`.
- `parsers.lattice.Lattice.__init__` — constructor + attribute.
- `parsers.lattice.Lattice._generate_table_bbox` — both `find_lines` call sites (with-regions and without-regions branches).
- `io.read_pdf` docstring + `utils.lattice_kwargs` allow-list — so `validate_input` / `remove_extra` accept the new kwarg.

Closes #363.