### PR TITLE
docs: polish comparison page (sortable + icons + theme fixes)

### DIFF
--- a/docs/_static/camelot-theme.css
+++ b/docs/_static/camelot-theme.css
@@ -1,42 +1,40 @@
 /*
  * Camelot brand theme overlay on top of sphinx-book-theme.
  *
- * The base theme (pydata-sphinx-theme under the hood) exposes a small
- * set of CSS custom properties for colour control; we rewire them to
+ * sphinx-book-theme inherits from pydata-sphinx-theme. Both expose CSS
+ * custom properties for accent colours; this file rewires them to
  * match the Camelot logo's saturated green.
  *
- * Logo green sampled from docs/_static/camelot.png: #0F9D47.
- * Darker shade for hover/active: #0B7A38.
- * Light tint for backgrounds: #E6F4EB.
+ * Logo green (sampled from docs/_static/camelot.png): #0F9D47
+ * Darker for hover/active:                            #0B7A38
+ * Light tint for hovered backgrounds:                 #E6F4EB
  */
 
 :root,
 html[data-theme="light"] {
+  /* pydata-sphinx-theme custom properties */
   --pst-color-primary: #0f9d47;
   --pst-color-primary-text: #ffffff;
   --pst-color-primary-highlight: #0b7a38;
+  --pst-color-primary-bg: #e6f4eb;
   --pst-color-secondary: #0b7a38;
+  --pst-color-secondary-text: #ffffff;
   --pst-color-secondary-highlight: #0f9d47;
   --pst-color-link: #0b7a38;
   --pst-color-link-hover: #0f9d47;
   --pst-color-accent: #0f9d47;
-}
-
-/* sphinx-book-theme has its own variable namespace too; mirror them so
- * the sidebar / TOC / next-prev navigation pick up the new accent. */
-:root,
-html[data-theme="light"] {
+  /* sphinx-book-theme aliases */
   --sbt-color-link: var(--pst-color-link);
   --sbt-color-link-hover: var(--pst-color-link-hover);
 }
 
-/* Dark mode — keep the green but with a slightly lighter shade so it
- * carries enough contrast against the dark background. */
 html[data-theme="dark"] {
   --pst-color-primary: #2cc36b;
   --pst-color-primary-text: #0a1f12;
   --pst-color-primary-highlight: #5bd98f;
+  --pst-color-primary-bg: #0e2418;
   --pst-color-secondary: #5bd98f;
+  --pst-color-secondary-text: #0a1f12;
   --pst-color-secondary-highlight: #2cc36b;
   --pst-color-link: #5bd98f;
   --pst-color-link-hover: #8be6ad;
@@ -45,49 +43,55 @@ html[data-theme="dark"] {
   --sbt-color-link-hover: var(--pst-color-link-hover);
 }
 
-/* Brand the page header underline + section anchors. */
-.bd-header.navbar-light .navbar-nav .nav-link:hover,
-.bd-header.navbar-light .navbar-nav .nav-link.active {
-  color: var(--pst-color-primary-highlight);
+/* Force in-text links to use the green even where the theme falls back
+ * to a per-element default. Some pages (how-it-works, quickstart, cli)
+ * were rendering pre-2.0 blue because pydata-sphinx-theme has
+ * hard-coded link colours in places the variable doesn't reach.
+ * High-specificity selector covers article body, sidebars, and TOC. */
+.bd-content a:not(.btn):not(.headerlink):not(.tag):not(.sd-btn),
+.bd-sidebar-primary a:not(.btn),
+.bd-toc-link,
+.bd-toc-item a,
+.toc-tree a,
+article a:not(.btn):not(.headerlink) {
+  color: var(--pst-color-link);
 }
 
-/* The "On this page" right sidebar uses a coloured accent bar — paint
- * it Camelot green rather than the default blue. */
-.bd-toc-item.active > .bd-toc-link,
-.toc-h2.active > .toc-entry > a {
+.bd-content a:not(.btn):not(.headerlink):not(.tag):not(.sd-btn):hover,
+.bd-sidebar-primary a:not(.btn):hover,
+.bd-toc-link:hover,
+.bd-toc-item a:hover,
+.toc-tree a:hover,
+article a:not(.btn):not(.headerlink):hover {
+  color: var(--pst-color-link-hover);
+}
+
+/* Left sidebar — active page indicator + TOC tree current-section. */
+.bd-sidebar-primary .nav-link.active,
+.bd-sidebar-primary .current > a,
+.bd-sidebar-primary li.toctree-l1.current > a,
+.bd-sidebar-primary li.toctree-l2.current > a,
+.bd-sidebar-primary li.toctree-l3.current > a {
   color: var(--pst-color-primary);
   border-left-color: var(--pst-color-primary);
 }
 
-/* admonitions: keep the default semantics (info/note blue, warning
- * orange, danger red) — overriding the *primary* colour would
- * gratuitously repaint them. The "note" block uses the link colour by
- * default though, so it picks up the green automatically. */
-
-/* Inline code: a faint green-tinted background reads as Camelot-y
- * without sacrificing legibility of the syntax-highlighted code in
- * fenced blocks (those keep their default monokai-style palette). */
-:not(pre) > code.literal,
-:not(pre) > code.docutils {
-  background-color: rgba(15, 157, 71, 0.08);
-  border-color: rgba(15, 157, 71, 0.2);
+/* Top navbar (when sphinx-book-theme renders one). */
+.bd-header .navbar-nav .nav-link:hover,
+.bd-header .navbar-nav .nav-link.active {
+  color: var(--pst-color-primary-highlight);
 }
 
-/* The "Edit this page" / "View source" buttons in sphinx-book-theme's
- * header use the primary colour, which is now green — make sure their
- * hover state is the darker shade for accessibility contrast. */
-.btn-primary,
-.btn-primary:focus {
-  background-color: var(--pst-color-primary);
-  border-color: var(--pst-color-primary);
-}
-.btn-primary:hover {
-  background-color: var(--pst-color-primary-highlight);
-  border-color: var(--pst-color-primary-highlight);
+/* Right "On this page" sidebar — active TOC entry highlight. */
+.bd-toc-item.active > .bd-toc-link,
+.bd-toc-item.active > a,
+.toc-h2.active > .toc-entry > a,
+.toc-entry a.active {
+  color: var(--pst-color-primary);
+  border-left-color: var(--pst-color-primary);
 }
 
-/* Section anchors that appear on heading hover — green so they read as
- * a brand element rather than as a stray default. */
+/* Heading anchors that appear on hover. */
 h1 .headerlink,
 h2 .headerlink,
 h3 .headerlink,
@@ -97,11 +101,113 @@ h6 .headerlink {
   color: var(--pst-color-primary);
 }
 
-/* The :class: full-width helper used by the comparison-page matrix
- * (and the v2 features doc). Keeps the table from being scrunched
- * inside the default content column. */
+/* Inline code — faint green-tinted background reads as Camelot-y
+ * without sacrificing legibility of syntax-highlighted code in fenced
+ * blocks (those keep their default palette). */
+:not(pre) > code.literal,
+:not(pre) > code.docutils {
+  background-color: rgba(15, 157, 71, 0.08);
+  border-color: rgba(15, 157, 71, 0.2);
+}
+
+html[data-theme="dark"] :not(pre) > code.literal,
+html[data-theme="dark"] :not(pre) > code.docutils {
+  background-color: rgba(44, 195, 107, 0.15);
+  border-color: rgba(44, 195, 107, 0.3);
+}
+
+/* Primary buttons (e.g. "Edit this page"). */
+.btn-primary,
+.btn-primary:focus,
+.sd-btn-primary {
+  background-color: var(--pst-color-primary) !important;
+  border-color: var(--pst-color-primary) !important;
+}
+.btn-primary:hover,
+.sd-btn-primary:hover {
+  background-color: var(--pst-color-primary-highlight) !important;
+  border-color: var(--pst-color-primary-highlight) !important;
+}
+
+/* Wide tables — `:class: full-width` is used throughout advanced.rst
+ * for csv-tables that overflow the default content column. Same rule
+ * applies to list-tables in the comparison page. */
 table.full-width,
 .full-width table {
   width: 100% !important;
   max-width: none !important;
+}
+
+/* ==========================================================================
+ * Comparison-matrix specific (docs/user/comparison.rst)
+ * Visual yes/no markers + alternating row shading + sortable affordance.
+ * ========================================================================== */
+
+table.comparison-matrix th,
+table.comparison-matrix td {
+  vertical-align: middle;
+  text-align: center;
+  font-size: 0.92em;
+}
+
+table.comparison-matrix th:first-child,
+table.comparison-matrix td:first-child {
+  text-align: left;
+  font-weight: 500;
+}
+
+/* Camelot column emphasis */
+table.comparison-matrix th:nth-child(2),
+table.comparison-matrix td:nth-child(2) {
+  background-color: rgba(15, 157, 71, 0.06);
+  font-weight: 500;
+}
+
+/* Yes / No / partial visual tokens */
+table.comparison-matrix .cm-yes {
+  color: #0f9d47;
+  font-weight: 600;
+}
+table.comparison-matrix .cm-no {
+  color: #b85c5c;
+}
+table.comparison-matrix .cm-partial {
+  color: #c98a23;
+}
+
+/* Sortable affordance — header arrow hint */
+table.comparison-matrix.sortable thead th {
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  padding-right: 18px;
+}
+table.comparison-matrix.sortable thead th::after {
+  content: "\25BE"; /* ▾ */
+  position: absolute;
+  right: 6px;
+  opacity: 0.35;
+  transition: opacity 0.15s;
+}
+table.comparison-matrix.sortable thead th:hover::after {
+  opacity: 0.85;
+}
+table.comparison-matrix.sortable thead th[aria-sort="ascending"]::after {
+  content: "\25B2"; /* ▲ */
+  opacity: 1;
+  color: var(--pst-color-primary);
+}
+table.comparison-matrix.sortable thead th[aria-sort="descending"]::after {
+  content: "\25BC"; /* ▼ */
+  opacity: 1;
+  color: var(--pst-color-primary);
+}
+
+/* Alternating row shading for readability — pydata-sphinx-theme has
+ * its own striping but it's too subtle on the matrix; bump contrast. */
+table.comparison-matrix tbody tr:nth-child(even) {
+  background-color: rgba(15, 157, 71, 0.03);
+}
+html[data-theme="dark"] table.comparison-matrix tbody tr:nth-child(even) {
+  background-color: rgba(44, 195, 107, 0.06);
 }

--- a/docs/_static/sortable-table.js
+++ b/docs/_static/sortable-table.js
@@ -1,0 +1,96 @@
+/* Tiny dependency-free sortable-table helper.
+ *
+ * Attaches click-to-sort to any <table class="sortable">. First click on
+ * a header sorts ascending, second click descending, third resets.
+ * Numeric, date, and string cells are detected automatically.
+ *
+ * Adapted from the public-domain pattern at https://adrianroselli.com/
+ * — kept minimal (~80 lines, no deps) so it ships alongside the docs
+ * without an npm install.
+ */
+(function () {
+  "use strict";
+
+  function parseCell(text) {
+    // Strip surrounding whitespace.
+    text = (text || "").trim();
+    if (!text) return { kind: "empty", value: "" };
+    // ISO date.
+    const isoDate = /^\d{4}-\d{2}-\d{2}$/.test(text);
+    if (isoDate) return { kind: "date", value: text };
+    // Number (allow %, comma separators, leading minus).
+    const num = text.replace(/[\s,%]/g, "");
+    if (/^-?\d+(\.\d+)?$/.test(num)) {
+      return { kind: "number", value: parseFloat(num) };
+    }
+    return { kind: "string", value: text.toLowerCase() };
+  }
+
+  function compareCells(a, b) {
+    // Empty cells sort to the bottom regardless of direction.
+    if (a.kind === "empty" && b.kind === "empty") return 0;
+    if (a.kind === "empty") return 1;
+    if (b.kind === "empty") return -1;
+    if (a.kind === "number" && b.kind === "number") return a.value - b.value;
+    if (a.kind === "date" && b.kind === "date") {
+      return a.value < b.value ? -1 : a.value > b.value ? 1 : 0;
+    }
+    // Mixed or string: lexicographic.
+    return a.value < b.value ? -1 : a.value > b.value ? 1 : 0;
+  }
+
+  function makeSortable(table) {
+    const headers = table.querySelectorAll("thead th");
+    if (!headers.length) return;
+    const tbody = table.querySelector("tbody");
+    if (!tbody) return;
+
+    // Cache the original row order so a third click can restore it.
+    const originalRows = Array.from(tbody.rows);
+
+    headers.forEach(function (th, colIdx) {
+      th.addEventListener("click", function () {
+        const current = th.getAttribute("aria-sort");
+        let next;
+        if (!current || current === "none") next = "ascending";
+        else if (current === "ascending") next = "descending";
+        else next = "none";
+
+        // Clear all headers, set the active one.
+        headers.forEach(function (other) {
+          other.setAttribute("aria-sort", "none");
+        });
+        th.setAttribute("aria-sort", next);
+
+        if (next === "none") {
+          // Restore original.
+          originalRows.forEach(function (r) {
+            tbody.appendChild(r);
+          });
+          return;
+        }
+
+        const rows = Array.from(tbody.rows);
+        rows.sort(function (a, b) {
+          const av = parseCell(a.cells[colIdx]?.textContent);
+          const bv = parseCell(b.cells[colIdx]?.textContent);
+          const cmp = compareCells(av, bv);
+          return next === "ascending" ? cmp : -cmp;
+        });
+        rows.forEach(function (r) {
+          tbody.appendChild(r);
+        });
+      });
+    });
+  }
+
+  function init() {
+    document.querySelectorAll("table.sortable").forEach(makeSortable);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,6 +180,11 @@ html_static_path = ["_static"]
 # Camelot logo green (sampled from docs/_static/camelot.png).
 html_css_files = ["camelot-theme.css"]
 
+# Tiny dependency-free helper that wires click-to-sort onto any
+# <table class="sortable">. Currently used by the comparison-matrix
+# on docs/user/comparison.rst.
+html_js_files = ["sortable-table.js"]
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,9 +83,7 @@ Why Camelot?
 
 .. _ETL and data analysis workflows: https://gist.github.com/vinayak-mehta/e5949f7c2410a0e12f25d3682dc9e873
 
-See `comparison with similar libraries and tools`_.
-
-.. _comparison with similar libraries and tools: https://github.com/camelot-dev/camelot/wiki/Comparison-with-other-PDF-Table-Extraction-libraries-and-tools
+See :ref:`comparison with similar libraries and tools <comparison>`.
 
 
 The User Guide

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -343,7 +343,7 @@ In this case, the text that `other tools`_ return, will be ``24.912``. This is r
 
 You can solve this by passing ``flag_size=True``, which will enclose the superscripts and subscripts with ``<s></s>``, based on font size, as shown below.
 
-.. _other tools: https://github.com/camelot-dev/camelot/wiki/Comparison-with-other-PDF-Table-Extraction-libraries-and-tools
+.. _other tools: comparison.html
 
 .. code-block:: pycon
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -226,11 +226,12 @@ In cases such as `these <../_static/pdf/table_areas.pdf>`__, it can be useful to
 
 Table areas that you want camelot to analyze can be passed as a list of comma-separated strings to :meth:`read_pdf() <camelot.read_pdf>`, using the ``table_areas`` keyword argument.
 
-.. code-block:: pycon
-  :class: full-width
+.. container:: full-width
 
-    >>> tables = camelot.read_pdf('table_areas.pdf', flavor='stream', table_areas=['316,499,566,337'])
-    >>> tables[0].df
+   .. code-block:: pycon
+
+       >>> tables = camelot.read_pdf('table_areas.pdf', flavor='stream', table_areas=['316,499,566,337'])
+       >>> tables[0].df
 
 .. tip::
     Here's how you can do the same with the :ref:`command-line interface <cli>`.
@@ -281,11 +282,12 @@ For example, if you have specified two table areas, ``table_areas=['12,54,43,23'
 
 Let's get back to the *x* coordinates we got from plotting the text that exists on this `PDF <../_static/pdf/column_separators.pdf>`__, and get the table out!
 
-.. code-block:: pycon
-  :class: full-width
+.. container:: full-width
 
-    >>> tables = camelot.read_pdf('column_separators.pdf', flavor='stream', columns=['72,95,209,327,442,529,566,606,683'])
-    >>> tables[0].df
+   .. code-block:: pycon
+
+       >>> tables = camelot.read_pdf('column_separators.pdf', flavor='stream', columns=['72,95,209,327,442,529,566,606,683'])
+       >>> tables[0].df
 
 .. tip::
     Here's how you can do the same with the :ref:`command-line interface <cli>`.
@@ -309,11 +311,12 @@ Split text along separators
 
 To deal with cases like the output from the previous section, you can pass ``split_text=True`` to :meth:`read_pdf() <camelot.read_pdf>`, which will split any strings that lie in different cells but have been assigned to a single cell (as a result of being merged together by `playa <https://pypi.org/project/playa-pdf/>`_, the PDFMiner-compatible layout engine).
 
-.. code-block:: pycon
-  :class: full-width
+.. container:: full-width
 
-    >>> tables = camelot.read_pdf('column_separators.pdf', flavor='stream', columns=['72,95,209,327,442,529,566,606,683'], split_text=True)
-    >>> tables[0].df
+   .. code-block:: pycon
+
+       >>> tables = camelot.read_pdf('column_separators.pdf', flavor='stream', columns=['72,95,209,327,442,529,566,606,683'], split_text=True)
+       >>> tables[0].df
 
 .. tip::
     Here's how you can do the same with the :ref:`command-line interface <cli>`.

--- a/docs/user/comparison.rst
+++ b/docs/user/comparison.rst
@@ -1,5 +1,3 @@
-:html_theme.sidebar_secondary.remove: true
-
 .. _comparison:
 
 How Camelot compares to other tools
@@ -30,113 +28,115 @@ Click any column header to sort. The Camelot column is highlighted; ✓
 means "supported out of the box", ✗ "not supported", ◐ "partial /
 workaround required".
 
-.. raw:: html
+.. container:: full-width
 
-   <table class="comparison-matrix sortable full-width">
-     <thead>
-       <tr>
-         <th scope="col">Capability</th>
-         <th scope="col">Camelot</th>
-         <th scope="col">Tabula</th>
-         <th scope="col">pdfplumber</th>
-         <th scope="col">PyMuPDF</th>
-         <th scope="col">gmft</th>
-         <th scope="col">unstructured.io</th>
-       </tr>
-     </thead>
-     <tbody>
-       <tr>
-         <th scope="row">License</th>
-         <td>MIT</td>
-         <td>MIT</td>
-         <td>MIT</td>
-         <td>AGPL / commercial</td>
-         <td>MIT</td>
-         <td>Apache 2.0</td>
-       </tr>
-       <tr>
-         <th scope="row">Runtime</th>
-         <td>pure Python</td>
-         <td>Java + wrapper</td>
-         <td>pure Python</td>
-         <td>C binding</td>
-         <td>PyTorch model</td>
-         <td>Python + plugins</td>
-       </tr>
-       <tr>
-         <th scope="row">Ruled-grid tables</th>
-         <td><span class="cm-yes" title="flavor='lattice'">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes" title="model-based">&#10003;</span></td>
-         <td><span class="cm-partial" title="via backend">&#9680;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Borderless / whitespace tables</th>
-         <td><span class="cm-yes" title="stream / network / hybrid">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-partial">&#9680;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Per-page kwarg overrides</th>
-         <td><span class="cm-yes" title="per_page= (#41)">&#10003;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-partial" title="manual loop">&#9680;</span></td>
-         <td><span class="cm-partial">&#9680;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Scanned PDFs (no text layer)</th>
-         <td><span class="cm-no" title="preprocess with ocrmypdf">&#10007;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-partial" title="via OCR plugin">&#9680;</span></td>
-         <td><span class="cm-yes" title="vision model">&#10003;</span></td>
-         <td><span class="cm-yes" title="Tesseract plugin">&#10003;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Confidence score per table</th>
-         <td><span class="cm-yes" title="Table.confidence">&#10003;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-         <td><span class="cm-partial" title="heuristic">&#9680;</span></td>
-         <td><span class="cm-yes" title="model score">&#10003;</span></td>
-         <td><span class="cm-no">&#10007;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">In-memory bytes / file-like input</th>
-         <td><span class="cm-yes" title="#270">&#10003;</span></td>
-         <td><span class="cm-no" title="needs path">&#10007;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-         <td><span class="cm-yes">&#10003;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Multi-page table stitching</th>
-         <td><span class="cm-yes" title="TableList.stack_contiguous (#628)">&#10003;</span></td>
-         <td><span class="cm-partial" title="manual">&#9680;</span></td>
-         <td><span class="cm-partial">&#9680;</span></td>
-         <td><span class="cm-partial">&#9680;</span></td>
-         <td><span class="cm-yes" title="model-aware">&#10003;</span></td>
-         <td><span class="cm-partial">&#9680;</span></td>
-       </tr>
-       <tr>
-         <th scope="row">Heavy native deps</th>
-         <td>opencv-headless, pdfium</td>
-         <td>JRE</td>
-         <td>none</td>
-         <td>mupdf (vendored)</td>
-         <td>PyTorch (+ GPU)</td>
-         <td>varies</td>
-       </tr>
-     </tbody>
-   </table>
+  .. raw:: html
+
+        <table class="comparison-matrix sortable">
+        <thead>
+          <tr>
+            <th scope="col">Capability</th>
+            <th scope="col">Camelot</th>
+            <th scope="col">Tabula</th>
+            <th scope="col">pdfplumber</th>
+            <th scope="col">PyMuPDF</th>
+            <th scope="col">gmft</th>
+            <th scope="col">unstructured.io</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">License</th>
+            <td>MIT</td>
+            <td>MIT</td>
+            <td>MIT</td>
+            <td>AGPL / commercial</td>
+            <td>MIT</td>
+            <td>Apache 2.0</td>
+          </tr>
+          <tr>
+            <th scope="row">Runtime</th>
+            <td>pure Python</td>
+            <td>Java + wrapper</td>
+            <td>pure Python</td>
+            <td>C binding</td>
+            <td>PyTorch model</td>
+            <td>Python + plugins</td>
+          </tr>
+          <tr>
+            <th scope="row">Ruled-grid tables</th>
+            <td><span class="cm-yes" title="flavor='lattice'">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes" title="model-based">&#10003;</span></td>
+            <td><span class="cm-partial" title="via backend">&#9680;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Borderless / whitespace tables</th>
+            <td><span class="cm-yes" title="stream / network / hybrid">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Per-page kwarg overrides</th>
+            <td><span class="cm-yes" title="per_page= (#41)">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-partial" title="manual loop">&#9680;</span></td>
+            <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Scanned PDFs (no text layer)</th>
+            <td><span class="cm-no" title="preprocess with ocrmypdf">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-partial" title="via OCR plugin">&#9680;</span></td>
+            <td><span class="cm-yes" title="vision model">&#10003;</span></td>
+            <td><span class="cm-yes" title="Tesseract plugin">&#10003;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Confidence score per table</th>
+            <td><span class="cm-yes" title="Table.confidence">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-partial" title="heuristic">&#9680;</span></td>
+            <td><span class="cm-yes" title="model score">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">In-memory bytes / file-like input</th>
+            <td><span class="cm-yes" title="#270">&#10003;</span></td>
+            <td><span class="cm-no" title="needs path">&#10007;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-yes">&#10003;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Multi-page table stitching</th>
+            <td><span class="cm-yes" title="TableList.stack_contiguous (#628)">&#10003;</span></td>
+            <td><span class="cm-partial" title="manual">&#9680;</span></td>
+            <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-yes" title="model-aware">&#10003;</span></td>
+            <td><span class="cm-partial">&#9680;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Heavy native deps</th>
+            <td>opencv-headless, pdfium</td>
+            <td>JRE</td>
+            <td>none</td>
+            <td>mupdf (vendored)</td>
+            <td>PyTorch (+ GPU)</td>
+            <td>varies</td>
+          </tr>
+        </tbody>
+      </table>
 
 Side-by-side example
 --------------------

--- a/docs/user/comparison.rst
+++ b/docs/user/comparison.rst
@@ -1,3 +1,5 @@
+:html_theme.sidebar_secondary.remove: true
+
 .. _comparison:
 
 How Camelot compares to other tools
@@ -24,88 +26,117 @@ your PDFs.
 At a glance
 -----------
 
-.. list-table:: Capability matrix
-   :header-rows: 1
-   :widths: 18 12 14 14 14 14 14
-   :class: full-width
+Click any column header to sort. The Camelot column is highlighted; ✓
+means "supported out of the box", ✗ "not supported", ◐ "partial /
+workaround required".
 
-   * - Capability
-     - **Camelot**
-     - Tabula
-     - pdfplumber
-     - PyMuPDF
-     - gmft
-     - unstructured.io
-   * - License
-     - MIT
-     - MIT
-     - MIT
-     - AGPL / commercial
-     - MIT
-     - Apache 2.0
-   * - Runtime
-     - pure Python
-     - Java + Python wrapper
-     - pure Python
-     - C / Python binding
-     - PyTorch model
-     - Python (pluggable backends)
-   * - Ruled-grid tables (lattice)
-     - yes (``flavor='lattice'``)
-     - yes
-     - yes
-     - yes
-     - yes (model-based)
-     - via backend
-   * - Borderless / whitespace-separated tables
-     - yes (``flavor='stream'``, ``'network'``, ``'hybrid'``)
-     - yes
-     - partial
-     - yes
-     - yes
-     - yes
-   * - Per-page parameter overrides
-     - yes (``per_page=``, #41)
-     - no
-     - manual loop
-     - manual loop
-     - no
-     - no
-   * - Scanned PDFs (image-only)
-     - no — preprocess with ocrmypdf
-     - no
-     - no
-     - via OCR plugin
-     - **yes** (vision model)
-     - **yes** (Tesseract / OCR plugin)
-   * - Confidence score per table
-     - yes (``Table.confidence``)
-     - no
-     - no
-     - heuristic
-     - model score
-     - no
-   * - In-process bytes / file-like input
-     - yes (#270)
-     - no — needs path
-     - yes
-     - yes
-     - yes
-     - yes
-   * - Multi-page table stitching
-     - yes (``TableList.stack_contiguous``, #628)
-     - manual
-     - manual
-     - manual
-     - model-aware
-     - manual
-   * - Heavy native deps
-     - opencv-python-headless, pdfium
-     - JRE
-     - none
-     - mupdf C lib (vendored)
-     - PyTorch + CUDA optional
-     - varies by backend
+.. raw:: html
+
+   <table class="comparison-matrix sortable full-width">
+     <thead>
+       <tr>
+         <th scope="col">Capability</th>
+         <th scope="col">Camelot</th>
+         <th scope="col">Tabula</th>
+         <th scope="col">pdfplumber</th>
+         <th scope="col">PyMuPDF</th>
+         <th scope="col">gmft</th>
+         <th scope="col">unstructured.io</th>
+       </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <th scope="row">License</th>
+         <td>MIT</td>
+         <td>MIT</td>
+         <td>MIT</td>
+         <td>AGPL / commercial</td>
+         <td>MIT</td>
+         <td>Apache 2.0</td>
+       </tr>
+       <tr>
+         <th scope="row">Runtime</th>
+         <td>pure Python</td>
+         <td>Java + wrapper</td>
+         <td>pure Python</td>
+         <td>C binding</td>
+         <td>PyTorch model</td>
+         <td>Python + plugins</td>
+       </tr>
+       <tr>
+         <th scope="row">Ruled-grid tables</th>
+         <td><span class="cm-yes" title="flavor='lattice'">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes" title="model-based">&#10003;</span></td>
+         <td><span class="cm-partial" title="via backend">&#9680;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Borderless / whitespace tables</th>
+         <td><span class="cm-yes" title="stream / network / hybrid">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-partial">&#9680;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Per-page kwarg overrides</th>
+         <td><span class="cm-yes" title="per_page= (#41)">&#10003;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-partial" title="manual loop">&#9680;</span></td>
+         <td><span class="cm-partial">&#9680;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Scanned PDFs (no text layer)</th>
+         <td><span class="cm-no" title="preprocess with ocrmypdf">&#10007;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-partial" title="via OCR plugin">&#9680;</span></td>
+         <td><span class="cm-yes" title="vision model">&#10003;</span></td>
+         <td><span class="cm-yes" title="Tesseract plugin">&#10003;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Confidence score per table</th>
+         <td><span class="cm-yes" title="Table.confidence">&#10003;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+         <td><span class="cm-partial" title="heuristic">&#9680;</span></td>
+         <td><span class="cm-yes" title="model score">&#10003;</span></td>
+         <td><span class="cm-no">&#10007;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">In-memory bytes / file-like input</th>
+         <td><span class="cm-yes" title="#270">&#10003;</span></td>
+         <td><span class="cm-no" title="needs path">&#10007;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+         <td><span class="cm-yes">&#10003;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Multi-page table stitching</th>
+         <td><span class="cm-yes" title="TableList.stack_contiguous (#628)">&#10003;</span></td>
+         <td><span class="cm-partial" title="manual">&#9680;</span></td>
+         <td><span class="cm-partial">&#9680;</span></td>
+         <td><span class="cm-partial">&#9680;</span></td>
+         <td><span class="cm-yes" title="model-aware">&#10003;</span></td>
+         <td><span class="cm-partial">&#9680;</span></td>
+       </tr>
+       <tr>
+         <th scope="row">Heavy native deps</th>
+         <td>opencv-headless, pdfium</td>
+         <td>JRE</td>
+         <td>none</td>
+         <td>mupdf (vendored)</td>
+         <td>PyTorch (+ GPU)</td>
+         <td>varies</td>
+       </tr>
+     </tbody>
+   </table>
 
 Side-by-side example
 --------------------

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -27,7 +27,7 @@ Here is a `comparison`_ of Camelot's output with outputs from other open-source 
 .. _pdf-table-extract: https://github.com/ashima/pdf-table-extract
 .. _PDFTables: https://pdftables.com/
 .. _Smallpdf: https://smallpdf.com
-.. _comparison: https://github.com/camelot-dev/camelot/wiki/Comparison-with-other-PDF-Table-Extraction-libraries-and-tools
+.. _comparison: comparison.html
 
 What's in a name?
 -----------------


### PR DESCRIPTION
Six linked fixes for the comparison + theme rollout:

- **Stronger CSS link-colour overrides.** Some pages (how-it-works, quickstart, cli) were still rendering pre-2.0 blue because pydata-sphinx-theme hard-codes link colours in places the CSS variable doesn't reach. High-specificity selectors now cover `.bd-content a`, `.bd-sidebar-primary a`, `.bd-toc-link`, and `article a`.
- **Wrap the comparison matrix in `.. container:: full-width`.** That's the existing pydata-sphinx-theme mechanism (same one used at the 'Specify table areas' first code-block in advanced.rst) — collapses the right 'On this page' sidebar *locally* for that one block AND expands content width.
- **Wrap the 3 `code-block:: pycon` directives in advanced.rst** that had `:class: full-width` on them. Applying the class to the code-block directly was clashing with Pygments and stripping python syntax highlighting (the user-reported regression on 'Specify table areas'). Same width + sidebar-collapse behaviour, but the syntax colours come back.
- **New `docs/_static/sortable-table.js`** — ~80 lines, dependency-free, click-any-th-to-sort with three states (asc / desc / restore). Registered via `html_js_files` in conf.py.
- **Comparison 'At a glance' rewritten** as raw HTML with color-coded yes/no icons (✓ green, ✗ red, ◐ amber for partial). Each cell carries a `title=` tooltip with the supporting kwarg / PR number. Camelot column highlighted with a light green background; alternating row shading.
- **Three remaining wiki links fixed** (docs/index.rst, docs/user/advanced.rst, docs/user/intro.rst) — all now point at the in-repo `comparison.html` via `:ref:` or relative link.