### PR TITLE
fix(image): remove arbitrary 10-table contour cap

### DIFF
--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -3,7 +3,6 @@
 import cv2
 import numpy as np
 
-
 #: Minimum contour area, expressed as a fraction of the page image area,
 #: for a contour to be considered a candidate table. The previous code
 #: capped the contour list at the 10 largest regardless of size, which

--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -4,6 +4,16 @@ import cv2
 import numpy as np
 
 
+#: Minimum contour area, expressed as a fraction of the page image area,
+#: for a contour to be considered a candidate table. The previous code
+#: capped the contour list at the 10 largest regardless of size, which
+#: silently dropped any tables past the first 10 on a page (#319). A
+#: relative-area threshold scales correctly across page sizes and keeps
+#: typed-character noise (a single glyph is well under 0.05% of A4) out
+#: of the candidate list.
+_MIN_TABLE_AREA_FRACTION = 0.0005
+
+
 def undo_rotation(pdf_image, rotation):
     """Undo rotation of an image extracted from a PDF.
 
@@ -271,8 +281,14 @@ def find_contours(vertical, horizontal):
     contours, __ = cv2.findContours(
         mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
     )
-    # sort in reverse based on contour area and use first 10 contours
-    contours = sorted(contours, key=cv2.contourArea, reverse=True)[:10]
+    # Sort largest-first so callers iterating in detected order pick up the
+    # primary table first; filter out anything smaller than the configured
+    # fraction of the page area. Replaces the previous arbitrary 10-contour
+    # cap that silently dropped tables past index 9 (#319).
+    page_area = float(mask.shape[0] * mask.shape[1]) or 1.0
+    min_area = page_area * _MIN_TABLE_AREA_FRACTION
+    contours = sorted(contours, key=cv2.contourArea, reverse=True)
+    contours = [c for c in contours if cv2.contourArea(c) >= min_area]
 
     cont = []
     for c in contours:


### PR DESCRIPTION
`find_contours` used to slice the sorted contour list to the first 10 entries — silently dropping every table past index 9 on a page. The constant was undocumented and not configurable. Reported by @ottohirr in #319 against a financial-report PDF that had >10 small tables per page.

Replace the count cap with a relative-area threshold (`0.05%` of the page image area):

- keeps the previous noise-filtering intent — a single glyph or stray line segment is well under the threshold on any normal page;
- scales to arbitrary numbers of tables per page;
- scales correctly across page sizes (A4 vs A0 vs Letter etc.) because the threshold is a fraction of the rendered page area, not an absolute pixel count.

Closes #319.