### PR TITLE
fix(core): Table.to_excel writer flush + drop removed encoding kwarg (+ export coverage)

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1002,11 +1002,15 @@ class Table:
         # indices (0, 1, 2, …) for rows and columns, which leak into the
         # Excel output as a meaningless extra row and column. See #634.
         # Users can override by passing index=True / header=True.
-        kw = {"encoding": "utf-8", "index": False, "header": False}
+        # NB: no "encoding" key — pandas >= 2 removed it from to_excel and
+        # passing it raises TypeError.
+        kw = {"index": False, "header": False}
         sheet_name = f"page-{self.page}-table-{self.order}"
         kw.update(kwargs)
-        writer = pd.ExcelWriter(path, mode=mode)
-        self.df.to_excel(writer, sheet_name=sheet_name, **kw)
+        # Context-manage the writer: a bare ExcelWriter that is never closed
+        # leaves the workbook unflushed (empty file) on pandas >= 2.
+        with pd.ExcelWriter(path, mode=mode) as writer:
+            self.df.to_excel(writer, sheet_name=sheet_name, **kw)
 
     def to_html(self, path, **kwargs):
         """Write Table(s) to an HTML file.

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,96 @@
+import sqlite3
+
+import pandas as pd
+import pytest
+
+from camelot.core import Table
+from camelot.core import TableList
+
+
+def _table(data, page=1, order=1):
+    # Minimal parser-free Table: real cols/rows so Cell construction works,
+    # plus the df / page / order the export paths read.
+    cols = [(0, 100), (100, 200)]
+    rows = [(200, 100), (100, 0)]
+    t = Table(cols=cols, rows=rows)
+    t.df = pd.DataFrame(data)
+    t.page = page
+    t.order = order
+    t.shape = t.df.shape
+    return t
+
+
+@pytest.fixture
+def tables():
+    return TableList(
+        [
+            _table([["a", "b"], ["c", "d"]], page=1, order=1),
+            _table([["e", "f"]], page=2, order=1),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "fmt,ext",
+    [("csv", ".csv"), ("json", ".json"), ("html", ".html"), ("markdown", ".md")],
+)
+def test_export_textual_formats(tables, tmp_path, fmt, ext):
+    tables.export(str(tmp_path / f"out{ext}"), f=fmt)
+    # _write_file emits one file per table: "<root>-page-<n>-table-<m><ext>".
+    assert list(tmp_path.glob(f"out-page-*{ext}"))
+
+
+def test_export_excel(tables, tmp_path):
+    out = tmp_path / "out.xlsx"
+    tables.export(str(out), f="excel")
+    assert out.exists()
+    # Both tables land as separate sheets.
+    assert set(pd.ExcelFile(out).sheet_names) == {"page-1-table-1", "page-2-table-1"}
+
+
+def test_export_sqlite(tables, tmp_path):
+    out = tmp_path / "out.sqlite"
+    tables.export(str(out), f="sqlite")
+    assert out.exists()
+    conn = sqlite3.connect(str(out))
+    try:
+        names = [
+            r[0]
+            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        ]
+    finally:
+        conn.close()
+    assert any("page-1" in n for n in names)
+
+
+@pytest.mark.parametrize(
+    "fmt,ext", [("csv", ".csv"), ("excel", ".xlsx"), ("sqlite", ".sqlite")]
+)
+def test_export_compress_makes_zip(tables, tmp_path, fmt, ext):
+    tables.export(str(tmp_path / f"out{ext}"), f=fmt, compress=True)
+    assert (tmp_path / "out.zip").exists()
+
+
+def test_table_to_excel_roundtrip(tmp_path):
+    # Regression: Table.to_excel previously passed encoding= (removed in
+    # pandas >= 2) and never closed the writer, so it raised / wrote an
+    # empty file. It should now produce a readable workbook.
+    t = _table([["x", "y"]])
+    out = tmp_path / "t.xlsx"
+    t.to_excel(str(out))
+    assert out.exists()
+    back = pd.read_excel(out, header=None)
+    assert back.iloc[0, 0] == "x"
+    assert back.iloc[0, 1] == "y"
+
+
+def test_table_to_sqlite(tmp_path):
+    t = _table([["x", "y"]], page=3, order=2)
+    out = tmp_path / "t.sqlite"
+    t.to_sqlite(str(out))
+    conn = sqlite3.connect(str(out))
+    try:
+        rows = conn.execute('SELECT * FROM "page-3-table-2"').fetchall()
+    finally:
+        conn.close()
+    assert rows == [("x", "y")]


### PR DESCRIPTION
While adding export coverage I found **`Table.to_excel` is broken on pandas ≥ 2** — and untested, because `export(f="excel")` inlines its *own* (correct) writer, so the standalone method was never exercised:

1. it passed `encoding="utf-8"` to `DataFrame.to_excel`, which pandas 2.0 **removed** → `TypeError`;
2. it never closed the `ExcelWriter`, so the workbook was left **unflushed** (empty file) on pandas ≥ 2.

**Fix:** context-manage the writer (flush/close) and drop the `encoding` key.

**Coverage** (`tests/test_export.py`): exercises `TableList.export` across **csv / json / html / markdown / excel / sqlite**, the **`compress=True`** ZIP path, and `Table.to_excel` / `to_sqlite` directly — all with synthetic, parser-free tables and real `tmp_path` I/O. This covers the previously-untested export branches in `core.py` (the excel/sqlite/compress arms + `to_excel`/`to_sqlite`) — part of the "more coverage" tier.

Verified lint + format clean under ruff 0.15.14; logic verified against the source (couldn't run pandas locally — CI is the executor).