### PR TITLE
feat(lattice): add engine= kwarg with auto-probe (#763 Stage 2b plumbing)

### DIFF
--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -607,3 +607,26 @@ def find_joints_from_lines(horizontal_lines, vertical_lines, tol=_JOINT_TOL):
         bbox: joints
         for bbox, joints in _cluster_lines(horizontal_lines, vertical_lines, tol)
     }
+
+
+#: Minimum number of ruled lines a layout must carry for the vector engine
+#: to be worth attempting. A genuine ruled table has at least a handful of
+#: edges; fewer than this is likely a stray rule or page border, where the
+#: raster engine (which also reads text-region heuristics) is the safer bet.
+_VECTOR_ENGINE_MIN_LINES = 4
+
+
+def layout_has_ruled_lines(layout, min_lines=_VECTOR_ENGINE_MIN_LINES):
+    """Probe whether a layout carries enough vector ruled lines.
+
+    Used by ``flavor='lattice'``'s ``engine='auto'`` to decide between the
+    vector and raster line-detection paths (#763). Returns ``True`` when
+    the layout tree contains at least ``min_lines`` stroked ``LTLine`` /
+    ``LTRect`` edges (via :func:`_ruled_lines_from_layout`).
+
+    A ``None`` layout (e.g. probed before page preparation) returns
+    ``False`` — the caller should fall back to raster.
+    """
+    if layout is None:
+        return False
+    return len(_ruled_lines_from_layout(layout)) >= min_lines

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -274,6 +274,17 @@ def read_pdf(
         Fallback to another backend if unavailable, by default True
     resolution* : int, optional (default: 300)
         Resolution used for PDF to PNG conversion.
+    engine* : str, optional (default: 'raster')
+        Line-detection engine for ``flavor='lattice'``:
+
+        - ``'raster'`` (default): render the page and detect ruled lines
+          with OpenCV — the long-standing behaviour.
+        - ``'auto'``: use the vector engine when the PDF carries native
+          ruled lines, else fall back to raster. (Currently resolves to
+          raster pending the vector pipeline; #763.)
+        - ``'vector'``: read ruled lines straight from the PDF's vector
+          graphics, skipping rasterisation. **Not yet wired** — raises
+          ``NotImplementedError`` for now (#763).
 
     Returns
     -------

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -256,7 +256,13 @@ class Lattice(BaseParser):
             return "raster"
         return "raster"
 
-    def _generate_table_bbox(self):
+    def _check_engine_supported(self):
+        """Raise if the resolved engine has no implementation yet.
+
+        Keeps the not-yet-wired ``engine='vector'`` guard out of
+        :meth:`_generate_table_bbox`'s body (a method call, not an inline
+        branch, so it doesn't inflate that method's complexity).
+        """
         if self._resolve_engine() == "vector":
             raise NotImplementedError(
                 "engine='vector' for flavor='lattice' is not wired yet"
@@ -265,6 +271,9 @@ class Lattice(BaseParser):
                 " pending). Use engine='raster' (default) or engine='auto'"
                 " for now. Tracked in #763."
             )
+
+    def _generate_table_bbox(self):
+        self._check_engine_supported()
 
         def scale_areas(areas):
             scaled_areas = []

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -10,6 +10,7 @@ from ..image_processing import adaptive_threshold
 from ..image_processing import find_contours
 from ..image_processing import find_joints
 from ..image_processing import find_lines
+from ..image_processing import layout_has_ruled_lines
 from ..utils import build_file_path_in_temp_dir
 from ..utils import merge_close_lines
 from ..utils import scale_image
@@ -112,8 +113,14 @@ class Lattice(BaseParser):
         resolution=300,
         use_fallback=True,
         backend="pdfium",
+        engine="raster",
         **kwargs,
     ):
+        if engine not in ("raster", "vector", "auto"):
+            raise ValueError(
+                f"engine must be 'raster', 'vector' or 'auto', got {engine!r}"
+            )
+        self.engine = engine
         super().__init__("lattice", replace_text=replace_text)
         self.table_regions = table_regions
         self.table_areas = table_areas
@@ -222,7 +229,43 @@ class Lattice(BaseParser):
         # for plotting
         table._segments = (self.vertical_segments, self.horizontal_segments)
 
+    def _resolve_engine(self):
+        """Resolve the effective line-detection engine for this page.
+
+        * ``'raster'`` → ``'raster'`` (the OpenCV pipeline).
+        * ``'vector'`` → ``'vector'`` (explicit; not yet wired — see
+          :meth:`_generate_table_bbox`).
+        * ``'auto'``  → ``'vector'`` when the page layout carries enough
+          ruled lines to attempt vector detection, else ``'raster'``.
+
+        Note: until the vector ``_generate_table_bbox`` path is wired
+        (#763 Stage 2b), ``'auto'`` deliberately resolves to ``'raster'``
+        even when vector lines are present — the probe result is computed
+        for forward-compatibility and diagnostics but the only
+        implemented path is raster. Explicit ``engine='vector'`` is the
+        single value that surfaces the not-yet-implemented state.
+        """
+        if self.engine == "vector":
+            return "vector"
+        if self.engine == "auto":
+            # Diagnostic: record whether the vector path *would* apply.
+            self._vector_lines_available = layout_has_ruled_lines(
+                getattr(self, "layout", None)
+            )
+            # TODO(#763): return "vector" here once 2b is wired.
+            return "raster"
+        return "raster"
+
     def _generate_table_bbox(self):
+        if self._resolve_engine() == "vector":
+            raise NotImplementedError(
+                "engine='vector' for flavor='lattice' is not wired yet"
+                " (the vector find_lines_from_layout / find_contours_from_lines"
+                " helpers exist, but the _generate_table_bbox integration is"
+                " pending). Use engine='raster' (default) or engine='auto'"
+                " for now. Tracked in #763."
+            )
+
         def scale_areas(areas):
             scaled_areas = []
             for area in areas:

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -139,6 +139,7 @@ lattice_kwargs = common_kwargs + [
     "erode_iterations",
     "resolution",
     "use_fallback",
+    "engine",
 ]
 flavor_to_kwargs = {
     "stream": text_kwargs,

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -1,0 +1,88 @@
+"""engine= kwarg + layout_has_ruled_lines probe — #763 Stage 2b plumbing."""
+
+import pytest
+
+from camelot.image_processing import layout_has_ruled_lines
+
+
+class _MockLTLine:
+    def __init__(self, x0, y0, x1, y1, stroke=True):
+        self.x0, self.y0, self.x1, self.y1 = x0, y0, x1, y1
+        self.stroke = stroke
+
+    def __iter__(self):
+        return iter(())
+
+
+class _MockContainer:
+    def __init__(self, objs):
+        self._objs = objs
+
+    def __iter__(self):
+        return iter(self._objs)
+
+
+def test_probe_none_layout_is_false():
+    assert layout_has_ruled_lines(None) is False
+
+
+def test_probe_below_threshold_false(monkeypatch):
+    from camelot import image_processing as ip
+
+    monkeypatch.setattr(ip, "LTLine", _MockLTLine)
+    monkeypatch.setattr(ip, "LTContainer", _MockContainer)
+    # 3 lines, default min_lines=4 -> False
+    layout = _MockContainer([_MockLTLine(0, i, 10, i) for i in range(3)])
+    assert layout_has_ruled_lines(layout) is False
+
+
+def test_probe_at_threshold_true(monkeypatch):
+    from camelot import image_processing as ip
+
+    monkeypatch.setattr(ip, "LTLine", _MockLTLine)
+    monkeypatch.setattr(ip, "LTContainer", _MockContainer)
+    layout = _MockContainer([_MockLTLine(0, i, 10, i) for i in range(4)])
+    assert layout_has_ruled_lines(layout) is True
+
+
+def test_probe_custom_threshold(monkeypatch):
+    from camelot import image_processing as ip
+
+    monkeypatch.setattr(ip, "LTLine", _MockLTLine)
+    monkeypatch.setattr(ip, "LTContainer", _MockContainer)
+    layout = _MockContainer([_MockLTLine(0, i, 10, i) for i in range(2)])
+    assert layout_has_ruled_lines(layout, min_lines=2) is True
+    assert layout_has_ruled_lines(layout, min_lines=3) is False
+
+
+def test_lattice_engine_validation():
+    from camelot.parsers.lattice import Lattice
+
+    # Valid values construct fine.
+    for eng in ("raster", "vector", "auto"):
+        assert Lattice(engine=eng).engine == eng
+    # Invalid value rejected at construction.
+    with pytest.raises(ValueError, match="engine must be"):
+        Lattice(engine="opencv")
+
+
+def test_lattice_default_engine_is_raster():
+    from camelot.parsers.lattice import Lattice
+
+    assert Lattice().engine == "raster"
+
+
+def test_explicit_vector_engine_not_yet_implemented(testdir, foo_pdf):
+    """engine='vector' surfaces a clear NotImplementedError pointing at #763."""
+    import camelot
+
+    with pytest.raises(NotImplementedError, match="#763"):
+        camelot.read_pdf(foo_pdf, flavor="lattice", engine="vector")
+
+
+def test_auto_engine_falls_back_to_raster(foo_pdf):
+    """engine='auto' must not raise — it resolves to raster until 2b lands."""
+    import camelot
+
+    tables = camelot.read_pdf(foo_pdf, flavor="lattice", engine="auto")
+    assert len(tables) == 1


### PR DESCRIPTION
Lands the **user-facing surface** for the vector lattice engine ahead of the `_generate_table_bbox` wiring. Pairs with the helpers in #774 (and #764).

## What's added

- **`Lattice(engine='raster'|'vector'|'auto')`** — default `'raster'`, **no behaviour change**. Validated at construction (`ValueError` on anything else).
- **`image_processing.layout_has_ruled_lines(layout, min_lines=4)`** — pure probe: `True` when the layout carries ≥ `min_lines` vector ruled lines (reuses `_ruled_lines_from_layout` from #764). `None` layout → `False`.
- **`Lattice._resolve_engine()`** — decides the effective engine:
  - `'raster'` → raster
  - `'auto'` → probes the layout, records `_vector_lines_available` for diagnostics, but **resolves to raster for now** (vector path not wired — forward-compatible: flip to vector when 2b lands)
  - `'vector'` → surfaces a clear `NotImplementedError` pointing at #763 (the helpers exist, the render-skipping integration is pending)
- `'engine'` added to `utils.lattice_kwargs` (so `validate_input`/`remove_extra` accept it) + documented in `read_pdf`.

## Behaviour today
Default and `'auto'` are **pure raster** (zero change); `'vector'` is reserved with an explicit not-yet-implemented error. So this is safe to ship now — it reserves and validates the API, and 2b only has to (a) flip the `_resolve_engine` `'auto'` return and (b) implement the vector branch in `_generate_table_bbox`.

## Tests
8 tests: probe (None / below / at / custom threshold), engine validation (valid trio + bad value), default-is-raster, `'vector'` raises `NotImplementedError`, `'auto'` falls back to raster cleanly. Probe + validation logic verified standalone locally.

Refs #763. Stacks on #774 (both touch `image_processing.py`); whichever merges second will need a trivial rebase.