### PR TITLE
fix(bench): clear D301/F401/mypy debt from #777

### DIFF
--- a/bench/comparison.py
+++ b/bench/comparison.py
@@ -22,7 +22,7 @@ Design notes
   *not* score extraction *quality* — that needs ground-truth dataframes
   per PDF and is a separate, larger effort. Table-count + timing is the
   cheap, objective, auto-refreshable signal.
-* **CI wiring (follow-up).** A release-time job that ``pip install``\\s the
+* **CI wiring (follow-up).** A release-time job that pip-installs the
   heavyweight comparators (tabula-py + a JRE, gmft + torch, unstructured)
   and runs this script is the remaining piece; until then the bench runs
   with the pure-Python comparators that are cheap to install

--- a/tests/test_comparison_bench.py
+++ b/tests/test_comparison_bench.py
@@ -11,11 +11,10 @@ import importlib.util
 import sys
 from pathlib import Path
 
-import pytest
-
 # bench/ is not a package; load comparison.py by path.
 _BENCH = Path(__file__).resolve().parent.parent / "bench" / "comparison.py"
 _spec = importlib.util.spec_from_file_location("comparison_bench", _BENCH)
+assert _spec is not None and _spec.loader is not None
 comparison = importlib.util.module_from_spec(_spec)
 sys.modules["comparison_bench"] = comparison
 _spec.loader.exec_module(comparison)


### PR DESCRIPTION
#777's bench files reached master carrying lint/type issues that pre-commit `--all-files` + mypy now flag on every open PR (blocking #771):

- `bench/comparison.py` **D301** — literal backslash in the module docstring (`pip install\\s`); reworded to `pip-installs`.
- `tests/test_comparison_bench.py` **F401** — unused `import pytest` (tests use plain asserts + auto-injected fixtures); removed.
- **mypy** — `spec_from_file_location` returns `ModuleSpec | None` / `.loader` is `Loader | None`; added an `assert` before `module_from_spec`/`exec_module`.

Behaviour unchanged. Unblocks #771.