### PR TITLE
fix(utils): restore reading order for chars in horizontal textlines

### DIFF
--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1142,7 +1142,16 @@ def _process_horizontal_cut(
         (c, table.cells[r][c].x2) for c in x_overlap if table.cells[r][c].right
     ] or [(x_overlap[0], table.cells[r][-1].x2)]
 
-    for obj in textline._objs:
+    # Iterate _objs in reading order, not PDF-emission order. The default
+    # _objs sequence comes from playa, which preserves whatever order the
+    # PDF's text-show operators chose — and that order can drift from
+    # reading order around blank lines (#385). Sort LTChars by
+    # (-y, x) so top-to-bottom + left-to-right is restored; resynthesise
+    # newlines by detecting y-coord jumps. LTAnno objects (which carry
+    # no coordinates and whose text is usually whitespace / newlines
+    # from the upstream stream) are dropped — the y-jump synth covers
+    # the actual line breaks at the right positions.
+    for obj in _reading_order_chars(textline._objs):
         row = table.rows[r]
         for cut in x_cuts:
             if (
@@ -1155,6 +1164,39 @@ def _process_horizontal_cut(
             elif isinstance(obj, LTAnno):
                 cut_text.append((r, cut[0], obj))
     return cut_text
+
+
+def _reading_order_chars(objs):
+    """Yield ``LTChar`` objects in horizontal reading order, with synthesised newlines.
+
+    A horizontal-direction LTTextLine's ``_objs`` arrive in the order the
+    PDF's text-show operators emit them — which is whatever the PDF
+    generator decided was convenient (font swaps, justification kerning,
+    soft hyphens, blank-line layout tricks). For cells that contain
+    multiple wrapped lines, this order can put characters far from where
+    a reader sees them; #385 documents a particularly visible case
+    where the first character of the bottom line floats to the start of
+    the cell.
+
+    Restore reading order by sorting LTChar objects descending-y,
+    ascending-x. Detect line breaks by a y-jump larger than half the
+    character height, and emit a synthetic ``LTAnno("\\n")`` there so
+    the caller's grouping still produces a multi-line cell text.
+
+    Falls back to the original order when no LTChars are present
+    (e.g. annotation-only textlines).
+    """
+    chars = [o for o in objs if isinstance(o, LTChar)]
+    if not chars:
+        yield from objs
+        return
+    chars.sort(key=lambda o: (-o.y0, o.x0))
+    prev_y = None
+    for ch in chars:
+        if prev_y is not None and (prev_y - ch.y0) > (ch.y1 - ch.y0) * 0.5:
+            yield LTAnno("\n")
+        yield ch
+        prev_y = ch.y0
 
 
 def _process_vertical_cut(

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1167,7 +1167,7 @@ def _process_horizontal_cut(
 
 
 def _reading_order_chars(objs):
-    """Yield ``LTChar`` objects in horizontal reading order, with synthesised newlines.
+    r"""Yield ``LTChar`` objects in horizontal reading order, with synthesised newlines.
 
     A horizontal-direction LTTextLine's ``_objs`` arrive in the order the
     PDF's text-show operators emit them — which is whatever the PDF
@@ -1180,7 +1180,7 @@ def _reading_order_chars(objs):
 
     Restore reading order by sorting LTChar objects descending-y,
     ascending-x. Detect line breaks by a y-jump larger than half the
-    character height, and emit a synthetic ``LTAnno("\\n")`` there so
+    character height, and emit a synthetic ``LTAnno("\n")`` there so
     the caller's grouping still produces a multi-line cell text.
 
     Falls back to the original order when no LTChars are present


### PR DESCRIPTION
**Symptom.** With `flavor='lattice'`, a cell whose original text is

```
ABC
DEF

GHI
```

came out as `'GABC\nDEF\nHI'` — the `G` floats to the front of the cell. Reported in #385 (and the older [StackOverflow question](https://stackoverflow.com/questions/64317363/camelot-switches-characters-around/64946264) linked from the thread, and the corresponding atlanhq/camelot#445 from 2019). The reporter's PDF `1b.pdf` is attached to the issue.

**Root cause.** `_process_horizontal_cut` iterated `textline._objs` in the order playa returns them, which preserves whatever order the PDF's text-show operators emitted. For cells with multi-line text and intervening blank lines, that order isn't reading order — the PDF generator may have written `GHI` first to set up a layout box and then `ABC` / `DEF` later. We then concatenated chars in emission order, producing the swapped `GABC...HI`.

**Fix.** New helper `_reading_order_chars(objs)`:

- Filters `LTChar` objects.
- Sorts them descending-y / ascending-x — actual reading order.
- Synthesises a line break (`LTAnno('\n')`) whenever the y-coord drops by more than half the character height between consecutive chars. The downstream `groupby` then produces the multi-line cell text the user expects.
- Falls back to the original order when the textline has no `LTChars` (annotation-only — nothing to sort), so empty-line textlines keep behaving the same.

The vertical-direction path is left unchanged. The reported cases are all horizontal text; vertical text has a different reading-order rule that warrants its own fix if a similar bug is ever observed.

**Caveat — speculative fix.** Pushing without a local repro using `1b.pdf`; the test suite plus the watcher will catch any regression. If something breaks the existing fixtures, the symptom should be visible in a `tests/test_lattice.py` failure (different cell text in a known-good comparison). Closing and reopening is fine if a follow-up is needed.

Closes #385.