### PR TITLE
fix(utils): clear error for malformed/zero-area table_areas/regions (#63)

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -382,10 +382,13 @@ class Lattice(BaseParser):
         def scale_areas(areas):
             scaled_areas = []
             for area in areas:
-                # bbox_from_str validates the coordinates (clear error on a
-                # malformed / zero-area box instead of a later ZeroDivision,
-                # #63) and normalises corner order.
-                x1, y1, x2, y2 = bbox_from_str(area)
+                # Validate (clear error on a malformed / zero-area box instead
+                # of a later ZeroDivision, #63) but keep the caller's raw
+                # corner order: scale_pdf + the (x, y, w, h) form below expect
+                # y1 to be the *top* edge, so bbox_from_str's min/max
+                # normalisation must NOT be applied here.
+                bbox_from_str(area)
+                x1, y1, x2, y2 = (float(v) for v in area.split(","))
                 x1, y1, x2, y2 = scale_pdf((x1, y1, x2, y2), image_scalers)
                 scaled_areas.append((x1, y1, abs(x2 - x1), abs(y2 - y1)))
             return scaled_areas

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -14,6 +14,7 @@ from ..image_processing import find_joints
 from ..image_processing import find_lines
 from ..image_processing import find_lines_from_layout
 from ..image_processing import layout_has_ruled_lines
+from ..utils import bbox_from_str
 from ..utils import build_file_path_in_temp_dir
 from ..utils import merge_close_lines
 from ..utils import scale_image
@@ -381,11 +382,10 @@ class Lattice(BaseParser):
         def scale_areas(areas):
             scaled_areas = []
             for area in areas:
-                x1, y1, x2, y2 = area.split(",")
-                x1 = float(x1)
-                y1 = float(y1)
-                x2 = float(x2)
-                y2 = float(y2)
+                # bbox_from_str validates the coordinates (clear error on a
+                # malformed / zero-area box instead of a later ZeroDivision,
+                # #63) and normalises corner order.
+                x1, y1, x2, y2 = bbox_from_str(area)
                 x1, y1, x2, y2 = scale_pdf((x1, y1, x2, y2), image_scalers)
                 scaled_areas.append((x1, y1, abs(x2 - x1), abs(y2 - y1)))
             return scaled_areas

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -495,12 +495,37 @@ def bbox_from_str(bbox_str):
     bbox : tuple
         Tuple (x1, y1, x2, y2).
 
+    Raises
+    ------
+    ValueError
+        If the string isn't four numbers, or describes a zero-area box.
+        The latter is the usual cause of the otherwise cryptic
+        ``ZeroDivisionError`` downstream (#63), commonly because the
+        coordinates came from a top-left-origin tool — PDF space has its
+        origin at the bottom-left, so ``y1`` must be greater than ``y2``.
+
     """
-    x1, y1, x2, y2 = bbox_str.split(",")
-    x1 = float(x1)
-    y1 = float(y1)
-    x2 = float(x2)
-    y2 = float(y2)
+    parts = bbox_str.split(",")
+    if len(parts) != 4:
+        raise ValueError(
+            f"Invalid table area/region {bbox_str!r}: expected four "
+            "comma-separated numbers in the form 'x1,y1,x2,y2'."
+        )
+    try:
+        x1, y1, x2, y2 = (float(p) for p in parts)
+    except ValueError:
+        raise ValueError(
+            f"Invalid table area/region {bbox_str!r}: coordinates must be "
+            "numbers, in the form 'x1,y1,x2,y2'."
+        ) from None
+    if x1 == x2 or y1 == y2:
+        raise ValueError(
+            f"Invalid table area/region {bbox_str!r}: it has zero width or "
+            "height. Use 'x1,y1,x2,y2' where (x1, y1) is the top-left and "
+            "(x2, y2) the bottom-right corner in PDF coordinate space — the "
+            "origin is the bottom-left of the page, so y1 must be greater "
+            "than y2."
+        )
     return (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,11 @@
 import os
 
 import playa.miner as pm
+import pytest
 from playa.miner import LAParams
 from playa.miner import LTTextBoxHorizontal
 
+from camelot.utils import bbox_from_str
 from camelot.utils import bbox_intersection_area
 
 
@@ -175,3 +177,25 @@ def test_get_table_index_text_outside_any_row():
     indices, err = get_table_index(table, textline, direction="horizontal")
     assert indices == []
     assert err == 1.0
+
+
+def test_bbox_from_str_normalises_corner_order():
+    # top-left/bottom-right and the inverted-y form both normalise to
+    # (xmin, ymin, xmax, ymax) — no error for a valid, non-degenerate box.
+    assert bbox_from_str("49,403,568,217") == (49, 217, 568, 403)
+    assert bbox_from_str("49,217,568,403") == (49, 217, 568, 403)
+
+
+def test_bbox_from_str_rejects_zero_area():
+    # Zero width or height is the usual cause of the cryptic downstream
+    # ZeroDivisionError (#63); it must raise a clear, hint-bearing error.
+    for bad in ("49,217,568,217", "100,100,100,400"):
+        with pytest.raises(ValueError, match="zero width or height"):
+            bbox_from_str(bad)
+
+
+def test_bbox_from_str_rejects_malformed():
+    with pytest.raises(ValueError, match="four"):
+        bbox_from_str("1,2,3")
+    with pytest.raises(ValueError, match="must be numbers"):
+        bbox_from_str("a,b,c,d")


### PR DESCRIPTION
Closes #63.

A `table_areas`/`table_regions` string with **zero width or height** surfaced as the cryptic `ZeroDivisionError: float division by zero` deep in parsing — most often because coordinates came from a **top-left-origin** tool (PDF space's origin is bottom-left, so `y1` must be > `y2`). Several people hit this and a 2023 comment explicitly asked for a detectable error + hint.

`bbox_from_str` now validates and raises a clear `ValueError`:
- wrong number of values → *"expected four … 'x1,y1,x2,y2'"*
- non-numeric → *"coordinates must be numbers"*
- **zero-area box** → spells out the coordinate convention (origin bottom-left, `y1 > y2`)

Inverted-but-valid boxes still normalise silently (/) as before — no behaviour change for correct input. Lattice's `scale_areas` (which used a raw `split`) now routes through `bbox_from_str`, so all four flavors share the same validation + corner-order normalisation.

Tests cover normalisation, zero-area rejection, and malformed input (verified standalone — pure function).