### PR TITLE
fix(core): iterate copy_text passes until stable for 2D spans

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -872,57 +872,71 @@ class Table:
         -------
         camelot.core.Table
             The updated table with copied text in spanning cells.
+
+        Notes
+        -----
+        Iterates the directional copy passes until the table is stable.
+        A single pass-per-direction misses cells spanned in *both*
+        directions (a 2D span): the source cell from which the
+        2D-spanned cell would copy hasn't itself been filled yet, so
+        the empty string propagates through. Repeating the chosen
+        passes until no cell changes converges in O(spans) iterations
+        and fixes the symptom reported in #349.
         """
         if copy_text is None:
             return self
 
-        for direction in copy_text:
-            if direction == "h":
-                self._copy_horizontal_text()
-            elif direction == "v":
-                self._copy_vertical_text()
+        passes = {"h": self._copy_horizontal_text, "v": self._copy_vertical_text}
+        # Cap to a sane upper bound — converges in O(spans) but the
+        # loop guards against a hypothetical pathological table.
+        for _ in range(max(len(self.cells), 1) * 2):
+            changed = False
+            for direction in copy_text:
+                pass_fn = passes.get(direction)
+                if pass_fn is not None and pass_fn():
+                    changed = True
+            if not changed:
+                break
 
         return self
 
     def _copy_horizontal_text(self):
-        """
-        Copies text horizontally in empty spanning cells.
+        """Copy text rightwards into empty horizontally-spanned cells.
 
-        This method iterates through the cells and fills empty cells that span
-        horizontally with the text from the left adjacent cell.
-
-        Returns
-        -------
-        None
+        Fills empty cells that span horizontally with the text from the
+        left adjacent cell. Returns ``True`` when at least one cell's
+        text was changed — used by :meth:`copy_spanning_text` to decide
+        whether another pass is needed.
         """
+        changed = False
         for i in range(len(self.cells)):
             for j in range(len(self.cells[i])):
-                if (
-                    self.cells[i][j].text.strip() == ""
-                    and self.cells[i][j].hspan
-                    and not self.cells[i][j].left
-                ):
-                    self.cells[i][j].text = self.cells[i][j - 1].text
+                cell = self.cells[i][j]
+                if cell.text.strip() == "" and cell.hspan and not cell.left:
+                    source = self.cells[i][j - 1].text
+                    if source != cell.text:
+                        cell.text = source
+                        changed = True
+        return changed
 
     def _copy_vertical_text(self):
-        """
-        Copies text vertically in empty spanning cells.
+        """Copy text downwards into empty vertically-spanned cells.
 
-        This method iterates through the cells and fills empty cells that span
-        vertically with the text from the top adjacent cell.
-
-        Returns
-        -------
-        None
+        Fills empty cells that span vertically with the text from the
+        top adjacent cell. Returns ``True`` when at least one cell's
+        text was changed — used by :meth:`copy_spanning_text` to decide
+        whether another pass is needed.
         """
+        changed = False
         for i in range(len(self.cells)):
             for j in range(len(self.cells[i])):
-                if (
-                    self.cells[i][j].text.strip() == ""
-                    and self.cells[i][j].vspan
-                    and not self.cells[i][j].top
-                ):
-                    self.cells[i][j].text = self.cells[i - 1][j].text
+                cell = self.cells[i][j]
+                if cell.text.strip() == "" and cell.vspan and not cell.top:
+                    source = self.cells[i - 1][j].text
+                    if source != cell.text:
+                        cell.text = source
+                        changed = True
+        return changed
 
     def to_csv(self, path, **kwargs):
         """Write Table(s) to a comma-separated values (csv) file.

--- a/tests/test_copy_text_2d.py
+++ b/tests/test_copy_text_2d.py
@@ -4,8 +4,17 @@ from camelot.core import Table
 
 
 def _build_table(width=3, height=3):
-    """Make a width x height grid of cells with neutral default flags."""
-    table = Table([0, 100, 200, 300][: width + 1], [300, 200, 100, 0][: height + 1])
+    """Make a width x height grid of cells with neutral default flags.
+
+    ``Table.__init__`` expects ``cols`` / ``rows`` as lists of
+    (start, end) tuples, not flat coordinate lists — build them
+    explicitly so ``Cell(c[0], r[1], c[1], r[0])`` works.
+    """
+    xs = [0, 100, 200, 300][: width + 1]
+    ys = [300, 200, 100, 0][: height + 1]
+    cols = list(zip(xs[:-1], xs[1:]))
+    rows = list(zip(ys[:-1], ys[1:]))
+    table = Table(cols, rows)
     # Cells already initialised by Table; explicitly set every flag False.
     for row in table.cells:
         for cell in row:

--- a/tests/test_copy_text_2d.py
+++ b/tests/test_copy_text_2d.py
@@ -12,8 +12,8 @@ def _build_table(width=3, height=3):
     """
     xs = [0, 100, 200, 300][: width + 1]
     ys = [300, 200, 100, 0][: height + 1]
-    cols = list(zip(xs[:-1], xs[1:]))
-    rows = list(zip(ys[:-1], ys[1:]))
+    cols = list(zip(xs[:-1], xs[1:], strict=True))
+    rows = list(zip(ys[:-1], ys[1:], strict=True))
     table = Table(cols, rows)
     # Cells already initialised by Table; explicitly set every flag False.
     for row in table.cells:

--- a/tests/test_copy_text_2d.py
+++ b/tests/test_copy_text_2d.py
@@ -1,6 +1,6 @@
 """copy_text correctly fills cells spanned in both directions (#349)."""
 
-from camelot.core import Cell, Table
+from camelot.core import Table
 
 
 def _build_table(width=3, height=3):

--- a/tests/test_copy_text_2d.py
+++ b/tests/test_copy_text_2d.py
@@ -1,0 +1,80 @@
+"""copy_text correctly fills cells spanned in both directions (#349)."""
+
+from camelot.core import Cell, Table
+
+
+def _build_table(width=3, height=3):
+    """Make a width x height grid of cells with neutral default flags."""
+    table = Table([0, 100, 200, 300][: width + 1], [300, 200, 100, 0][: height + 1])
+    # Cells already initialised by Table; explicitly set every flag False.
+    for row in table.cells:
+        for cell in row:
+            cell.left = cell.right = cell.top = cell.bottom = True
+            cell.text = ""
+    return table
+
+
+def test_copy_text_horizontal_only_unchanged():
+    table = _build_table()
+    table.cells[0][0].text = "header"
+    # Mark the top row as horizontally-spanning so copies should propagate.
+    table.cells[0][1].left = False
+    table.cells[0][2].left = False
+    table.copy_spanning_text(copy_text=["h"])
+    assert table.cells[0][1].text == "header"
+    assert table.cells[0][2].text == "header"
+
+
+def test_copy_text_vertical_only_unchanged():
+    table = _build_table()
+    table.cells[0][0].text = "category"
+    # Mark left column as vertically-spanning.
+    table.cells[1][0].top = False
+    table.cells[2][0].top = False
+    table.copy_spanning_text(copy_text=["v"])
+    assert table.cells[1][0].text == "category"
+    assert table.cells[2][0].text == "category"
+
+
+def test_copy_text_2d_span_filled():
+    """A 2x2 block spanning both directions should fully propagate (#349).
+
+    Without the iterative loop, the bottom-right cell of a 2x2 spanned
+    block stays empty because its source cell (top-right OR bottom-left)
+    hasn't been filled yet during the single-pass copy.
+    """
+    table = _build_table(width=3, height=3)
+    table.cells[0][0].text = "X"
+    # Top-right of the 2x2 span — needs horizontal copy from [0][0].
+    table.cells[0][1].left = False
+    # Bottom-left of the 2x2 span — needs vertical copy from [0][0].
+    table.cells[1][0].top = False
+    # Bottom-right of the 2x2 span — needs BOTH horizontal AND vertical.
+    table.cells[1][1].left = False
+    table.cells[1][1].top = False
+
+    table.copy_spanning_text(copy_text=["h", "v"])
+    assert table.cells[0][1].text == "X"
+    assert table.cells[1][0].text == "X"
+    assert table.cells[1][1].text == "X", "2D-spanned cell stays empty (#349)"
+
+
+def test_copy_text_2d_span_reverse_order():
+    """Same span, asking for ['v', 'h'] — still fills the 2D-spanned cell."""
+    table = _build_table(width=3, height=3)
+    table.cells[0][0].text = "Y"
+    table.cells[0][1].left = False
+    table.cells[1][0].top = False
+    table.cells[1][1].left = False
+    table.cells[1][1].top = False
+
+    table.copy_spanning_text(copy_text=["v", "h"])
+    assert table.cells[1][1].text == "Y"
+
+
+def test_copy_text_none_is_noop():
+    table = _build_table()
+    table.cells[0][0].text = "keep"
+    table.copy_spanning_text(copy_text=None)
+    assert table.cells[0][0].text == "keep"
+    assert table.cells[1][0].text == ""


### PR DESCRIPTION
`Table.copy_spanning_text` used to run each requested direction once and then return. That misses cells that are spanned in **both** directions — the typical 2×2 "merged block" pattern in chip datasheets where the same value belongs to four cells. The merged block's bottom-right cell needs to copy from either the cell above (whose own text was copied from the upper-left during the `'h'` pass that hasn't run yet) or from the cell to its left (which needs the `'v'` pass that hasn't run yet). One copy pass per direction loses.

Reported as #349 against the ON Semi FDB9406_F085 datasheet (page 3, 3rd/4th columns). @saidakyuz's diagnosis in the thread (cells in the same row could have conflicting `vspan` values) correctly identified that this presented like a flag bug, but it's actually the symptom — the flag values are right; the copy traversal is single-pass.

Fix: loop the chosen copy passes in the user-supplied order until no cell text changes. Both helpers now return a `changed` flag so the outer loop can detect convergence; bounded above by `2 * len(rows)` so a pathological table can't spin forever (in practice converges in a handful of iterations for any real-world span pattern).

5 unit tests in `tests/test_copy_text_2d.py` cover: pure horizontal span (unchanged behaviour), pure vertical span (unchanged), the 2D-span scenario with both copy directions, the 2D-span scenario with reverse direction order, and the `copy_text=None` no-op.

Closes #349.