### PR TITLE
docs(readme): feature list, uv-first install, fix backend/link; add tablers to comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@
 
 **Camelot** is a Python library that can help you extract tables from PDFs.
 
+## Features
+
+- 📊 **Four parsers** — `lattice` (ruled tables), `stream` (whitespace), and the text-alignment `network` / `hybrid`, plus `flavor="auto"` to pick one for you.
+- 🧠 **Vector + raster line detection** — `engine="combined"` unions the PDF's native vector ruled lines with OpenCV detection, so faintly-ruled tables are still found.
+- 🐼 **pandas output** — every table is a `DataFrame`, ready for analysis.
+- 📤 **Many export formats** — CSV, JSON, Excel, HTML, Markdown, and SQLite.
+- 📐 **Quality metrics** — accuracy, whitespace, and a confidence score per table; drop noise with `TableList.filter(...)`.
+- 🧩 **Multi-page tables** — stitch continuations across pages with `stack_contiguous()`.
+- 🎛️ **Highly configurable** — table areas/regions, column separators, text processing, and more.
+- 🔌 **Flexible input** — a file path, URL, raw `bytes`, or any binary file-like object.
+- 🖥️ **CLI included** — `camelot lattice file.pdf`, etc.
+- 📦 **Light install** — the default pdfium backend is bundled, with no system dependencies.
+
 ---
 
 **Extract tables from PDFs in just a few lines of code:**
@@ -63,42 +76,47 @@ You can check out some frequently asked questions [here](https://camelot-py.read
 - **Metrics**: You can discard bad tables based on metrics like accuracy and whitespace, without having to manually look at each table.
 - **Output**: Each table is extracted into a **pandas DataFrame**, which seamlessly integrates into [ETL and data analysis workflows](https://gist.github.com/vinayak-mehta/e5949f7c2410a0e12f25d3682dc9e873). You can also export tables to multiple formats, which include CSV, JSON, Excel, HTML, Markdown, and Sqlite.
 
-See [comparison with similar libraries and tools](https://github.com/camelot-dev/camelot/wiki/Comparison-with-other-PDF-Table-Extraction-libraries-and-tools).
+See [comparison with similar libraries and tools](https://camelot-py.readthedocs.io/en/latest/user/comparison.html).
 
 ## Installation
 
-### Using conda
+Camelot's default image-conversion backend is [pdfium](https://pypi.org/project/pypdfium2/), which ships as a wheel — so a plain install needs **no system dependencies**. The optional [ghostscript](https://www.ghostscript.com/) and poppler backends require [additional dependencies](https://camelot-py.readthedocs.io/en/latest/user/install-deps.html).
 
-The easiest way to install Camelot is with [conda](https://conda.io/docs/), which is a package manager and environment management system for the [Anaconda](http://docs.continuum.io/anaconda/) distribution.
+### Using uv
+
+[uv](https://docs.astral.sh/uv/) is a fast Python package and project manager. To add Camelot to a project:
 
 ```bash
-conda install -c conda-forge camelot-py
+uv add camelot-py
+```
+
+Or to install it into the current environment:
+
+```bash
+uv pip install camelot-py
 ```
 
 ### Using pip
-
-You can also use pip to install Camelot:
 
 ```bash
 pip install "camelot-py"
 ```
 
-Note that [additional dependencies](https://camelot-py.readthedocs.io/en/latest/user/install-deps.html) may be required if you want to use the non-default backend [ghostscript](https://www.ghostscript.com/).
+### Using conda
+
+[conda](https://conda.io/docs/) is the package manager for the [Anaconda](http://docs.continuum.io/anaconda/) distribution:
+
+```bash
+conda install -c conda-forge camelot-py
+```
 
 ### From the source code
 
 ```bash
 git clone https://github.com/camelot-dev/camelot.git
-```
-
-and install using pip:
-
-```
 cd camelot
-pip install "."
+uv pip install "."  # or: pip install "."
 ```
-
-Note that [additional dependencies](https://camelot-py.readthedocs.io/en/latest/user/install-deps.html) may be required if you want to use the non-default backend [ghostscript](https://www.ghostscript.com/).
 
 ## Documentation
 
@@ -107,10 +125,6 @@ The documentation is available at [http://camelot-py.readthedocs.io/](http://cam
 ## Wrappers
 
 - [camelot-php](https://github.com/randomstate/camelot-php) provides a [PHP](https://www.php.net/) wrapper on Camelot.
-
-## Related projects
-
-- [camelot-sharp](https://github.com/BobLd/camelot-sharp) provides a C sharp implementation of Camelot.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ uv pip install "."  # or: pip install "."
 
 The documentation is available at [http://camelot-py.readthedocs.io/](http://camelot-py.readthedocs.io/).
 
-## Wrappers
-
-- [camelot-php](https://github.com/randomstate/camelot-php) provides a [PHP](https://www.php.net/) wrapper on Camelot.
-
 ## Contributing
 
 The [Contributor's Guide](https://camelot-py.readthedocs.io/en/latest/dev/contributing.html) has detailed information about contributing issues, documentation, code, and tests.

--- a/docs/user/comparison.rst
+++ b/docs/user/comparison.rst
@@ -42,6 +42,7 @@ workaround required".
             <th scope="col">PyMuPDF</th>
             <th scope="col">gmft</th>
             <th scope="col">unstructured.io</th>
+            <th scope="col">tablers</th>
           </tr>
         </thead>
         <tbody>
@@ -53,6 +54,7 @@ workaround required".
             <td>AGPL / commercial</td>
             <td>MIT</td>
             <td>Apache 2.0</td>
+            <td>MIT</td>
           </tr>
           <tr>
             <th scope="row">Runtime</th>
@@ -62,6 +64,7 @@ workaround required".
             <td>C binding</td>
             <td>PyTorch model</td>
             <td>Python + plugins</td>
+            <td>Rust + Python</td>
           </tr>
           <tr>
             <th scope="row">Ruled-grid tables</th>
@@ -71,6 +74,7 @@ workaround required".
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-yes" title="model-based">&#10003;</span></td>
             <td><span class="cm-partial" title="via backend">&#9680;</span></td>
+            <td><span class="cm-yes" title="line/rect edge detection">&#10003;</span></td>
           </tr>
           <tr>
             <th scope="row">Borderless / whitespace tables</th>
@@ -80,6 +84,7 @@ workaround required".
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-no" title="edge-based detection">&#10007;</span></td>
           </tr>
           <tr>
             <th scope="row">Per-page kwarg overrides</th>
@@ -87,6 +92,7 @@ workaround required".
             <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-partial" title="manual loop">&#9680;</span></td>
             <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
           </tr>
@@ -98,6 +104,7 @@ workaround required".
             <td><span class="cm-partial" title="via OCR plugin">&#9680;</span></td>
             <td><span class="cm-yes" title="vision model">&#10003;</span></td>
             <td><span class="cm-yes" title="Tesseract plugin">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
           </tr>
           <tr>
             <th scope="row">Confidence score per table</th>
@@ -106,6 +113,7 @@ workaround required".
             <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-partial" title="heuristic">&#9680;</span></td>
             <td><span class="cm-yes" title="model score">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
           </tr>
           <tr>
@@ -116,6 +124,7 @@ workaround required".
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
+            <td><span class="cm-no" title="not documented">&#10007;</span></td>
           </tr>
           <tr>
             <th scope="row">Multi-page table stitching</th>
@@ -125,6 +134,7 @@ workaround required".
             <td><span class="cm-partial">&#9680;</span></td>
             <td><span class="cm-yes" title="model-aware">&#10003;</span></td>
             <td><span class="cm-partial">&#9680;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
           </tr>
           <tr>
             <th scope="row">Heavy native deps</th>
@@ -134,6 +144,7 @@ workaround required".
             <td>mupdf (vendored)</td>
             <td>PyTorch (+ GPU)</td>
             <td>varies</td>
+            <td>none (Rust/pdfium bundled)</td>
           </tr>
         </tbody>
       </table>
@@ -275,6 +286,28 @@ elements (Title, NarrativeText, Table, …).
   JSON / SQLite / Markdown.
 
 *Last verified: 2026-05-21 against unstructured 0.16.x.*
+
+tablers
+-------
+
+`tablers <https://github.com/monchin/tablers>`_ is a young, MIT-licensed
+extractor with its core algorithms written in **Rust** (exposed to Python
+via PyO3) and PDF handling through pdfium — so it installs with no external
+Python dependencies and is built for speed.
+
+* **When tablers wins.** Throughput on **ruled** tables — it detects
+  tables from line/rectangle edges and is designed to be very fast, with
+  lazy page loading for large files. If your PDFs are consistently
+  ruled and speed matters, it's worth a look.
+* **When Camelot wins.** Breadth: borderless / whitespace tables
+  (``stream`` / ``network`` / ``hybrid``), the vector+raster
+  ``engine="combined"``, per-table ``accuracy`` / ``whitespace`` /
+  ``confidence`` metrics with :meth:`TableList.filter`, multi-page
+  stitching, and pandas-DataFrame output. tablers currently focuses on
+  edge-detected tables and exports to CSV / Markdown / HTML.
+
+*Last verified: 2026-05-21 against the tablers README (project is new;
+assessed from its documented features rather than a benchmark run).*
 
 Tools we no longer compare against
 -----------------------------------


### PR DESCRIPTION
README polish (inspired by the clean [tablers](https://github.com/monchin/tablers) README) + comparison-page update.

### README
- **Features list** — a scannable, emoji-bulleted summary near the top (four parsers, `engine="combined"`, pandas output, exports, metrics + `TableList.filter`, multi-page stitching, configurability, flexible input, CLI, light install).
- **Installation reworked** — leads with **uv** (`uv add camelot-py` / `uv pip install camelot-py`), then pip, then conda, then source. States up front that the **default pdfium backend is bundled (no system deps)** and ghostscript/poppler are optional. (The old text already said ghostscript is *non-default* — now it's explicit that pdfium is the default.)
- **Comparison link** → the [ReadTheDocs comparison page](https://camelot-py.readthedocs.io/en/latest/user/comparison.html) (was the old wiki link).
- **Removed the "Related projects" section** — its only entry, `camelot-sharp`, has been archived for ~6 years.

### Comparison page
- Added **tablers** as a 7th matrix column + a per-tool section: a new MIT, **Rust-core** (PyO3) extractor on pdfium — fast on **ruled** tables with no external Python deps. Notes where Camelot wins (borderless/whitespace tables, the combined engine, per-table metrics + `filter`, multi-page stitching, DataFrame output). Footer flags it's assessed from the README (project is new), consistent with the page's "Last verified" convention.