### PR TITLE
fix(parsers): assemble cell text in global reading order (#385)

### DIFF
--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -188,34 +188,53 @@ class BaseParser:
             Parse errors
         """
         pos_errors = []
-        # TODO: have a single list in place of two directional ones?
-        # sorted on x-coordinate based on reading order i.e. LTR or RTL
-        for direction in ["vertical", "horizontal"]:
-            for t in self.t_bbox[direction]:
-                indices, error = get_table_index(
-                    table,
-                    t,
-                    direction,
-                    split_text=self.split_text,
-                    flag_size=self.flag_size,
-                    strip_text=self.strip_text,
-                )
-                if len(indices) > 0:
-                    if indices[0][:2] != (-1, -1):
-                        pos_errors.append(error)
-                        indices = type(self)._reduce_index(
-                            table, indices, shift_text=self.shift_text
-                        )
-                        for r_idx, c_idx, text in indices:
-                            # replace_text (#482) is applied after the
-                            # split/strip/flag-size pipeline, at the
-                            # last point before the text reaches the
-                            # output cell. Order: strip first (already
-                            # done upstream in get_table_index), then
-                            # replace, then assign.
-                            if self.replace_text:
-                                text = text_replace(text, self.replace_text)
-                            table.cells[r_idx][c_idx].text = text
+        # Process textlines from both orientations in a single global
+        # reading-order stream (-y0 top-first, then x0 left-first) rather
+        # than the previous vertical-pass-then-horizontal-pass loop.
+        #
+        # Cell.text is an *appending* setter, so the order textlines are
+        # visited determines the order their fragments concatenate in a
+        # cell. The old "all vertical, then all horizontal" order meant a
+        # glyph that playa happened to classify as a vertical textline
+        # (e.g. a lone single character split off from a word) was
+        # appended *before* the horizontal textlines of the same cell —
+        # floating it to the front of the cell text. Reported as #385
+        # ('d' of 'dihydroclorid' jumping to the start of the cell).
+        #
+        # Sorting both orientations together by reading order places each
+        # textline by its own position, so the cell accumulates
+        # top-to-bottom, left-to-right regardless of orientation tag.
+        textlines = [
+            (t, direction)
+            for direction in ("vertical", "horizontal")
+            for t in self.t_bbox[direction]
+        ]
+        textlines.sort(key=lambda td: (-td[0].y0, td[0].x0))
+        for t, direction in textlines:
+            indices, error = get_table_index(
+                table,
+                t,
+                direction,
+                split_text=self.split_text,
+                flag_size=self.flag_size,
+                strip_text=self.strip_text,
+            )
+            if len(indices) > 0:
+                if indices[0][:2] != (-1, -1):
+                    pos_errors.append(error)
+                    indices = type(self)._reduce_index(
+                        table, indices, shift_text=self.shift_text
+                    )
+                    for r_idx, c_idx, text in indices:
+                        # replace_text (#482) is applied after the
+                        # split/strip/flag-size pipeline, at the
+                        # last point before the text reaches the
+                        # output cell. Order: strip first (already
+                        # done upstream in get_table_index), then
+                        # replace, then assign.
+                        if self.replace_text:
+                            text = text_replace(text, self.replace_text)
+                        table.cells[r_idx][c_idx].text = text
         return pos_errors
 
     def _generate_columns_and_rows(self, bbox, user_cols):


### PR DESCRIPTION
## Root cause

`Cell.text` is an **appending** setter (`self._text = "".join([self._text, t])`), so the order textlines are visited in `compute_parse_errors` determines how their fragments concatenate within a cell. The loop was:

```python
for direction in ["vertical", "horizontal"]:
    for t in self.t_bbox[direction]:
        ...
        table.cells[r_idx][c_idx].text = text   # appends
```

— all *vertical* textlines, then all *horizontal* ones. So a glyph that playa classifies as a vertical textline (typically a **lone single character** split off from a word) gets appended **before** the horizontal textlines of the same cell, floating it to the front.

Diagnosed against the #385 reproducer: a cell reading **"Eprazinon dihydroclorid"** came out as `'d\nEprazinon \nihydrocl\norid'`. The spy output showed 5 textlines feed that cell, and the `d` of "dihydroclorid" is its own one-char textline tagged **vertical**, processed first:

```
vertical     y0=156.4  x0=74.5   '  d\n'        <- floats to front
horizontal   y0=173.2  x0=74.5   'Eprazinon \n'
horizontal   y0=156.4  x0=77.9   'ihydrocl\n'
horizontal   y0=148.0  x0=74.5   'orid\n'
```

## The fix

Flatten both orientation passes into one list and sort by reading order (`-y0` top-first, then `x0` left-first) before processing. Each textline then lands at its own position and the cell accumulates top-to-bottom, left-to-right regardless of orientation tag → "Eprazinon dihydroclorid".

## Regression risk — please let CI be the judge

This changes textline processing order for **every** table, not just the bug case. It should be equal-or-better (reading order is more correct than vertical-first), but the place to watch is rotated tables where vertical text is the *primary* content — `test_lattice_table_rotated`, `test_network_table_rotated`, `test_hybrid_table_rotated`. **The full lattice/stream/network/hybrid CI suites are the regression sweep for this PR.** If a rotated fixture shifts, the fallback is to restrict the reorder to same-row textlines only (group by y-band, sort within band) rather than a global sort.

No dedicated regression test fixture is added here — the #385 reproducer is a 100KB+ Vietnamese pharma PDF; a crafted minimal fixture is a sensible follow-up once CI confirms the approach.

Closes #385.