### PR TITLE
docs(faq): bbox-vs-image coordinates + wrong-package AttributeError

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -80,3 +80,64 @@ When using the :ref:`Lattice <lattice>` flavor, you can supply your own :ref:`im
     >>>         pass
     >>>
     >>> tables = camelot.read_pdf(filename, backend=ConversionBackend())
+
+Why don't a table's bbox coordinates line up with the page image?
+-----------------------------------------------------------------
+
+A ``Table``'s ``_bbox`` (and the coordinates in its cells) live in **PDF
+coordinate space**, while ``table.get_pdf_image()`` returns the page as a
+rendered raster in **image coordinate space**. The two differ in two ways,
+so drawing ``_bbox`` straight onto the image puts the box in the wrong
+place:
+
+- **Origin / direction.** PDF space has its origin at the *bottom-left*
+  with y increasing *upward*; image space has its origin at the
+  *top-left* with y increasing *downward*. The y-axis must be flipped.
+- **Scale.** PDF coordinates are in points (1/72 inch). The image is
+  rendered at a higher resolution (300 dpi by default), so it is roughly
+  ``300/72`` times larger on each axis.
+
+``Table`` exposes the page size as ``table.pdf_size`` ``(width, height)``,
+which together with the rendered image's pixel size gives the per-axis
+scale. To overlay a table's bbox on its page image::
+
+    import camelot
+    import cv2
+
+    tables = camelot.read_pdf("foo.pdf", flavor="lattice")
+    table = tables[0]
+
+    img = table.get_pdf_image()          # rendered raster (BGR)
+    image_h, image_w = img.shape[:2]
+    pdf_w, pdf_h = table.pdf_size
+    scale_x, scale_y = image_w / pdf_w, image_h / pdf_h
+
+    x0, y0, x1, y1 = table._bbox         # PDF coords (origin bottom-left)
+    top_left = (round(x0 * scale_x), round((pdf_h - y1) * scale_y))
+    bottom_right = (round(x1 * scale_x), round((pdf_h - y0) * scale_y))
+
+    cv2.rectangle(img, top_left, bottom_right, (0, 255, 0), 3)
+    cv2.imwrite("foo_bbox.jpg", img)
+
+The same scale-and-flip converts any PDF-space coordinate (a cell, a
+joint) into the image, and inverting it converts an image-space
+coordinate back into PDF space.
+
+I get ``AttributeError: module 'camelot' has no attribute 'read_pdf'``
+----------------------------------------------------------------------
+
+This almost always means the **wrong package** is installed. There is an
+unrelated project on PyPI also called ``camelot`` (a configuration
+library); ``pip install camelot`` installs *that*, not this table-
+extraction library. Uninstall it and install ``camelot-py``::
+
+    $ pip uninstall camelot camelot-py
+    $ pip install "camelot-py[base]"
+
+The import name is still ``camelot`` (``import camelot``) — only the
+*install* name differs (``camelot-py``).
+
+If the right package is installed and you still hit this, check that you
+don't have a local file named ``camelot.py`` (or a ``camelot/`` folder)
+in your working directory shadowing the installed package — rename it and
+try again.


### PR DESCRIPTION
Two recurring questions from the legacy **atlanhq** tracker, neither in the current FAQ. Both still apply to camelot-dev/camelot (verified `_bbox` / `pdf_size` / `get_pdf_image()` are present).

### atlanhq#486 — table bbox doesn't line up with the page image
`_bbox` is **PDF coordinate space** (origin bottom-left, points); `get_pdf_image()` is the **rendered raster** (origin top-left, ~300 dpi). The FAQ now explains the origin/y-flip + per-axis scale and gives a copy-paste overlay snippet using the public `table.pdf_size` + `get_pdf_image()`. (This is the same PDF↔image transform the new `engine='combined'` work in #779 uses internally.)

### atlanhq#377 — `AttributeError: module 'camelot' has no attribute 'read_pdf'`
The classic **wrong-package** install — there's an unrelated PyPI `camelot`. The FAQ now shows the uninstall/reinstall of `camelot-py` and the local `camelot.py` shadowing gotcha.

Docs-only; no code change.