### PR TITLE
ci(release-drafter): autolabel PRs by conventional-commit title

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,3 +27,28 @@ template: |
   ## Changes
 
   $CHANGES
+autolabeler:
+  - label: "breaking"
+    title:
+      - "/(^|\\s)\\w+(\\(.*\\))?!:/" # conventional "type!:" breaking marker
+      - "/breaking change/i"
+  - label: "enhancement"
+    title: ["/^feat([(!:]|ure)/i"]
+  - label: "bug"
+    title: ["/^fix[(!:]/i"]
+  - label: "documentation"
+    title: ["/^docs[(:]/i"]
+  - label: "testing"
+    title: ["/^test[(:]/i"]
+  - label: "performance"
+    title: ["/^perf[(:]/i"]
+  - label: "ci"
+    title: ["/^ci[(:]/i"]
+  - label: "style"
+    title: ["/^style[(:]/i"]
+  - label: "refactoring"
+    title: ["/^refactor[(:]/i"]
+  - label: "dependencies"
+    title:
+      - "/^build[(:]/i"
+      - "/^chore\\(deps\\)/i"


### PR DESCRIPTION
Release-drafter categorises notes by **PR label**, but PRs have been merging **unlabeled** (21 since v1.0.9 — including the headline `engine='combined'` / vector-engine series), so they'd land uncategorised in the 2.0 notes.

Adds an `autolabeler` mapping the conventional-commit title prefix → the existing category labels:

| title prefix | label |
|---|---|
| `feat` | enhancement |
| `fix` | bug |
| `docs` | documentation |
| `test` | testing |
| `perf` | performance |
| `ci` | ci |
| `style` | style |
| `refactor` | refactoring |
| `build` / `chore(deps)` | dependencies |
| `type!:` / "breaking change" | breaking |

Future PRs self-label → release-drafter groups them correctly with zero manual upkeep. (I'm retro-labeling the existing 21 unlabeled PRs separately so the 2.0 notes are correct now.)