### PR TITLE
docs: add xdoctest examples to read_pdf + TableList

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1178,6 +1178,15 @@ class TableList:
     n : int
         Number of tables in the list.
 
+    Examples
+    --------
+    >>> from camelot.core import TableList
+    >>> tables = TableList([])
+    >>> tables.n
+    0
+    >>> tables
+    <TableList n=0>
+
     """
 
     def __init__(self, tables: Iterable[Table]) -> None:  # noqa D105

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -312,6 +312,21 @@ def read_pdf(
     Supplying the document owner password through ``password=`` bypasses
     the user-password permission set (matches every other PDF tool).
 
+    Examples
+    --------
+    >>> import camelot
+    >>> tables = camelot.read_pdf("foo.pdf")  # xdoctest: +SKIP
+    >>> tables.n  # xdoctest: +SKIP
+    1
+    >>> tables[0].df  # xdoctest: +SKIP
+    >>> tables[0].to_csv("foo.csv")  # xdoctest: +SKIP
+
+    Select a parser and restrict extraction to a page range:
+
+    >>> tables = camelot.read_pdf(  # xdoctest: +SKIP
+    ...     "foo.pdf", flavor="lattice", pages="1-3"
+    ... )
+
     """
     if layout_kwargs is None:
         layout_kwargs = {}


### PR DESCRIPTION
The package had **zero** doctest examples, so the `xdoctest` CI session was passing trivially. This gives it teeth — and since `sphinx.ext.autodoc` + `napoleon` already render these docstrings into `api.rst`, the examples become copy-pasteable API documentation too.

- **TableList** — a fully **runnable** example (`TableList([]).n == 0`, repr `<TableList n=0>`), executed and validated by xdoctest.
- **read_pdf** — a usage example marked `# xdoctest: +SKIP` (it needs a real PDF), so it shows in the API reference without being executed.

(Re: your questions — **autodoc is already implemented**: `sphinx.ext.autodoc` + `napoleon` in `conf.py`, with `api.rst` auto-documenting `read_pdf`/parsers/`Table`/`TableList`/etc. And **xdoctest is already wired** in the noxfile + CI — it just had nothing to run until now.)