### PR TITLE
test(cli): cover matplotlib-missing plot branch for all flavors

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,6 +338,22 @@ def test_version_package_not_found():
         assert get_version() is None
 
 
+@pytest.mark.parametrize("flavor", ["lattice", "stream", "network", "hybrid"])
+def test_cli_plot_without_matplotlib_raises(flavor, testdir, monkeypatch):
+    # When matplotlib isn't available, asking any flavor for a --plot_type
+    # must raise ImportError before parsing. Covers the
+    # `if not _HAS_MPL: raise ImportError` branch in each flavor command —
+    # no existing test reaches it, since matplotlib is installed in CI.
+    import camelot.cli
+
+    monkeypatch.setattr(camelot.cli, "_HAS_MPL", False)
+    infile = os.path.join(testdir, "foo.pdf")
+    runner = CliRunner()
+    result = runner.invoke(cli, [flavor, "--plot_type", "text", infile])
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ImportError)
+
+
 def test_config_set_config():
     """Config.set_config stores values for the cli group's kwargs handoff (#614).
 


### PR DESCRIPTION
Covers the `if not _HAS_MPL: raise ImportError` guard in every flavor command (lattice/stream/network/hybrid) — currently unreached:

- `test_cli_lattice_plot_type` passes **no filepath**, so it errors on the missing argument *before* reaching the guard, and only touches lattice.
- matplotlib is always installed in CI, so the `not _HAS_MPL` branch is never naturally exercised.

The new parametrized test monkeypatches `camelot.cli._HAS_MPL = False` and invokes each flavor with `--plot_type` on a real (but **unparsed** — the guard fires first) PDF, asserting the `ImportError` surfaces.

### Scope note
This is the part of `cli.py` I could target with confidence. The remaining ~19 scattered misses (export branches, format inference edge cases) need the actual `coverage report -m camelot/cli.py` to pinpoint — the codecov line API maps imprecisely to a slightly older revision, and I can't run the suite in my environment to verify a test actually moves a given line. Happy to target them exactly if you run `nox -s coverage` (or `coverage run -m pytest tests/test_cli.py && coverage report -m camelot/cli.py`) and share the missing-line list.