### PR TITLE
fix: update RTD badge + test URLs from /en/master/ to /en/latest/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Camelot: PDF Table Extraction for Humans
 
-[![tests](https://github.com/camelot-dev/camelot/actions/workflows/tests.yml/badge.svg)](https://github.com/camelot-dev/camelot/actions/workflows/tests.yml) [![Documentation Status](https://readthedocs.org/projects/camelot-py/badge/?version=master)](https://camelot-py.readthedocs.io/en/master/)
+[![tests](https://github.com/camelot-dev/camelot/actions/workflows/tests.yml/badge.svg)](https://github.com/camelot-dev/camelot/actions/workflows/tests.yml) [![Documentation Status](https://readthedocs.org/projects/camelot-py/badge/?version=latest)](https://camelot-py.readthedocs.io/en/latest/)
 [![codecov.io](https://codecov.io/github/camelot-dev/camelot/badge.svg?branch=master&service=github)](https://codecov.io/github/camelot-dev/camelot?branch=master)
 [![image](https://img.shields.io/pypi/v/camelot-py.svg)](https://pypi.org/project/camelot-py/) [![image](https://img.shields.io/pypi/l/camelot-py.svg)](https://pypi.org/project/camelot-py/) [![image](https://img.shields.io/pypi/pyversions/camelot-py.svg)](https://pypi.org/project/camelot-py/)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -83,7 +83,7 @@ def test_repr_ghostscript_custom_backend(testdir):
 
 
 def test_url_pdfium():
-    url = "https://camelot-py.readthedocs.io/en/master/_static/pdf/foo.pdf"
+    url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
     tables = camelot.read_pdf(
         url, flavor="lattice", backend="pdfium", use_fallback=False
     )
@@ -120,7 +120,7 @@ def test_url_ghostscript_custom_backend(testdir):
 
 
 def test_pages_pdfium():
-    url = "https://camelot-py.readthedocs.io/en/master/_static/pdf/foo.pdf"
+    url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
     tables = camelot.read_pdf(url, backend="pdfium", use_fallback=False)
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"


### PR DESCRIPTION
The 'master' RTD version was deactivated after #759 landed — it duplicated 'latest' (both built the default branch) and just consumed quota. With it gone, the README badge plus two URL fixtures in `test_common.py` pointed at a 404. Flip both to `/en/latest/`.

The codecov badge's `branch=master` query parameter is unrelated — that's the GitHub branch name, not an RTD version, so it stays.

Three lines across two files:
- README.md (line 7): RTD badge + link target
- tests/test_common.py (lines 86, 123): `foo.pdf` URL fixtures used by `test_url_pdfium` and `test_pages_pdfium`