### PR TITLE
test: cover __main__ entrypoint + backend ABC (codecov low-hanging fruit)

### DIFF
--- a/tests/test_backends_base.py
+++ b/tests/test_backends_base.py
@@ -1,0 +1,13 @@
+import pytest
+
+from camelot.backends.base import ConversionBackend
+
+
+def test_conversion_backend_methods_are_abstract():
+    # The base class defines the interface; both methods must raise until a
+    # concrete backend overrides them.
+    backend = ConversionBackend()
+    with pytest.raises(NotImplementedError):
+        backend.installed()
+    with pytest.raises(NotImplementedError):
+        backend.convert("in.pdf", "out.png")

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -1,0 +1,26 @@
+import runpy
+
+import camelot.cli
+
+
+def test_main_invokes_cli(monkeypatch):
+    calls = []
+    monkeypatch.setattr(camelot.cli, "cli", lambda *a, **k: calls.append(True))
+
+    from camelot.__main__ import main
+
+    main()
+
+    assert calls == [True]
+
+
+def test_run_as_module_invokes_cli(monkeypatch):
+    # Executes camelot/__main__.py with __name__ == "__main__" in-process
+    # (the `python -m camelot` path), so the module-level `main()` call under
+    # the `if __name__ == "__main__"` guard is exercised and measured.
+    calls = []
+    monkeypatch.setattr(camelot.cli, "cli", lambda *a, **k: calls.append(True))
+
+    runpy.run_module("camelot.__main__", run_name="__main__")
+
+    assert calls == [True]


### PR DESCRIPTION
Two zero-risk coverage wins from the codecov report (project is at **91.03%**; config targets are already realistic since #729):

| file | before | after |
|------|--------|-------|
| camelot/__main__.py | **0%** (never imported by the suite) | 100% |
| camelot/backends/base.py (ConversionBackend ABC) | 60% | 100% |

- **__main__**: main() invokes cli() (mocked); plus a runpy run with run_name="__main__" so the module-level main() call under the `if __name__ == "__main__"` guard runs in-process (measured, unlike a subprocess).
- **base.py**: exercises the abstract installed()/convert() NotImplementedError branches.

No production code changed. Verified lint + format clean under ruff 0.15.14.