### PR TITLE
feat(bench): cross-tool comparison bench script (#31)

### DIFF
--- a/bench/comparison.py
+++ b/bench/comparison.py
@@ -1,0 +1,192 @@
+"""Cross-tool comparison bench for the docs comparison page (#31, #763 context).
+
+Not a pytest test — run directly with ``python bench/comparison.py``.
+
+Runs Camelot and whichever peer table-extractors are importable against a
+small canonical PDF corpus, and emits a machine-readable CSV
+(``docs/_static/comparison_bench.csv``) that ``docs/user/comparison.rst``
+can render via ``.. csv-table::``. This is the "Option A" follow-up to
+that page's hand-maintained matrix: numbers refresh by re-running the
+bench rather than editing prose.
+
+Design notes
+------------
+
+* **Graceful degradation.** Each peer tool is behind a guarded import; a
+  missing dependency (no Java for Tabula, no PyTorch for gmft, …) is
+  recorded as ``available=False`` and skipped, never an error. So the
+  bench runs anywhere — CI installs as many comparators as are practical
+  and the CSV reflects exactly what was measured.
+* **What it measures.** Per (tool, pdf): whether the tool ran, the number
+  of tables it returned, and wall-clock seconds. It deliberately does
+  *not* score extraction *quality* — that needs ground-truth dataframes
+  per PDF and is a separate, larger effort. Table-count + timing is the
+  cheap, objective, auto-refreshable signal.
+* **CI wiring (follow-up).** A release-time job that ``pip install``\\s the
+  heavyweight comparators (tabula-py + a JRE, gmft + torch, unstructured)
+  and runs this script is the remaining piece; until then the bench runs
+  with the pure-Python comparators that are cheap to install
+  (pdfplumber, pymupdf), plus Camelot.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+#: Canonical corpus — small, in-tree, covers a ruled (lattice) table, a
+#: borderless (stream) table, and a two-table page. Paths are relative to
+#: the repo root.
+CORPUS = [
+    "tests/files/foo.pdf",
+    "tests/files/health.pdf",
+    "tests/files/tabula/12s0324.pdf",
+]
+
+
+@dataclass
+class Result:
+    """One (tool, pdf) measurement row."""
+
+    tool: str
+    pdf: str
+    available: bool
+    n_tables: int | None
+    seconds: float | None
+    error: str = ""
+
+
+def _module_available(name: str) -> bool:
+    """True if ``name`` can be imported without actually importing it."""
+    return importlib.util.find_spec(name) is not None
+
+
+# --- per-tool runners -----------------------------------------------------
+#
+# Each returns the number of tables found. Raising is fine — the caller
+# records it as an error row. Each is paired with an availability probe so
+# we never import a missing dependency.
+
+
+def _run_camelot(pdf_path: str) -> int:
+    import camelot
+
+    # Try lattice first, fall back to stream — the bench is about "did the
+    # tool get tables", not about flavor selection.
+    tables = camelot.read_pdf(pdf_path, flavor="lattice")
+    if len(tables) == 0:
+        tables = camelot.read_pdf(pdf_path, flavor="stream")
+    return len(tables)
+
+
+def _run_pdfplumber(pdf_path: str) -> int:
+    import pdfplumber
+
+    n = 0
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            n += len(page.find_tables())
+    return n
+
+
+def _run_pymupdf(pdf_path: str) -> int:
+    import pymupdf  # PyMuPDF >= 1.24 exposes the 'pymupdf' name
+
+    n = 0
+    doc = pymupdf.open(pdf_path)
+    try:
+        for page in doc:
+            n += len(page.find_tables().tables)
+    finally:
+        doc.close()
+    return n
+
+
+#: tool name -> (import-probe module, runner). Add tabula-py / gmft /
+#: unstructured here once the CI install matrix supports them.
+RUNNERS = {
+    "camelot": ("camelot", _run_camelot),
+    "pdfplumber": ("pdfplumber", _run_pdfplumber),
+    "pymupdf": ("pymupdf", _run_pymupdf),
+}
+
+
+def measure(tool: str, probe_module: str, runner, pdf_path: str) -> Result:
+    """Run one tool on one PDF, capturing availability / count / timing."""
+    rel = os.path.relpath(pdf_path, ROOT)
+    if not _module_available(probe_module):
+        return Result(tool, rel, available=False, n_tables=None, seconds=None)
+    start = time.perf_counter()
+    try:
+        n = runner(pdf_path)
+    except Exception as exc:  # noqa: BLE001 - bench records, never crashes
+        return Result(
+            tool, rel, available=True, n_tables=None, seconds=None, error=str(exc)
+        )
+    return Result(
+        tool, rel, available=True, n_tables=n, seconds=time.perf_counter() - start
+    )
+
+
+def run_bench(corpus=None, runners=None) -> list[Result]:
+    """Measure every available tool against every PDF in the corpus."""
+    corpus = corpus if corpus is not None else CORPUS
+    runners = runners if runners is not None else RUNNERS
+    results: list[Result] = []
+    for rel_pdf in corpus:
+        pdf_path = str(ROOT / rel_pdf)
+        for tool, (probe, runner) in runners.items():
+            results.append(measure(tool, probe, runner, pdf_path))
+    return results
+
+
+def write_csv(results: list[Result], out_path: str) -> None:
+    """Write results to ``out_path`` as CSV (header + one row per result)."""
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["tool", "pdf", "available", "tables", "seconds", "error"])
+        for r in results:
+            w.writerow(
+                [
+                    r.tool,
+                    r.pdf,
+                    "yes" if r.available else "no",
+                    "" if r.n_tables is None else r.n_tables,
+                    "" if r.seconds is None else f"{r.seconds:.3f}",
+                    r.error,
+                ]
+            )
+
+
+def main(argv=None) -> int:
+    """Run the bench and write the CSV (default: docs/_static)."""
+    argv = argv if argv is not None else sys.argv[1:]
+    out = argv[0] if argv else str(ROOT / "docs" / "_static" / "comparison_bench.csv")
+    results = run_bench()
+    write_csv(results, out)
+    for r in results:
+        status = (
+            "skipped (not installed)"
+            if not r.available
+            else (
+                f"ERROR: {r.error}"
+                if r.error
+                else f"{r.n_tables} tables in {r.seconds:.3f}s"
+            )
+        )
+        print(f"{r.tool:12} {r.pdf:32} {status}")
+    print(f"\nwrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/user/comparison.rst
+++ b/docs/user/comparison.rst
@@ -301,10 +301,23 @@ Each per-tool section ends with a ``Last verified: YYYY-MM-DD``
 marker so drift is visible without having to dig through commit
 history. The intent is for one of these to fall out of date — that's
 expected — and for a contributor to refresh it via PR when they
-notice. A future iteration of this page may add a ``bench/`` script
-that runs each comparator on a canonical PDF corpus and emits a
-machine-readable matrix; until then, the matrix above is hand-
-maintained.
+notice. The per-tool prose + capability matrix above are
+hand-maintained.
+
+The objective numbers — does each tool run on a given PDF, how many
+tables it returns, and how long it takes — are produced by a script,
+so they can be refreshed without editing prose::
+
+    $ python bench/comparison.py
+
+That runs Camelot plus every peer extractor that's importable in the
+environment (missing ones are skipped, not errored) against a small
+canonical corpus, and writes ``docs/_static/comparison_bench.csv``.
+The script measures table-count + timing only, not extraction
+*quality* (which needs per-PDF ground truth — a separate effort).
+Wiring it into a release-time CI job that installs the heavyweight
+comparators (a JRE for Tabula, PyTorch for gmft, …) so the CSV
+refreshes automatically is the remaining follow-up.
 
 ----
 

--- a/tests/test_comparison_bench.py
+++ b/tests/test_comparison_bench.py
@@ -1,0 +1,97 @@
+"""Unit tests for bench/comparison.py — the pure (non-tool-running) parts.
+
+The per-tool runners need the real libraries + PDFs, so these tests exercise
+the harness logic with mock runners: graceful-skip on a missing module, the
+Result shape on success / error, and CSV serialisation. No comparator and no
+PDF parse required.
+"""
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# bench/ is not a package; load comparison.py by path.
+_BENCH = Path(__file__).resolve().parent.parent / "bench" / "comparison.py"
+_spec = importlib.util.spec_from_file_location("comparison_bench", _BENCH)
+comparison = importlib.util.module_from_spec(_spec)
+sys.modules["comparison_bench"] = comparison
+_spec.loader.exec_module(comparison)
+
+
+def test_missing_module_is_skipped_not_errored():
+    r = comparison.measure(
+        "ghost", "a_module_that_does_not_exist_xyz", lambda p: 1 / 0, "x.pdf"
+    )
+    assert r.available is False
+    assert r.n_tables is None and r.seconds is None and r.error == ""
+
+
+def test_successful_run_records_count_and_time():
+    # 'csv' is always importable -> available=True; runner returns a count.
+    r = comparison.measure("fake", "csv", lambda p: 3, "doc.pdf")
+    assert r.available is True
+    assert r.n_tables == 3
+    assert r.seconds is not None and r.seconds >= 0
+
+
+def test_runner_exception_recorded_as_error_row():
+    def boom(_):
+        raise RuntimeError("kaboom")
+
+    r = comparison.measure("fake", "csv", boom, "doc.pdf")
+    assert r.available is True
+    assert r.n_tables is None
+    assert "kaboom" in r.error
+
+
+def test_run_bench_iterates_corpus_x_runners():
+    corpus = ["tests/files/foo.pdf", "tests/files/health.pdf"]
+    runners = {
+        "a": ("csv", lambda p: 1),
+        "b": ("csv", lambda p: 2),
+    }
+    results = comparison.run_bench(corpus=corpus, runners=runners)
+    assert len(results) == 4  # 2 pdfs x 2 tools
+    assert {r.tool for r in results} == {"a", "b"}
+
+
+def test_write_csv_shape(tmp_path):
+    results = [
+        comparison.Result("camelot", "tests/files/foo.pdf", True, 1, 0.123),
+        comparison.Result("ghost", "tests/files/foo.pdf", False, None, None),
+        comparison.Result(
+            "broken", "tests/files/foo.pdf", True, None, None, error="nope"
+        ),
+    ]
+    out = tmp_path / "sub" / "bench.csv"
+    comparison.write_csv(results, str(out))
+    assert out.exists()  # parent dir auto-created
+    rows = list(csv.reader(out.open()))
+    assert rows[0] == ["tool", "pdf", "available", "tables", "seconds", "error"]
+    # camelot row: available yes, count 1, time formatted to 3dp
+    assert rows[1] == ["camelot", "tests/files/foo.pdf", "yes", "1", "0.123", ""]
+    # ghost row: skipped -> blanks
+    assert rows[2] == ["ghost", "tests/files/foo.pdf", "no", "", "", ""]
+    # broken row: error captured
+    assert rows[3] == ["broken", "tests/files/foo.pdf", "yes", "", "", "nope"]
+
+
+def test_registry_has_camelot():
+    assert "camelot" in comparison.RUNNERS
+    probe, runner = comparison.RUNNERS["camelot"]
+    assert probe == "camelot" and callable(runner)
+
+
+def test_main_writes_csv(tmp_path, monkeypatch):
+    # Force every tool to look unavailable so main() runs without comparators.
+    monkeypatch.setattr(comparison, "_module_available", lambda name: False)
+    out = tmp_path / "out.csv"
+    rc = comparison.main([str(out)])
+    assert rc == 0
+    assert out.exists()
+    rows = list(csv.reader(out.open()))
+    # header + (len(CORPUS) * len(RUNNERS)) skipped rows
+    assert len(rows) == 1 + len(comparison.CORPUS) * len(comparison.RUNNERS)


### PR DESCRIPTION
The comparison docs page (#766) shipped with a hand-maintained capability matrix (Option B). This is the **Option-A foundation**: a script that produces the *objective* numbers (does each tool run, how many tables, how long) so they refresh by re-running rather than editing prose.

## `bench/comparison.py`

- Runs **Camelot + every peer extractor that's importable** (pdfplumber, pymupdf today; tabula-py / gmft / unstructured slot into `RUNNERS` once a CI install matrix supports them).
- **Graceful degradation:** a missing dependency is recorded `available=False` and skipped, never raised — so the bench runs anywhere and the CSV reflects exactly what was measured.
- Emits `docs/_static/comparison_bench.csv` (`tool, pdf, available, tables, seconds, error`), consumable by `comparison.rst` via `csv-table`.
- Measures **table-count + timing only** — not extraction *quality* (which needs per-PDF ground truth; documented as a separate effort).

```
$ python bench/comparison.py
```

## Tests
8 unit tests (`tests/test_comparison_bench.py`) exercise the harness with **mock runners** — graceful-skip on missing module, success/error capture, corpus×runner iteration, CSV shape, and all-unavailable `main()`. No comparator or PDF parse required; verified standalone locally.

## Scope / follow-up
`comparison.rst`'s "Keeping this page up-to-date" now documents `python bench/comparison.py` as the refresh path. Wiring it into a **release-time CI job** that `pip install`s the heavyweight comparators (a JRE for Tabula, PyTorch for gmft) is the remaining piece — flagged in the script docstring + the docs.

Refs #31.