### PR TITLE
feat(lattice,hybrid): engine='combined' — union vector ruled lines into raster (#763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ changes. **Heads-up if upgrading from 1.0.x**:
 ### Added
 
 - **`engine="combined"`** for `flavor="lattice"` (and the lattice half of
-  `flavor="hybrid"`): unions the PDF's *native vector* ruled lines into the
+  `flavor="hybrid"`): unions the PDF's _native vector_ ruled lines into the
   rasterised OpenCV line masks before contour/joint detection, so tables
   whose rules render faintly (vector strokes, anti-aliasing) are still
   found. Safe by construction — raster always runs, vector lines can only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ changes. **Heads-up if upgrading from 1.0.x**:
 
 ### Added
 
+- **`engine="combined"`** for `flavor="lattice"` (and the lattice half of
+  `flavor="hybrid"`): unions the PDF's *native vector* ruled lines into the
+  rasterised OpenCV line masks before contour/joint detection, so tables
+  whose rules render faintly (vector strokes, anti-aliasing) are still
+  found. Safe by construction — raster always runs, vector lines can only
+  add, so output is never worse than `engine="raster"`. `engine="auto"`
+  now resolves to `combined` when the page carries vector ruled lines,
+  else `raster`. `engine="vector"` (render-free) remains reserved. (#763)
 - **`flavor="auto"`**: render the first requested page, count ruled
   horizontal/vertical lines, pick `lattice` when ruled and `network`
   otherwise. Emits a `UserWarning` naming the chosen flavor. (#737)

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -275,16 +275,22 @@ def read_pdf(
     resolution* : int, optional (default: 300)
         Resolution used for PDF to PNG conversion.
     engine* : str, optional (default: 'raster')
-        Line-detection engine for ``flavor='lattice'``:
+        Line-detection engine for ``flavor='lattice'`` (and the lattice
+        half of ``flavor='hybrid'``):
 
         - ``'raster'`` (default): render the page and detect ruled lines
           with OpenCV — the long-standing behaviour.
-        - ``'auto'``: use the vector engine when the PDF carries native
-          ruled lines, else fall back to raster. (Currently resolves to
-          raster pending the vector pipeline; #763.)
+        - ``'combined'``: run raster detection **and** union in the ruled
+          lines read from the PDF's native vector graphics, so tables
+          whose rules render faintly (vector strokes, anti-aliasing) are
+          still found. Safe by construction — raster always runs, vector
+          lines can only add, so the result is never worse than
+          ``'raster'`` (#763).
+        - ``'auto'``: use ``'combined'`` when the PDF carries native ruled
+          lines, else fall back to ``'raster'`` (#763).
         - ``'vector'``: read ruled lines straight from the PDF's vector
-          graphics, skipping rasterisation. **Not yet wired** — raises
-          ``NotImplementedError`` for now (#763).
+          graphics, skipping rasterisation entirely. **Not yet wired** —
+          raises ``NotImplementedError`` for now (#763).
 
     Returns
     -------

--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -56,6 +56,7 @@ class Hybrid(BaseParser):
         row_tol=2,
         column_tol=0,
         debug=False,
+        engine="raster",
         **kwargs,
     ):
         super().__init__(
@@ -93,6 +94,10 @@ class Hybrid(BaseParser):
             row_tol=row_tol,
             column_tol=column_tol,
             debug=debug,
+            # Forward the line-detection engine so flavor='hybrid' can use
+            # the 'combined' (raster + PDF vector lines) engine for its
+            # lattice half — #763.
+            engine=engine,
         )
 
     def prepare_page_parse(

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
+import cv2
+
 from ..backends import ImageConversionBackend
 from ..image_processing import adaptive_threshold
 from ..image_processing import find_contours
 from ..image_processing import find_joints
 from ..image_processing import find_lines
+from ..image_processing import find_lines_from_layout
 from ..image_processing import layout_has_ruled_lines
 from ..utils import build_file_path_in_temp_dir
 from ..utils import merge_close_lines
@@ -89,6 +92,15 @@ class Lattice(BaseParser):
         Fallback to another backend if unavailable, by default True
     resolution : int, optional (default: 300)
         Resolution used for PDF to PNG conversion.
+    engine : str, optional (default: 'raster')
+        Line-detection engine. ``'raster'`` uses OpenCV on the rendered
+        page (the long-standing behaviour). ``'combined'`` additionally
+        unions the PDF's native vector ruled lines into the line masks
+        before contour/joint detection, recovering tables whose rules
+        render faintly; it is safe by construction (raster always runs,
+        vector lines can only add). ``'auto'`` picks ``'combined'`` when
+        the page carries vector ruled lines, else ``'raster'``.
+        ``'vector'`` (render-free) is reserved and not yet wired (#763).
 
     """
 
@@ -116,11 +128,16 @@ class Lattice(BaseParser):
         engine="raster",
         **kwargs,
     ):
-        if engine not in ("raster", "vector", "auto"):
+        if engine not in ("raster", "vector", "combined", "auto"):
             raise ValueError(
-                f"engine must be 'raster', 'vector' or 'auto', got {engine!r}"
+                "engine must be 'raster', 'vector', 'combined' or 'auto',"
+                f" got {engine!r}"
             )
         self.engine = engine
+        #: Vector ruled lines drawn onto the raster line masks, in image
+        #: coords, accumulated by the 'combined' engine for diagnostics /
+        #: plotting. Populated per page in :meth:`_detect_line_masks`.
+        self._vector_segments: list[tuple[int, int, int, int]] = []
         super().__init__("lattice", replace_text=replace_text)
         self.table_regions = table_regions
         self.table_areas = table_areas
@@ -232,48 +249,134 @@ class Lattice(BaseParser):
     def _resolve_engine(self):
         """Resolve the effective line-detection engine for this page.
 
-        * ``'raster'`` → ``'raster'`` (the OpenCV pipeline).
-        * ``'vector'`` → ``'vector'`` (explicit; not yet wired — see
-          :meth:`_generate_table_bbox`).
-        * ``'auto'``  → ``'vector'`` when the page layout carries enough
-          ruled lines to attempt vector detection, else ``'raster'``.
+        * ``'raster'``   → ``'raster'`` (the OpenCV pipeline only).
+        * ``'combined'`` → ``'combined'`` (raster **plus** the PDF's
+          vector ruled lines unioned into the line masks — #763 Stage 2b).
+        * ``'vector'``   → ``'vector'`` (explicit; the render-free path is
+          not yet wired — see :meth:`_check_engine_supported`).
+        * ``'auto'``     → ``'combined'`` when the page layout carries
+          enough ruled lines for the vector union to help, else
+          ``'raster'``.
 
-        Note: until the vector ``_generate_table_bbox`` path is wired
-        (#763 Stage 2b), ``'auto'`` deliberately resolves to ``'raster'``
-        even when vector lines are present — the probe result is computed
-        for forward-compatibility and diagnostics but the only
-        implemented path is raster. Explicit ``engine='vector'`` is the
-        single value that surfaces the not-yet-implemented state.
+        ``'combined'`` is safe by construction: raster always runs first,
+        so vector lines can only *add* to the detected masks, never
+        remove — a page with no usable vector lines (or a mis-scaled one)
+        yields the same result as ``'raster'``.
         """
         if self.engine == "vector":
             return "vector"
+        if self.engine == "combined":
+            return "combined"
         if self.engine == "auto":
-            # Diagnostic: record whether the vector path *would* apply.
             self._vector_lines_available = layout_has_ruled_lines(
                 getattr(self, "layout", None)
             )
-            # TODO(#763): return "vector" here once 2b is wired.
-            return "raster"
+            return "combined" if self._vector_lines_available else "raster"
         return "raster"
 
     def _check_engine_supported(self):
         """Raise if the resolved engine has no implementation yet.
 
-        Keeps the not-yet-wired ``engine='vector'`` guard out of
-        :meth:`_generate_table_bbox`'s body (a method call, not an inline
-        branch, so it doesn't inflate that method's complexity).
+        Only ``engine='vector'`` (the render-free path) is unimplemented;
+        ``'raster'``, ``'combined'`` and ``'auto'`` are all wired. Keeping
+        the guard in a helper (a call, not an inline branch) keeps
+        :meth:`_generate_table_bbox`'s complexity down.
         """
         if self._resolve_engine() == "vector":
             raise NotImplementedError(
                 "engine='vector' for flavor='lattice' is not wired yet"
-                " (the vector find_lines_from_layout / find_contours_from_lines"
-                " helpers exist, but the _generate_table_bbox integration is"
-                " pending). Use engine='raster' (default) or engine='auto'"
-                " for now. Tracked in #763."
+                " (the render-free path is pending). Use engine='combined'"
+                " to union the PDF's vector ruled lines into the raster"
+                " detection, engine='auto' to do that only when vector"
+                " lines are present, or engine='raster' (default) for the"
+                " OpenCV-only pipeline. Tracked in #763."
             )
+
+    def _augment_masks_with_vector_lines(
+        self,
+        vertical_mask,
+        horizontal_mask,
+        image_scalers,
+    ):
+        """Union the PDF's vector ruled lines into the raster line masks.
+
+        The ``'combined'`` engine (#763) draws the layout's vector ruled
+        lines — converted from PDF to image coords with the same
+        :func:`scale_pdf` the rest of this method uses — onto the OpenCV
+        line masks *before* :func:`find_contours` / :func:`find_joints`.
+        A table whose rules are PDF vector strokes (and therefore render
+        faintly / anti-aliased in the raster) is then found just like a
+        crisply-printed one. The masks are mutated in place; the
+        image-coord vector segments are returned so the caller can append
+        them to the segment lists fed to :func:`scale_image`.
+
+        A ``None`` layout (no vector graphics available) is a no-op.
+        """
+        layout = getattr(self, "layout", None)
+        if layout is None:
+            return [], []
+        v_segments = self._stamp_vector_lines(
+            find_lines_from_layout(layout, direction="vertical"),
+            vertical_mask,
+            image_scalers,
+        )
+        h_segments = self._stamp_vector_lines(
+            find_lines_from_layout(layout, direction="horizontal"),
+            horizontal_mask,
+            image_scalers,
+        )
+        return v_segments, h_segments
+
+    @staticmethod
+    def _stamp_vector_lines(pdf_lines, mask, image_scalers):
+        """Draw PDF-coord lines onto ``mask`` (image coords); return segments."""
+        segments = []
+        for line in pdf_lines:
+            ix0, iy0, ix1, iy1 = scale_pdf(line, image_scalers)
+            # 2px so a crossing v/h pair shares pixels and np.multiply in
+            # find_joints registers the intersection.
+            cv2.line(mask, (ix0, iy0), (ix1, iy1), 255, 2)
+            segments.append((ix0, iy0, ix1, iy1))
+        return segments
+
+    def _detect_line_masks(self, regions, image_scalers, engine):
+        """find_lines for both directions, plus optional vector union.
+
+        Extracted from :meth:`_generate_table_bbox` so the raster +
+        ``'combined'`` mask-building is shared between the table-areas and
+        auto-detect branches (and to keep that method under the
+        complexity limit). Returns
+        ``(vertical_mask, horizontal_mask, vertical_segments,
+        horizontal_segments)`` in image coords.
+        """
+        vertical_mask, vertical_segments = find_lines(
+            self.threshold,
+            regions=regions,
+            direction="vertical",
+            line_scale=self.line_scale,
+            iterations=self.iterations,
+            erode_iterations=self.erode_iterations,
+        )
+        horizontal_mask, horizontal_segments = find_lines(
+            self.threshold,
+            regions=regions,
+            direction="horizontal",
+            line_scale=self.line_scale,
+            iterations=self.iterations,
+            erode_iterations=self.erode_iterations,
+        )
+        if engine == "combined":
+            v_vec, h_vec = self._augment_masks_with_vector_lines(
+                vertical_mask, horizontal_mask, image_scalers
+            )
+            self._vector_segments = v_vec + h_vec
+            vertical_segments = vertical_segments + v_vec
+            horizontal_segments = horizontal_segments + h_vec
+        return vertical_mask, horizontal_mask, vertical_segments, horizontal_segments
 
     def _generate_table_bbox(self):
         self._check_engine_supported()
+        engine = self._resolve_engine()
 
         def scale_areas(areas):
             scaled_areas = []
@@ -314,39 +417,15 @@ class Lattice(BaseParser):
             if self.table_regions is not None:
                 regions = scale_areas(self.table_regions)
 
-            vertical_mask, vertical_segments = find_lines(
-                self.threshold,
-                regions=regions,
-                direction="vertical",
-                line_scale=self.line_scale,
-                iterations=self.iterations,
-                erode_iterations=self.erode_iterations,
-            )
-            horizontal_mask, horizontal_segments = find_lines(
-                self.threshold,
-                regions=regions,
-                direction="horizontal",
-                line_scale=self.line_scale,
-                iterations=self.iterations,
-                erode_iterations=self.erode_iterations,
+            vertical_mask, horizontal_mask, vertical_segments, horizontal_segments = (
+                self._detect_line_masks(regions, image_scalers, engine)
             )
 
             contours = find_contours(vertical_mask, horizontal_mask)
             table_bbox = find_joints(contours, vertical_mask, horizontal_mask)
         else:
-            vertical_mask, vertical_segments = find_lines(
-                self.threshold,
-                direction="vertical",
-                line_scale=self.line_scale,
-                iterations=self.iterations,
-                erode_iterations=self.erode_iterations,
-            )
-            horizontal_mask, horizontal_segments = find_lines(
-                self.threshold,
-                direction="horizontal",
-                line_scale=self.line_scale,
-                iterations=self.iterations,
-                erode_iterations=self.erode_iterations,
+            vertical_mask, horizontal_mask, vertical_segments, horizontal_segments = (
+                self._detect_line_masks(None, image_scalers, engine)
             )
 
             areas = scale_areas(self.table_areas)

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -54,6 +54,41 @@ Pair it with the new ``erode_iterations`` keyword to perform a **morphological c
 
 ``erode_iterations`` defaults to ``0`` (fully backward-compatible with the long-standing dilate-only behaviour). Bump it together with ``iterations`` only when you've confirmed the legacy behaviour leaves phantom rows around your table.
 
+.. _line_detection_engine:
+
+Line-detection engine: raster, combined, auto
+---------------------------------------------
+
+By default :ref:`Lattice <lattice>` finds a table's ruled lines by **rasterising** the page (rendering it to an image) and detecting lines with OpenCV. That works well for scanned or image-based tables, but a PDF that draws its rules as *native vector graphics* carries the exact line coordinates already — and those rules sometimes render faintly or anti-aliased, so the rasteriser misses them.
+
+The ``engine`` keyword lets you choose how lines are detected:
+
+- ``'raster'`` *(default)* — OpenCV on the rendered page. The long-standing behaviour.
+- ``'combined'`` — run raster detection **and** union in the ruled lines read straight from the PDF's vector graphics before the grid is reconstructed. A table whose rules are vector strokes is then found even when it renders faintly.
+- ``'auto'`` — use ``'combined'`` when the page actually carries vector ruled lines, otherwise fall back to ``'raster'``.
+- ``'vector'`` — *(reserved)* read lines only from the vector graphics, skipping rasterisation entirely. Not yet wired; raises ``NotImplementedError`` for now.
+
+.. code-block:: pycon
+
+    >>> # Recover a faintly-ruled vector table that 'raster' misses
+    >>> tables = camelot.read_pdf(
+    ...     'vector_ruled.pdf',
+    ...     flavor='lattice',
+    ...     engine='combined',
+    ... )
+
+``'combined'`` is **safe to try on any lattice PDF**: raster detection always runs first, so the vector lines can only *add* to what was found, never remove it. On a PDF whose rules the rasteriser already detects cleanly, ``engine='combined'`` returns exactly the same tables as ``engine='raster'``.
+
+The same keyword works with ``flavor='hybrid'``, where it drives the lattice half of the hybrid parser:
+
+.. code-block:: pycon
+
+    >>> tables = camelot.read_pdf(
+    ...     'mixed_layout.pdf',
+    ...     flavor='hybrid',
+    ...     engine='combined',
+    ... )
+
 .. _visual_debug:
 Visual debugging
 ----------------

--- a/docs/user/how-it-works.rst
+++ b/docs/user/how-it-works.rst
@@ -40,6 +40,19 @@ Lattice is more deterministic in nature, and it does not rely on guesses. It can
 
 It starts by converting the PDF page to an image using an image conversion backend (default pdfium), and then processes it to get horizontal and vertical line segments by applying a set of morphological transformations (erosion and dilation) using OpenCV.
 
+.. note::
+
+   That image-based (*raster*) line detection is the default. When a PDF
+   draws its rules as native vector graphics, those exact line
+   coordinates are already in the document — and they sometimes render
+   too faintly for the rasteriser to pick up. The ``engine='combined'``
+   option (see :ref:`line_detection_engine`) reads those vector lines
+   directly and **unions** them into the rasterised line masks before the
+   grid below is reconstructed, so faintly-ruled vector tables are still
+   found. Because raster detection always runs first, the vector lines
+   can only add to the result — ``'combined'`` is never worse than the
+   default ``'raster'``.
+
 Let's see how Lattice processes the second page of `this PDF`_, step-by-step.
 
 .. _this PDF: ../_static/pdf/us-030.pdf

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -89,7 +89,7 @@ def test_auto_engine_runs(foo_pdf):
 
 
 def test_combined_engine_matches_raster_on_vector_ruled_pdf(foo_pdf):
-    """combined == raster on foo.pdf.
+    """Combined output equals raster on a crisp vector-ruled PDF.
 
     foo.pdf's ruled lines are crisp vector strokes that the raster
     engine already finds, so unioning the same vector lines in must not

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -59,7 +59,7 @@ def test_lattice_engine_validation():
     from camelot.parsers.lattice import Lattice
 
     # Valid values construct fine.
-    for eng in ("raster", "vector", "auto"):
+    for eng in ("raster", "vector", "combined", "auto"):
         assert Lattice(engine=eng).engine == eng
     # Invalid value rejected at construction.
     with pytest.raises(ValueError, match="engine must be"):
@@ -80,9 +80,45 @@ def test_explicit_vector_engine_not_yet_implemented(testdir, foo_pdf):
         camelot.read_pdf(foo_pdf, flavor="lattice", engine="vector")
 
 
-def test_auto_engine_falls_back_to_raster(foo_pdf):
-    """engine='auto' must not raise — it resolves to raster until 2b lands."""
+def test_auto_engine_runs(foo_pdf):
+    """engine='auto' must not raise — resolves to combined/raster (#763)."""
     import camelot
 
     tables = camelot.read_pdf(foo_pdf, flavor="lattice", engine="auto")
     assert len(tables) == 1
+
+
+def test_combined_engine_matches_raster_on_vector_ruled_pdf(foo_pdf):
+    """combined == raster on foo.pdf.
+
+    foo.pdf's ruled lines are crisp vector strokes that the raster
+    engine already finds, so unioning the same vector lines in must not
+    change the result — this is the strict oracle for the 'combined'
+    integration: if the PDF->image transform or mask drawing were wrong,
+    the cell grid (and thus the DataFrame) would differ.
+    """
+    import camelot
+
+    raster = camelot.read_pdf(foo_pdf, flavor="lattice", engine="raster")
+    combined = camelot.read_pdf(foo_pdf, flavor="lattice", engine="combined")
+    assert len(combined) == len(raster) == 1
+    assert combined[0].df.equals(raster[0].df)
+    assert combined[0].shape == raster[0].shape
+
+
+def test_combined_engine_through_hybrid(foo_pdf):
+    """flavor='hybrid' forwards engine='combined' to its lattice half."""
+    import camelot
+
+    tables = camelot.read_pdf(foo_pdf, flavor="hybrid", engine="combined")
+    assert len(tables) >= 1
+
+
+def test_hybrid_forwards_engine_to_lattice():
+    """Hybrid constructs its Lattice sub-parser with the requested engine."""
+    from camelot.parsers.hybrid import Hybrid
+
+    h = Hybrid(engine="combined")
+    assert h.lattice_parser.engine == "combined"
+    # default stays raster
+    assert Hybrid().lattice_parser.engine == "raster"


### PR DESCRIPTION
Stage 2b of the vector engine (#763), in its **safest** form — reachable through `flavor='hybrid'` too.

Instead of *replacing* the OpenCV pipeline (`engine='vector'`, still reserved), `engine='combined'` runs raster detection as usual and then **unions in** the PDF's native vector ruled lines before `find_contours`/`find_joints`.

**Why it's safe to ship:**
- Raster always runs first → `pdf_image`/`threshold`/scaling/plotting untouched (zero blast radius).
- Vector lines are purely additive → can only *add*, never remove. No usable vector lines (or a mis-scaled one) ⇒ identical to `engine='raster'`.
- Opt-in; default stays `raster`.

**Lattice:** `_resolve_engine` maps `combined→combined`, `auto→combined` when vector lines present (else raster); `vector` still raises. `_augment_masks_with_vector_lines`/`_stamp_vector_lines` draw `find_lines_from_layout()` onto the raster masks via `scale_pdf`; `_detect_line_masks` factors this out of `_generate_table_bbox` (under C901).

**Hybrid:** `__init__` gains `engine=` and forwards to its Lattice sub-parser.

**Tests:** strict oracle `combined == raster` on foo.pdf (`df.equals`+shape); combined via `flavor='hybrid'`; Hybrid forwards engine; validation accepts `combined`.

**Verification:** PDF→image transform verified standalone vs foo.pdf's real bbox (correct y-flip, in-bounds). cv2 drawing not runnable in my env → CI's strict `combined==raster` test is the oracle; the additive/opt-in design means a transform bug fails that test rather than shipping wrong output.

Refs #763.