### PR TITLE
feat(core): TableList.filter() to drop noise/low-quality tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ changes. **Heads-up if upgrading from 1.0.x**:
 
 ### Added
 
+- **`TableList.filter(...)`** — post-extraction convenience to drop noise /
+  low-quality tables by `min_rows`, `min_columns`, `min_accuracy`,
+  `max_whitespace`. Returns a new `TableList` (composable); all thresholds
+  default to a no-op so nothing is dropped unless asked.
 - **`engine="combined"`** for `flavor="lattice"` (and the lattice half of
   `flavor="hybrid"`): unions the PDF's _native vector_ ruled lines into the
   rasterised OpenCV line masks before contour/joint detection, so tables

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1227,6 +1227,53 @@ class TableList:
         """The number of tables in the list."""
         return len(self)
 
+    def filter(
+        self,
+        min_rows: int = 1,
+        min_columns: int = 1,
+        min_accuracy: float = 0.0,
+        max_whitespace: float = 100.0,
+    ) -> TableList:
+        """Return a new TableList keeping only tables that pass all thresholds.
+
+        A post-extraction convenience for dropping noise / low-quality
+        tables (single stray cells, mostly-empty regions, …). Parsing is
+        unchanged — everything is still detected; this just selects from
+        the result. Every threshold defaults to a no-op, so calling
+        ``filter()`` with no arguments returns an equivalent list and a
+        legitimate single-row or single-column table is never dropped
+        unless you ask for it.
+
+        Parameters
+        ----------
+        min_rows : int, optional (default: 1)
+            Drop tables with fewer than this many rows.
+        min_columns : int, optional (default: 1)
+            Drop tables with fewer than this many columns.
+        min_accuracy : float, optional (default: 0.0)
+            Drop tables whose ``parsing_report`` accuracy (0-100) is below
+            this value.
+        max_whitespace : float, optional (default: 100.0)
+            Drop tables whose ``parsing_report`` whitespace (0-100) is
+            above this value.
+
+        Returns
+        -------
+        camelot.core.TableList
+            A new list (the original is left untouched), so calls compose:
+            ``tables.filter(min_rows=2).filter(min_accuracy=90)``.
+
+        """
+        kept = [
+            table
+            for table in self._tables
+            if table.shape[0] >= min_rows
+            and table.shape[1] >= min_columns
+            and table.accuracy >= min_accuracy
+            and table.whitespace <= max_whitespace
+        ]
+        return TableList(kept)
+
     def stack_contiguous(
         self,
         match: str = "column_count",

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -89,6 +89,28 @@ The same keyword works with ``flavor='hybrid'``, where it drives the lattice hal
     ...     engine='combined',
     ... )
 
+.. _filter_tables:
+
+Filter out noise tables
+-----------------------
+
+Detection sometimes returns small or low-quality "tables" — a stray single
+cell, a mostly-empty region, a heading mistaken for a 1x1 grid. :meth:`TableList.filter() <camelot.core.TableList.filter>` keeps only the tables that pass the thresholds you give and returns a new :class:`~camelot.core.TableList`; extraction itself is unchanged.
+
+.. code-block:: pycon
+
+    >>> tables = camelot.read_pdf('noisy.pdf')
+    >>> # keep tables with at least 2 rows and 2 columns
+    >>> real = tables.filter(min_rows=2, min_columns=2)
+    >>> # …or filter on parsing quality, and compose freely
+    >>> good = tables.filter(min_accuracy=90).filter(max_whitespace=50)
+
+Every threshold defaults to a no-op (``min_rows=1``, ``min_columns=1``,
+``min_accuracy=0``, ``max_whitespace=100``), so a legitimate single-row or
+single-column table is never dropped unless you ask for it. ``accuracy`` and
+``whitespace`` are the same 0–100 values reported in
+:attr:`Table.parsing_report <camelot.core.Table.parsing_report>`.
+
 .. _visual_debug:
 Visual debugging
 ----------------

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,58 @@
+from camelot.core import Table
+from camelot.core import TableList
+
+
+def _table(rows, cols, accuracy=99.0, whitespace=0.0):
+    # Minimal Table: filter() only reads .shape / .accuracy / .whitespace,
+    # so set those directly (real cell geometry is irrelevant here).
+    t = Table(cols=[(0, 1)], rows=[(1, 0)])
+    t.shape = (rows, cols)
+    t.accuracy = accuracy
+    t.whitespace = whitespace
+    return t
+
+
+def test_filter_defaults_keep_everything():
+    tables = TableList([_table(1, 1), _table(5, 3)])
+    out = tables.filter()
+    assert isinstance(out, TableList)
+    assert out.n == 2
+
+
+def test_filter_min_rows_and_columns():
+    tables = TableList([_table(1, 4), _table(4, 1), _table(4, 4)])
+    assert tables.filter(min_rows=2).n == 2  # drops the 1-row table
+    assert tables.filter(min_columns=2).n == 2  # drops the 1-col table
+    assert tables.filter(min_rows=2, min_columns=2).n == 1  # only 4x4
+
+
+def test_filter_accuracy_and_whitespace():
+    tables = TableList(
+        [
+            _table(3, 3, accuracy=95.0, whitespace=10.0),
+            _table(3, 3, accuracy=40.0, whitespace=10.0),
+            _table(3, 3, accuracy=95.0, whitespace=80.0),
+        ]
+    )
+    assert tables.filter(min_accuracy=80.0).n == 2
+    assert tables.filter(max_whitespace=50.0).n == 2
+    assert tables.filter(min_accuracy=80.0, max_whitespace=50.0).n == 1
+
+
+def test_filter_returns_new_list_and_composes():
+    tables = TableList([_table(1, 1), _table(5, 5, accuracy=99.0)])
+    filtered = tables.filter(min_rows=2).filter(min_accuracy=90.0)
+    assert filtered.n == 1
+    # original untouched
+    assert tables.n == 2
+
+
+def test_filter_thresholds_are_inclusive():
+    tables = TableList([_table(2, 2, accuracy=80.0, whitespace=50.0)])
+    # boundary values must be kept (>= / <=)
+    assert (
+        tables.filter(
+            min_rows=2, min_columns=2, min_accuracy=80.0, max_whitespace=50.0
+        ).n
+        == 1
+    )


### PR DESCRIPTION
Post-extraction convenience requested in discussion — a clean, composable way to drop noise / low-quality tables.

```python
tables = camelot.read_pdf("noisy.pdf")
real = tables.filter(min_rows=2, min_columns=2)
good = tables.filter(min_accuracy=90).filter(max_whitespace=50)
```

- **Post-hoc** method on `TableList` — parsing is unchanged; this just selects from the result (extraction and filtering stay decoupled).
- Returns a **new** `TableList` (original untouched) → calls compose.
- **All thresholds default to a no-op** (`min_rows=1`, `min_columns=1`, `min_accuracy=0`, `max_whitespace=100`), so a legitimate single-row/single-column table is never dropped unless asked — addresses the concern in #579 (someone who *wanted* a 1-row table).
- Subsumes the accuracy/whitespace filtering users were hand-rolling, and adds row/column-count filtering.

Autodoc renders it on the `TableList` API page; `advanced.rst` gains a "Filter out noise tables" section; CHANGELOG updated. 5 unit tests (synthetic tables) cover defaults, row/col, accuracy/whitespace, composition, and inclusive boundaries.

Targeting 2.0 (small, self-contained; rc soak gives runway). CLI flags (`--min-rows`, …) are a possible follow-up — left out here to avoid 16 repetitive option decorators across the 4 flavor commands.