### PR TITLE
feat(core): add TableList.stack_contiguous for multi-page tables

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1070,7 +1070,7 @@ class Table:
         conn.close()
 
 
-def _vstack_run(run: list["Table"], drop_repeated_header: bool = False) -> "Table":
+def _vstack_run(run: list[Table], drop_repeated_header: bool = False) -> Table:
     """Vertically concatenate a run of contiguous Tables (#628 POC).
 
     All tables in ``run`` must share the same column count — the caller
@@ -1217,7 +1217,7 @@ class TableList:
         self,
         match: str = "column_count",
         keep_first_header: bool = False,
-    ) -> "TableList":
+    ) -> TableList:
         """Vertically stack tables that look like continuations across pages.
 
         Many PDF reports break a single logical table over several pages

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import math
 import os
 import sqlite3
@@ -1069,6 +1070,88 @@ class Table:
         conn.close()
 
 
+def _vstack_run(run: list["Table"], drop_repeated_header: bool = False) -> "Table":
+    """Vertically concatenate a run of contiguous Tables (#628 POC).
+
+    All tables in ``run`` must share the same column count — the caller
+    (:meth:`TableList.stack_contiguous`) is responsible for that
+    invariant. A single-element run is returned via a deep copy so the
+    output never aliases the input.
+
+    Geometry:
+        * The first table's ``rows`` / ``cells`` / ``_bbox`` stay in
+          place. Each subsequent table's y-coordinates are shifted so
+          its top sits at the previous table's bottom — the stacked
+          result reads as one tall page even though source pages
+          differ.
+
+    ``parsing_report`` is mean-aggregated across the run (accuracy,
+    whitespace, confidence are averaged); ``page`` and ``order`` are
+    taken from the first table.
+    """
+    if len(run) == 1:
+        return copy.deepcopy(run[0])
+
+    out = copy.deepcopy(run[0])
+    out_dfs = [out.df]
+
+    for nxt in run[1:]:
+        nxt_copy = copy.deepcopy(nxt)
+        # Shift the upcoming table's geometry so its top sits at the
+        # current bottom of `out`. PDF coords: y0 = bottom, y1 = top
+        # within each table (rows are stored as (top_y, bottom_y) tuples
+        # within Table.rows; bbox is (x0, y0, x1, y1)).
+        out_bottom = out._bbox[1]
+        nxt_top = nxt_copy._bbox[3]
+        dy = out_bottom - nxt_top
+        nxt_copy.rows = [(r0 + dy, r1 + dy) for (r0, r1) in nxt_copy.rows]
+        for row in nxt_copy.cells:
+            for cell in row:
+                cell.y1 += dy
+                cell.y2 += dy
+                # lb/lt/rb/rt are snapshot tuples set in Cell.__init__;
+                # rebuild them so plotting and any other downstream
+                # geometry consumer sees the shifted coords.
+                cell.lb = (cell.x1, cell.y1)
+                cell.lt = (cell.x1, cell.y2)
+                cell.rb = (cell.x2, cell.y1)
+                cell.rt = (cell.x2, cell.y2)
+        nxt_copy._bbox = (
+            nxt_copy._bbox[0],
+            nxt_copy._bbox[1] + dy,
+            nxt_copy._bbox[2],
+            nxt_copy._bbox[3] + dy,
+        )
+
+        out.rows = out.rows + nxt_copy.rows
+        out.cells = out.cells + nxt_copy.cells
+        out._bbox = (
+            min(out._bbox[0], nxt_copy._bbox[0]),
+            nxt_copy._bbox[1],  # new bottom
+            max(out._bbox[2], nxt_copy._bbox[2]),
+            out._bbox[3],  # original top
+        )
+
+        nxt_df = nxt_copy.df
+        if drop_repeated_header and not nxt_df.empty:
+            nxt_df = nxt_df.iloc[1:].reset_index(drop=True)
+        out_dfs.append(nxt_df)
+
+    out.df = pd.concat(out_dfs, ignore_index=True)
+
+    # Average per-table quality metrics across the run.
+    accs = [t.accuracy for t in run if getattr(t, "accuracy", None) is not None]
+    wss = [t.whitespace for t in run if getattr(t, "whitespace", None) is not None]
+    if accs:
+        out.accuracy = sum(accs) / len(accs)
+    if wss:
+        out.whitespace = sum(wss) / len(wss)
+    if accs and wss:
+        out.confidence = (out.accuracy / 100.0) * (1 - out.whitespace / 100.0)
+
+    return out
+
+
 class _Kw(TypedDict):
     """Helper class to define file related arguments."""
 
@@ -1122,6 +1205,113 @@ class TableList:
     def n(self) -> int:
         """The number of tables in the list."""
         return len(self)
+
+    def stack_contiguous(
+        self,
+        match: str = "column_count",
+        keep_first_header: bool = False,
+    ) -> "TableList":
+        """Vertically stack tables that look like continuations across pages.
+
+        Many PDF reports break a single logical table over several pages
+        — a header on every page, a footer on every page, body rows in
+        between. ``read_pdf`` returns one :class:`Table` per page; this
+        helper stitches contiguous ones back together so the resulting
+        :class:`TableList` has one entry per *logical* table instead of
+        one per *physical* page.
+
+        Parameters
+        ----------
+        match : str, optional (default: 'column_count')
+            How to decide whether two adjacent tables are continuations
+            of each other.
+
+            * ``'column_count'`` — same number of columns (the rule from
+              #628's POC; the common case).
+            * ``'first_row'`` — same column count *and* identical text
+              in the first row (catches PDFs that repeat the header on
+              every page).
+        keep_first_header : bool, optional (default: False)
+            When ``match='first_row'``, the matching first row of every
+            continuation table is dropped (so the stacked table has
+            exactly one header row). Set to ``True`` to keep every
+            page's header row in the stacked output.
+
+        Returns
+        -------
+        camelot.core.TableList
+            A new TableList with continuation runs collapsed. Tables
+            that don't continue from the previous one (different
+            column count or different first row, depending on ``match``)
+            are passed through unchanged. The originals in ``self`` are
+            not mutated.
+
+        Notes
+        -----
+        Originally proposed by @TimothyOfDelphi in #628. Consolidates
+        #8 / #133 / #357 / #531.
+
+        Limitations:
+
+        * The stacked :class:`Table`'s ``page`` keeps the *first*
+          stitched table's page number; ``order`` keeps the first
+          table's order. Callers iterating with both shouldn't be
+          surprised by a missing row-of-pages.
+        * ``parsing_report`` is averaged: ``accuracy`` and
+          ``whitespace`` are mean-aggregated across the stitched
+          tables; ``confidence`` is recomputed from the averaged
+          accuracy + whitespace.
+        * Cell geometry (``_bbox``, ``cells``, ``rows``) is preserved
+          via the y-shift trick from #628's POC, so downstream
+          plotting on a single stitched table still works
+          page-locally. Cells from the second-and-later tables are
+          shifted to sit below the first table's bottom.
+        """
+        if match not in ("column_count", "first_row"):
+            raise ValueError(
+                f"match must be 'column_count' or 'first_row', got {match!r}"
+            )
+        if not self._tables:
+            return TableList([])
+
+        stitched: list[Table] = []
+        run: list[Table] = []
+
+        for table in self._tables:
+            if not run:
+                run.append(table)
+                continue
+            head = run[-1]
+            same_cols = len(head.cols) == len(table.cols)
+            same_header = same_cols and (
+                match != "first_row"
+                or (
+                    list(head.df.iloc[0]) == list(table.df.iloc[0])
+                    if not head.df.empty and not table.df.empty
+                    else False
+                )
+            )
+            if same_cols and (match == "column_count" or same_header):
+                run.append(table)
+            else:
+                stitched.append(
+                    _vstack_run(
+                        run,
+                        drop_repeated_header=(match == "first_row")
+                        and not keep_first_header,
+                    )
+                )
+                run = [table]
+        if run:
+            stitched.append(
+                _vstack_run(
+                    run,
+                    drop_repeated_header=(match == "first_row")
+                    and not keep_first_header,
+                )
+            )
+
+        return TableList(stitched)
 
     def _write_file(self, f=None, **kwargs: Unpack[_Kw]) -> None:
         dirname = kwargs["dirname"]

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1139,15 +1139,15 @@ def _vstack_run(run: list["Table"], drop_repeated_header: bool = False) -> "Tabl
 
     out.df = pd.concat(out_dfs, ignore_index=True)
 
-    # Average per-table quality metrics across the run.
+    # Average per-table quality metrics across the run. `confidence` is a
+    # read-only @property derived from accuracy + whitespace (#659/#739),
+    # so it doesn't need explicit assignment — recomputes on next access.
     accs = [t.accuracy for t in run if getattr(t, "accuracy", None) is not None]
     wss = [t.whitespace for t in run if getattr(t, "whitespace", None) is not None]
     if accs:
         out.accuracy = sum(accs) / len(accs)
     if wss:
         out.whitespace = sum(wss) / len(wss)
-    if accs and wss:
-        out.confidence = (out.accuracy / 100.0) * (1 - out.whitespace / 100.0)
 
     return out
 

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1101,36 +1101,43 @@ def _vstack_run(run: list["Table"], drop_repeated_header: bool = False) -> "Tabl
         # current bottom of `out`. PDF coords: y0 = bottom, y1 = top
         # within each table (rows are stored as (top_y, bottom_y) tuples
         # within Table.rows; bbox is (x0, y0, x1, y1)).
-        out_bottom = out._bbox[1]
-        nxt_top = nxt_copy._bbox[3]
-        dy = out_bottom - nxt_top
-        nxt_copy.rows = [(r0 + dy, r1 + dy) for (r0, r1) in nxt_copy.rows]
-        for row in nxt_copy.cells:
-            for cell in row:
-                cell.y1 += dy
-                cell.y2 += dy
-                # lb/lt/rb/rt are snapshot tuples set in Cell.__init__;
-                # rebuild them so plotting and any other downstream
-                # geometry consumer sees the shifted coords.
-                cell.lb = (cell.x1, cell.y1)
-                cell.lt = (cell.x1, cell.y2)
-                cell.rb = (cell.x2, cell.y1)
-                cell.rt = (cell.x2, cell.y2)
-        nxt_copy._bbox = (
-            nxt_copy._bbox[0],
-            nxt_copy._bbox[1] + dy,
-            nxt_copy._bbox[2],
-            nxt_copy._bbox[3] + dy,
-        )
-
-        out.rows = out.rows + nxt_copy.rows
-        out.cells = out.cells + nxt_copy.cells
-        out._bbox = (
-            min(out._bbox[0], nxt_copy._bbox[0]),
-            nxt_copy._bbox[1],  # new bottom
-            max(out._bbox[2], nxt_copy._bbox[2]),
-            out._bbox[3],  # original top
-        )
+        #
+        # Geometry shifting needs both tables to carry a _bbox. Parser-
+        # built Tables always do; if either is missing one (a Table
+        # constructed without going through a parser), skip the geometry
+        # merge and just concatenate the DataFrames — the df is what
+        # callers of stack_contiguous overwhelmingly want, and a missing
+        # bbox means there's no meaningful page geometry to stitch.
+        if out._bbox is not None and nxt_copy._bbox is not None:
+            out_bottom = out._bbox[1]
+            nxt_top = nxt_copy._bbox[3]
+            dy = out_bottom - nxt_top
+            nxt_copy.rows = [(r0 + dy, r1 + dy) for (r0, r1) in nxt_copy.rows]
+            for row in nxt_copy.cells:
+                for cell in row:
+                    cell.y1 += dy
+                    cell.y2 += dy
+                    # lb/lt/rb/rt are snapshot tuples set in Cell.__init__;
+                    # rebuild them so plotting and any other downstream
+                    # geometry consumer sees the shifted coords.
+                    cell.lb = (cell.x1, cell.y1)
+                    cell.lt = (cell.x1, cell.y2)
+                    cell.rb = (cell.x2, cell.y1)
+                    cell.rt = (cell.x2, cell.y2)
+            nxt_copy._bbox = (
+                nxt_copy._bbox[0],
+                nxt_copy._bbox[1] + dy,
+                nxt_copy._bbox[2],
+                nxt_copy._bbox[3] + dy,
+            )
+            out.rows = out.rows + nxt_copy.rows
+            out.cells = out.cells + nxt_copy.cells
+            out._bbox = (
+                min(out._bbox[0], nxt_copy._bbox[0]),
+                nxt_copy._bbox[1],  # new bottom
+                max(out._bbox[2], nxt_copy._bbox[2]),
+                out._bbox[3],  # original top
+            )
 
         nxt_df = nxt_copy.df
         if drop_repeated_header and not nxt_df.empty:

--- a/tests/test_stack_contiguous.py
+++ b/tests/test_stack_contiguous.py
@@ -7,7 +7,8 @@ tables that look like continuations across page breaks.
 import pandas as pd
 import pytest
 
-from camelot.core import Table, TableList
+from camelot.core import Table
+from camelot.core import TableList
 
 
 def _make_table(df, page=1, order=1, cols_x=(0, 100, 200), rows_y=(300, 200, 100)):
@@ -16,8 +17,8 @@ def _make_table(df, page=1, order=1, cols_x=(0, 100, 200), rows_y=(300, 200, 100
     The exact y-coords of rows/cells don't matter for stacking semantics;
     we just need them to round-trip through the shift logic.
     """
-    cols = list(zip(cols_x[:-1], cols_x[1:]))
-    rows = list(zip(rows_y[:-1], rows_y[1:]))
+    cols = list(zip(cols_x[:-1], cols_x[1:], strict=False))
+    rows = list(zip(rows_y[:-1], rows_y[1:], strict=False))
     t = Table(cols=cols, rows=rows)
     t.df = df.reset_index(drop=True)
     t.page = page

--- a/tests/test_stack_contiguous.py
+++ b/tests/test_stack_contiguous.py
@@ -24,7 +24,8 @@ def _make_table(df, page=1, order=1, cols_x=(0, 100, 200), rows_y=(300, 200, 100
     t.order = order
     t.accuracy = 95.0
     t.whitespace = 5.0
-    t.confidence = (t.accuracy / 100.0) * (1 - t.whitespace / 100.0)
+    # `confidence` is a read-only @property on Table; it recomputes
+    # from accuracy + whitespace on access.
     return t
 
 

--- a/tests/test_stack_contiguous.py
+++ b/tests/test_stack_contiguous.py
@@ -1,0 +1,158 @@
+"""TableList.stack_contiguous: vertically stack tables across pages (#628).
+
+Consolidates #8 / #133 / #357 / #531 / #628 — vertically concatenate
+tables that look like continuations across page breaks.
+"""
+
+import pandas as pd
+import pytest
+
+from camelot.core import Table, TableList
+
+
+def _make_table(df, page=1, order=1, cols_x=(0, 100, 200), rows_y=(300, 200, 100)):
+    """Build a minimal Table whose .df and column count match.
+
+    The exact y-coords of rows/cells don't matter for stacking semantics;
+    we just need them to round-trip through the shift logic.
+    """
+    cols = list(zip(cols_x[:-1], cols_x[1:]))
+    rows = list(zip(rows_y[:-1], rows_y[1:]))
+    t = Table(cols=cols, rows=rows)
+    t.df = df.reset_index(drop=True)
+    t.page = page
+    t.order = order
+    t.accuracy = 95.0
+    t.whitespace = 5.0
+    t.confidence = (t.accuracy / 100.0) * (1 - t.whitespace / 100.0)
+    return t
+
+
+def test_empty_tablelist_stack_returns_empty():
+    out = TableList([]).stack_contiguous()
+    assert len(out) == 0
+
+
+def test_single_table_stack_is_passthrough_copy():
+    df = pd.DataFrame([["a", "b"], ["c", "d"]])
+    t = _make_table(df)
+    stacked = TableList([t]).stack_contiguous()
+    assert len(stacked) == 1
+    # Deep-copy: mutating the result doesn't touch the source.
+    stacked[0].df.iloc[0, 0] = "X"
+    assert t.df.iloc[0, 0] == "a"
+
+
+def test_two_tables_same_columns_get_stacked():
+    df1 = pd.DataFrame([["1", "Alice"], ["2", "Bob"]])
+    df2 = pd.DataFrame([["3", "Charlie"], ["4", "Diana"]])
+    stacked = TableList(
+        [_make_table(df1, page=1), _make_table(df2, page=2)]
+    ).stack_contiguous()
+    assert len(stacked) == 1
+    result = stacked[0].df
+    assert result.shape == (4, 2)
+    assert list(result.iloc[:, 1]) == ["Alice", "Bob", "Charlie", "Diana"]
+
+
+def test_two_tables_different_columns_not_stacked():
+    df1 = pd.DataFrame([["a", "b"]])
+    df2 = pd.DataFrame([["c", "d", "e"]])  # different ncols
+    stacked = TableList(
+        [_make_table(df1), _make_table(df2, cols_x=(0, 100, 200, 300))]
+    ).stack_contiguous()
+    assert len(stacked) == 2
+
+
+def test_three_tables_partial_stacking():
+    # cols=2, cols=2, cols=3 → stack first two, third stays separate.
+    df1 = pd.DataFrame([["1", "Alice"]])
+    df2 = pd.DataFrame([["2", "Bob"]])
+    df3 = pd.DataFrame([["a", "b", "c"]])
+    stacked = TableList(
+        [
+            _make_table(df1),
+            _make_table(df2),
+            _make_table(df3, cols_x=(0, 100, 200, 300)),
+        ]
+    ).stack_contiguous()
+    assert len(stacked) == 2
+    assert stacked[0].df.shape == (2, 2)
+    assert stacked[1].df.shape == (1, 3)
+
+
+def test_match_first_row_keeps_only_first_header():
+    header = ["ID", "Name"]
+    df1 = pd.DataFrame([header, ["1", "Alice"], ["2", "Bob"]])
+    df2 = pd.DataFrame([header, ["3", "Charlie"]])
+    stacked = TableList([_make_table(df1), _make_table(df2)]).stack_contiguous(
+        match="first_row"
+    )
+    assert len(stacked) == 1
+    # Continuation table's header row should have been dropped, leaving one header.
+    result = stacked[0].df
+    assert list(result.iloc[0]) == header
+    assert result.shape == (4, 2)
+    # No second 'ID'/'Name' header lurking in the body.
+    assert "ID" not in result.iloc[1:].values.flatten().tolist()
+
+
+def test_match_first_row_keep_repeated_header_when_requested():
+    header = ["ID", "Name"]
+    df1 = pd.DataFrame([header, ["1", "Alice"]])
+    df2 = pd.DataFrame([header, ["2", "Bob"]])
+    stacked = TableList([_make_table(df1), _make_table(df2)]).stack_contiguous(
+        match="first_row", keep_first_header=True
+    )
+    assert stacked[0].df.shape == (4, 2)
+
+
+def test_match_first_row_distinct_headers_not_stacked():
+    df1 = pd.DataFrame([["ID", "Name"], ["1", "Alice"]])
+    df2 = pd.DataFrame([["NUM", "WHO"], ["2", "Bob"]])  # different header text
+    stacked = TableList([_make_table(df1), _make_table(df2)]).stack_contiguous(
+        match="first_row"
+    )
+    assert len(stacked) == 2  # Different headers → not continuations.
+
+
+def test_stack_invalid_match_raises():
+    with pytest.raises(ValueError, match="must be 'column_count' or 'first_row'"):
+        TableList([]).stack_contiguous(match="bogus")
+
+
+def test_stack_preserves_first_tables_page_and_order():
+    df1 = pd.DataFrame([["1", "Alice"]])
+    df2 = pd.DataFrame([["2", "Bob"]])
+    stacked = TableList(
+        [
+            _make_table(df1, page=3, order=2),
+            _make_table(df2, page=4, order=1),
+        ]
+    ).stack_contiguous()
+    assert stacked[0].page == 3
+    assert stacked[0].order == 2
+
+
+def test_stack_averages_quality_metrics():
+    df = pd.DataFrame([["x"]])
+    t1 = _make_table(df, cols_x=(0, 100))
+    t2 = _make_table(df, cols_x=(0, 100))
+    t1.accuracy, t1.whitespace = 80.0, 10.0
+    t2.accuracy, t2.whitespace = 100.0, 0.0
+    stacked = TableList([t1, t2]).stack_contiguous()
+    assert stacked[0].accuracy == pytest.approx(90.0)
+    assert stacked[0].whitespace == pytest.approx(5.0)
+    # confidence = (acc/100) * (1 - ws/100) = 0.9 * 0.95 = 0.855
+    assert stacked[0].confidence == pytest.approx(0.855)
+
+
+def test_stack_does_not_mutate_input_tables():
+    df1 = pd.DataFrame([["1", "Alice"]])
+    df2 = pd.DataFrame([["2", "Bob"]])
+    t1 = _make_table(df1)
+    t2 = _make_table(df2)
+    original_t2_rows = list(t2.rows)
+    _ = TableList([t1, t2]).stack_contiguous()
+    assert t2.rows == original_t2_rows  # input unchanged
+    assert t1.df.shape == (1, 2)

--- a/tests/test_stack_contiguous.py
+++ b/tests/test_stack_contiguous.py
@@ -25,6 +25,10 @@ def _make_table(df, page=1, order=1, cols_x=(0, 100, 200), rows_y=(300, 200, 100
     t.order = order
     t.accuracy = 95.0
     t.whitespace = 5.0
+    # Real parser-built Tables carry a _bbox; synthetic ones default to
+    # None, which the geometry-shift in _vstack_run would index into.
+    # Set it from the cols/rows extent so the stacking math runs.
+    t._bbox = (min(cols_x), min(rows_y), max(cols_x), max(rows_y))
     # `confidence` is a read-only @property on Table; it recomputes
     # from accuracy + whitespace on access.
     return t


### PR DESCRIPTION
Long-standing user request (#8 from 2019, restated in #133 / #357 / #531, and most concretely in #628 by @TimothyOfDelphi who included a working POC): vertically concatenate tables that span multiple pages of a PDF.

Implements TimothyOfDelphi's POC as `TableList.stack_contiguous()`, landing the helper at the right abstraction layer — a post-extraction TableList transform, not a `read_pdf=` kwarg, not a playa push-down (the 2020 triage by @vinayak-mehta concluded "no general algorithm exists" and they're right; an explicit caller-driven helper avoids the "silent mangling" failure mode).

\`\`\`python
tables = camelot.read_pdf("long_report.pdf", pages="all")
one_per_logical = tables.stack_contiguous()
\`\`\`

Two matching rules:

- `match='column_count'` (default): adjacent tables with the same number of columns are stitched. The common case — same-shape rows continuing across the page break.
- `match='first_row'`: also requires the continuation table's first row to be identical to the in-progress table's first row, catching PDFs that repeat their header on every page. The repeated header is dropped from the stacked output unless `keep_first_header=True`.

Implementation details:

- New `_vstack_run` helper concatenates the run's DataFrames with `pd.concat(ignore_index=True)`, and shifts each successor's `rows` / `cells` / `_bbox` y-coords so the stacked Table has a single contiguous PDF-coordinate geometry. `plotting.py` uses `Cell.lb/lt/rb/rt` tuples, so those are rebuilt to match the shifted y-coords.
- `parsing_report` is averaged across the run (accuracy, whitespace, confidence). `page`/`order` keep the first table's values.
- Always operates on deep copies — input TableList is never mutated.

12 unit tests in `tests/test_stack_contiguous.py` cover: empty input, single-table passthrough, two-table stacking, mixed (some-stack/some-don't), three-way partial stacking, `match='first_row'` with/without repeated-header drop, distinct headers no-stack, invalid-match error, page/order preservation, accuracy averaging, and input-non-mutation.

POC + design by @TimothyOfDelphi in #628.

Closes #628. Tracked-by-link in #8 / #133 / #357 / #531.