### PR TITLE
docs(notebook): demo engine='raster' vs 'combined' in parser comparison

### DIFF
--- a/examples/parser-comparison-notebook.ipynb
+++ b/examples/parser-comparison-notebook.ipynb
@@ -249,6 +249,57 @@
     "            )  # Inform user about the skipped table\n",
     "        timer_after_plot = time.perf_counter()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9646e0e3b062",
+   "metadata": {},
+   "source": [
+    "## Line-detection engine: raster vs combined (lattice)\n",
+    "\n",
+    "`flavor='lattice'` (and the lattice half of `flavor='hybrid'`) accept an\n",
+    "`engine=` option (#763):\n",
+    "\n",
+    "- `'raster'` *(default)* — render the page and detect ruled lines with OpenCV.\n",
+    "- `'combined'` — run raster detection **and** union in the ruled lines read\n",
+    "  straight from the PDF's native vector graphics. This recovers tables whose\n",
+    "  rules render faintly (vector strokes / anti-aliasing) and is **never worse\n",
+    "  than `'raster'`** — raster always runs first, vector lines can only add.\n",
+    "- `'auto'` — use `'combined'` when the page carries vector ruled lines, else\n",
+    "  `'raster'`.\n",
+    "\n",
+    "The cell below parses the selected PDF with both engines so you can compare\n",
+    "table counts and accuracy. On a crisply-ruled PDF the two are identical; the\n",
+    "difference shows up on faintly-ruled vector tables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3afe1f2a285e",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare the raster and combined line-detection engines on the lattice parser.\n",
+    "for engine in [\"raster\", \"combined\"]:\n",
+    "    timer = time.perf_counter()\n",
+    "    try:\n",
+    "        tables = camelot.read_pdf(\n",
+    "            filename, flavor=\"lattice\", engine=engine, **kwargs\n",
+    "        )\n",
+    "    except Exception as exc:  # noqa: BLE001 - demo: surface any parse error\n",
+    "        print(f\"engine={engine}: error: {exc}\")\n",
+    "        continue\n",
+    "    elapsed = time.perf_counter() - timer\n",
+    "    print(f\"##### engine={engine}: {tables.n} table(s) in {elapsed:.2f}s #####\")\n",
+    "    for idx, table in enumerate(tables):\n",
+    "        report = table.parsing_report\n",
+    "        print(\n",
+    "            f\"## table {idx}: accuracy={report.get('accuracy', 0):.1f}% \"\n",
+    "            f\"whitespace={report.get('whitespace', 0):.1f}% ##\"\n",
+    "        )\n",
+    "        display(table.df)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds a **"Line-detection engine: raster vs combined"** section to `parser-comparison-notebook` showcasing the lattice `engine=` option shipped in #779.

The new code cell parses the selected PDF with both `engine='raster'` and `engine='combined'` and prints table count + accuracy for each, so the vector-line union is visible side-by-side. The markdown explains raster/combined/auto and the *never-worse-than-raster* guarantee.

Cells carry **no stored output** (matches the notebook's output-stripped convention — 0/5 existing code cells store output) — run it (e.g. in Colab) to populate. Diff is add-only (2 cells appended).

Completes the notebook half of the #763 follow-up.