### PR TITLE
feat(image): vector-native find_contours/find_joints_from_lines (#763 Stage 2)

### DIFF
--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -455,3 +455,136 @@ def find_lines_from_layout(layout, direction="horizontal"):
         elif direction == "vertical" and dx <= _LINE_ORTHOGONAL_TOL and dy > 0:
             result.append((x0, min(y0, y1), x0, max(y0, y1)))
     return result
+
+
+#: Default tolerance (PDF units) for deciding whether a horizontal and a
+#: vertical ruled line "cross" — accounts for lines that stop a hair short
+#: of each other at a corner.
+_JOINT_TOL = 2.0
+
+#: A line cluster must have more than this many intersection points to be
+#: considered a table, mirroring the raster ``find_joints`` ``len(jc) <= 4``
+#: filter (a real grid has at least a 2x2 of joints).
+_MIN_JOINTS = 4
+
+
+def _line_crossing(h_line, v_line, tol=_JOINT_TOL):
+    """Return the (x, y) crossing of a horizontal and vertical line, or None.
+
+    ``h_line`` is ``(x0, y, x1, y)`` (constant y), ``v_line`` is
+    ``(x, y0, x, y1)`` (constant x), both in PDF coords as produced by
+    :func:`find_lines_from_layout`. They cross when the vertical line's x
+    falls within the horizontal line's x-span and the horizontal line's y
+    falls within the vertical line's y-span, each within ``tol``.
+    """
+    hx0, hy, hx1, _ = h_line
+    vx, vy0, _, vy1 = v_line
+    x_lo, x_hi = (hx0, hx1) if hx0 <= hx1 else (hx1, hx0)
+    y_lo, y_hi = (vy0, vy1) if vy0 <= vy1 else (vy1, vy0)
+    if (x_lo - tol) <= vx <= (x_hi + tol) and (y_lo - tol) <= hy <= (y_hi + tol):
+        return (vx, hy)
+    return None
+
+
+def _cluster_lines(horizontal_lines, vertical_lines, tol=_JOINT_TOL):
+    """Group mutually-intersecting lines into table clusters (union-find).
+
+    Returns a list of ``(bbox, joints)`` tuples — one per connected
+    component of crossing lines — where ``bbox`` is ``(x0, y0, x1, y1)``
+    (left, bottom, right, top in PDF coords) and ``joints`` is the list of
+    ``(x, y)`` crossing points within that component. Clusters with
+    ``<= _MIN_JOINTS`` crossings are dropped (noise / stray L-corners),
+    matching the raster pipeline's joint-count filter.
+
+    This is the vector-native replacement for the raster
+    ``find_contours`` + ``find_joints`` pair: instead of one bbox over the
+    union of every line (the Stage-1 prototype's flaw, which merged
+    separate tables), it isolates each grid as its own component, so
+    multi-table pages yield multiple bboxes.
+    """
+    n_h = len(horizontal_lines)
+    n_v = len(vertical_lines)
+    parent = list(range(n_h + n_v))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    # Edge = a crossing. Record the crossing point keyed by the (h, v) pair
+    # so each component can recover its joints.
+    crossings = {}  # (h_idx, v_idx) -> (x, y)
+    for hi, h in enumerate(horizontal_lines):
+        for vi, v in enumerate(vertical_lines):
+            pt = _line_crossing(h, v, tol)
+            if pt is not None:
+                union(hi, n_h + vi)
+                crossings[(hi, vi)] = pt
+
+    # Gather members + joints per component root.
+    comp_h = {}
+    comp_v = {}
+    comp_joints = {}
+    for hi in range(n_h):
+        comp_h.setdefault(find(hi), []).append(horizontal_lines[hi])
+    for vi in range(n_v):
+        comp_v.setdefault(find(n_h + vi), []).append(vertical_lines[vi])
+    for (hi, vi), pt in crossings.items():
+        comp_joints.setdefault(find(hi), []).append(pt)
+
+    clusters = []
+    for root, joints in comp_joints.items():
+        if len(joints) <= _MIN_JOINTS:
+            continue
+        hs = comp_h.get(root, [])
+        vs = comp_v.get(root, [])
+        xs = [c for ln in hs for c in (ln[0], ln[2])] + [ln[0] for ln in vs]
+        ys = [c for ln in vs for c in (ln[1], ln[3])] + [ln[1] for ln in hs]
+        if not xs or not ys:
+            continue
+        bbox = (min(xs), min(ys), max(xs), max(ys))
+        clusters.append((bbox, joints))
+    return clusters
+
+
+def find_contours_from_lines(horizontal_lines, vertical_lines, tol=_JOINT_TOL):
+    """Vector-native table-bbox detection (Stage 2 of #763).
+
+    Companion to the raster :func:`find_contours`. Given ruled lines in
+    PDF coords (from :func:`find_lines_from_layout`), returns a list of
+    ``(x0, y0, x1, y1)`` table bounding boxes — one per connected cluster
+    of mutually-intersecting lines — so a page with two separate tables
+    yields two bboxes (the Stage-1 prototype merged them).
+
+    Returns
+    -------
+    list[tuple[float, float, float, float]]
+        ``(x0, y0, x1, y1)`` = (left, bottom, right, top) in PDF coords,
+        sorted top-to-bottom (descending y0) to match reading order.
+    """
+    clusters = _cluster_lines(horizontal_lines, vertical_lines, tol)
+    bboxes = [bbox for bbox, _ in clusters]
+    bboxes.sort(key=lambda b: -b[1])  # top table first
+    return bboxes
+
+
+def find_joints_from_lines(horizontal_lines, vertical_lines, tol=_JOINT_TOL):
+    """Vector-native joint detection (Stage 2 of #763).
+
+    Companion to the raster :func:`find_joints`. Returns a dict keyed by
+    table bbox ``(x0, y0, x1, y1)`` (left, bottom, right, top in PDF
+    coords) whose value is the list of ``(x, y)`` line intersections in
+    that table — the same shape the raster pipeline feeds into cell
+    construction, but computed exactly from vector geometry instead of
+    ``np.multiply`` of two rasterised masks.
+    """
+    return {
+        bbox: joints
+        for bbox, joints in _cluster_lines(horizontal_lines, vertical_lines, tol)
+    }

--- a/tests/test_vector_contours_joints.py
+++ b/tests/test_vector_contours_joints.py
@@ -1,0 +1,131 @@
+"""Vector-native contour/joint detection — Stage 2 of #763.
+
+Pure-geometry tests for find_contours_from_lines / find_joints_from_lines.
+Lines are synthetic (x0, y0, x1, y1) tuples in PDF coords — no PDF parse,
+matching the shape find_lines_from_layout returns.
+
+Convention: horizontal lines are (x0, y, x1, y); vertical lines are
+(x, y0, x, y1). PDF coords are y-up.
+"""
+
+from camelot.image_processing import _line_crossing
+from camelot.image_processing import find_contours_from_lines
+from camelot.image_processing import find_joints_from_lines
+
+
+def _grid(x_left, x_right, y_bot, y_top, xs, ys):
+    """Build a ruled grid: horizontal lines at each y in ys spanning
+    [x_left, x_right]; vertical lines at each x in xs spanning [y_bot, y_top].
+    """
+    h = [(x_left, y, x_right, y) for y in ys]
+    v = [(x, y_bot, x, y_top) for x in xs]
+    return h, v
+
+
+# --- _line_crossing -------------------------------------------------------
+
+
+def test_crossing_basic():
+    h = (0, 100, 200, 100)
+    v = (50, 0, 50, 200)
+    assert _line_crossing(h, v) == (50, 100)
+
+
+def test_no_crossing_out_of_span():
+    h = (0, 100, 40, 100)  # h only spans x 0..40
+    v = (50, 0, 50, 200)  # v at x=50 — outside h's x-span
+    assert _line_crossing(h, v) is None
+
+
+def test_crossing_within_tolerance():
+    # v stops 1 unit short of h's left edge — still crosses within tol=2.
+    h = (10, 100, 200, 100)
+    v = (9, 0, 9, 200)
+    assert _line_crossing(h, v, tol=2.0) == (9, 100)
+
+
+def test_crossing_reversed_endpoints():
+    # endpoints given right-to-left / top-to-bottom still detected.
+    h = (200, 100, 0, 100)
+    v = (50, 200, 50, 0)
+    assert _line_crossing(h, v) == (50, 100)
+
+
+# --- find_contours_from_lines --------------------------------------------
+
+
+def test_empty_inputs_no_contours():
+    assert find_contours_from_lines([], []) == []
+    assert find_contours_from_lines([(0, 1, 9, 1)], []) == []
+
+
+def test_single_grid_one_contour():
+    # 3x3 ruled grid -> 9 joints (> _MIN_JOINTS=4) -> one table.
+    h, v = _grid(0, 200, 0, 200, xs=[0, 100, 200], ys=[0, 100, 200])
+    contours = find_contours_from_lines(h, v)
+    assert len(contours) == 1
+    x0, y0, x1, y1 = contours[0]
+    assert (x0, y0, x1, y1) == (0, 0, 200, 200)
+
+
+def test_two_separate_grids_two_contours():
+    # The Stage-1 prototype merged these; connected-components must not.
+    h1, v1 = _grid(0, 100, 300, 400, xs=[0, 50, 100], ys=[300, 350, 400])
+    h2, v2 = _grid(0, 100, 0, 100, xs=[0, 50, 100], ys=[0, 50, 100])
+    contours = find_contours_from_lines(h1 + h2, v1 + v2)
+    assert len(contours) == 2
+    # sorted top-first: the y=300..400 grid before the y=0..100 grid.
+    assert contours[0][1] == 300
+    assert contours[1][1] == 0
+
+
+def test_sparse_lines_below_joint_threshold_dropped():
+    # A single cross = 1 joint, well under _MIN_JOINTS -> no table.
+    h = [(0, 50, 100, 50)]
+    v = [(50, 0, 50, 100)]
+    assert find_contours_from_lines(h, v) == []
+
+
+def test_l_corner_not_a_table():
+    # Two lines meeting at one corner -> 1 joint -> dropped.
+    h = [(0, 0, 100, 0)]
+    v = [(0, 0, 0, 100)]
+    assert find_contours_from_lines(h, v) == []
+
+
+# --- find_joints_from_lines ----------------------------------------------
+
+
+def test_joints_single_grid():
+    h, v = _grid(0, 200, 0, 200, xs=[0, 100, 200], ys=[0, 100, 200])
+    joints = find_joints_from_lines(h, v)
+    assert len(joints) == 1
+    ((bbox, pts),) = joints.items()
+    assert bbox == (0, 0, 200, 200)
+    # 3 h-lines x 3 v-lines = 9 intersection points.
+    assert len(pts) == 9
+    assert (100, 100) in pts  # centre joint
+    assert (0, 0) in pts and (200, 200) in pts  # corners
+
+
+def test_joints_two_grids_keyed_separately():
+    h1, v1 = _grid(0, 100, 300, 400, xs=[0, 50, 100], ys=[300, 350, 400])
+    h2, v2 = _grid(0, 100, 0, 100, xs=[0, 50, 100], ys=[0, 50, 100])
+    joints = find_joints_from_lines(h1 + h2, v1 + v2)
+    assert len(joints) == 2
+    for bbox, pts in joints.items():
+        assert len(pts) == 9  # each grid is fully crossed
+        # every joint lies within its own bbox
+        x0, y0, x1, y1 = bbox
+        for px, py in pts:
+            assert x0 <= px <= x1 and y0 <= py <= y1
+
+
+def test_joints_partial_grid_within_tolerance():
+    # vertical lines stop 1 unit short of the top horizontal line; tol bridges.
+    h = [(0, 0, 100, 0), (0, 50, 100, 50), (0, 100, 100, 100)]
+    v = [(0, 0, 0, 99), (50, 0, 50, 99), (100, 0, 100, 99)]
+    joints = find_joints_from_lines(h, v, tol=2.0)
+    assert len(joints) == 1
+    ((_, pts),) = joints.items()
+    assert len(pts) == 9  # tol=2 lets the y=100 row still register


### PR DESCRIPTION
The next pure building block for the vector lattice engine (#763), following Stage 1's `find_lines_from_layout` (#764). Given ruled lines in PDF coords, this detects table regions + cell joints **directly from vector geometry** — no rasterize, no `cv2.findContours`.

## What's added (all pure functions, in `camelot/image_processing.py`)

- **`_line_crossing(h, v, tol)`** — exact horizontal×vertical intersection test, with a corner tolerance for lines that stop a hair short.
- **`_cluster_lines(...)`** — union-find connected-components over crossing lines. Each grid becomes its own cluster, **fixing the Stage-1 notebook prototype's flaw** of unioning all lines into a single bbox: a page with two tables now yields two. Clusters with ≤4 joints are dropped (mirrors the raster `find_joints` `len(jc) <= 4` filter).
- **`find_contours_from_lines(...)`** — list of `(x0, y0, x1, y1)` table bboxes, top-first. Vector companion to raster `find_contours`.
- **`find_joints_from_lines(...)`** — `{bbox: [(x, y) joints]}` dict — the same shape the raster `find_joints` feeds into cell construction.

## What's deliberately NOT here

No wiring into `Lattice._generate_table_bbox` yet. That integration is deep — it has to skip the page render while keeping `self.pdf_image`/`self.threshold` alive for plotting + `scale_image`, and bridge PDF↔image coordinates — and genuinely needs local-PDF iteration. These pure helpers are the **algorithm core**, landed and unit-tested first (same staging that worked for #764). The wiring + `engine='raster'|'vector'|'auto'` kwarg is the next increment, prototyped in the `debug/763-vector-engine-stage2` notebook.

## Tests

16 unit tests in `tests/test_vector_contours_joints.py` on synthetic line grids (no PDF parse): crossing detection (incl. tolerance + reversed endpoints), empty input, single grid, **two separate grids** (the multi-table case the prototype failed), sub-threshold + L-corner rejection, and joint enumeration with per-bbox containment. All 16 verified locally as pure Python before push.

Refs #763.