### PR TITLE
feat(lattice): wire engine='vector' — render-free table detection (#763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,11 @@ changes. **Heads-up if upgrading from 1.0.x**:
   found. Safe by construction — raster always runs, vector lines can only
   add, so output is never worse than `engine="raster"`. `engine="auto"`
   now resolves to `combined` when the page carries vector ruled lines,
-  else `raster`. `engine="vector"` (render-free) remains reserved. (#763)
+  else `raster`. (#763)
+- **`engine="vector"`** for `flavor="lattice"`: detects tables purely from
+  the PDF's native vector ruled lines, **skipping page rasterisation and
+  OpenCV entirely** — the fastest path for PDFs whose tables are drawn
+  with real vector strokes. (#763)
 - **`flavor="auto"`**: render the first requested page, count ruled
   horizontal/vertical lines, pick `lattice` when ruled and `network`
   otherwise. Emits a `UserWarning` naming the chosen flavor. (#737)

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -288,9 +288,9 @@ def read_pdf(
           ``'raster'`` (#763).
         - ``'auto'``: use ``'combined'`` when the PDF carries native ruled
           lines, else fall back to ``'raster'`` (#763).
-        - ``'vector'``: read ruled lines straight from the PDF's vector
-          graphics, skipping rasterisation entirely. **Not yet wired** —
-          raises ``NotImplementedError`` for now (#763).
+        - ``'vector'``: detect tables straight from the PDF's vector ruled
+          lines, skipping rasterisation entirely — the fastest path, for
+          PDFs whose tables are drawn with real vector strokes (#763).
 
     Returns
     -------

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -8,12 +8,15 @@ from typing import Any
 import cv2
 
 from ..backends import ImageConversionBackend
+from ..image_processing import _line_crossing
 from ..image_processing import adaptive_threshold
 from ..image_processing import find_contours
 from ..image_processing import find_joints
+from ..image_processing import find_joints_from_lines
 from ..image_processing import find_lines
 from ..image_processing import find_lines_from_layout
 from ..image_processing import layout_has_ruled_lines
+from ..utils import bbox_from_str
 from ..utils import build_file_path_in_temp_dir
 from ..utils import merge_close_lines
 from ..utils import scale_image
@@ -21,6 +24,40 @@ from ..utils import scale_pdf
 from ..utils import segments_in_bbox
 from ..utils import text_in_bbox_per_axis
 from .base import BaseParser
+
+
+def _line_in_any_bbox(line, bboxes):
+    """True if a ruled line's extent overlaps any of the given bboxes.
+
+    Used by the vector engine to keep only lines relevant to the
+    user-supplied ``table_regions``. ``line`` is ``(x0, y0, x1, y1)`` and
+    each bbox is ``(x0, y0, x1, y1)`` = (left, bottom, right, top), both in
+    PDF coords.
+    """
+    lx0, ly0, lx1, ly1 = line
+    lxmin, lxmax = (lx0, lx1) if lx0 <= lx1 else (lx1, lx0)
+    lymin, lymax = (ly0, ly1) if ly0 <= ly1 else (ly1, ly0)
+    for x0, y0, x1, y1 in bboxes:
+        if lxmax >= x0 and lxmin <= x1 and lymax >= y0 and lymin <= y1:
+            return True
+    return False
+
+
+def _joints_in_bbox(h_lines, v_lines, bbox):
+    """Line crossings (joints) that fall inside ``bbox`` (PDF coords).
+
+    The vector engine's equivalent of the raster ``find_joints`` over a
+    user-supplied ``table_areas`` box: every h/v line intersection within
+    the box becomes a joint.
+    """
+    x0, y0, x1, y1 = bbox
+    joints = []
+    for h in h_lines:
+        for v in v_lines:
+            pt = _line_crossing(h, v)
+            if pt is not None and x0 <= pt[0] <= x1 and y0 <= pt[1] <= y1:
+                joints.append(pt)
+    return joints
 
 
 class Lattice(BaseParser):
@@ -100,7 +137,9 @@ class Lattice(BaseParser):
         render faintly; it is safe by construction (raster always runs,
         vector lines can only add). ``'auto'`` picks ``'combined'`` when
         the page carries vector ruled lines, else ``'raster'``.
-        ``'vector'`` (render-free) is reserved and not yet wired (#763).
+        ``'vector'`` detects tables purely from the PDF's vector ruled
+        lines, skipping rasterisation entirely — fastest, for PDFs whose
+        tables are drawn with real vector strokes (#763).
 
     """
 
@@ -252,8 +291,9 @@ class Lattice(BaseParser):
         * ``'raster'``   → ``'raster'`` (the OpenCV pipeline only).
         * ``'combined'`` → ``'combined'`` (raster **plus** the PDF's
           vector ruled lines unioned into the line masks — #763 Stage 2b).
-        * ``'vector'``   → ``'vector'`` (explicit; the render-free path is
-          not yet wired — see :meth:`_check_engine_supported`).
+        * ``'vector'``   → ``'vector'`` (render-free: detect tables from
+          the PDF's vector ruled lines without rasterising the page — see
+          :meth:`_generate_table_bbox_vector`).
         * ``'auto'``     → ``'combined'`` when the page layout carries
           enough ruled lines for the vector union to help, else
           ``'raster'``.
@@ -273,24 +313,6 @@ class Lattice(BaseParser):
             )
             return "combined" if self._vector_lines_available else "raster"
         return "raster"
-
-    def _check_engine_supported(self):
-        """Raise if the resolved engine has no implementation yet.
-
-        Only ``engine='vector'`` (the render-free path) is unimplemented;
-        ``'raster'``, ``'combined'`` and ``'auto'`` are all wired. Keeping
-        the guard in a helper (a call, not an inline branch) keeps
-        :meth:`_generate_table_bbox`'s complexity down.
-        """
-        if self._resolve_engine() == "vector":
-            raise NotImplementedError(
-                "engine='vector' for flavor='lattice' is not wired yet"
-                " (the render-free path is pending). Use engine='combined'"
-                " to union the PDF's vector ruled lines into the raster"
-                " detection, engine='auto' to do that only when vector"
-                " lines are present, or engine='raster' (default) for the"
-                " OpenCV-only pipeline. Tracked in #763."
-            )
 
     def _augment_masks_with_vector_lines(
         self,
@@ -375,8 +397,10 @@ class Lattice(BaseParser):
         return vertical_mask, horizontal_mask, vertical_segments, horizontal_segments
 
     def _generate_table_bbox(self):
-        self._check_engine_supported()
         engine = self._resolve_engine()
+        if engine == "vector":
+            self._generate_table_bbox_vector()
+            return
 
         def scale_areas(areas):
             scaled_areas = []
@@ -435,12 +459,60 @@ class Lattice(BaseParser):
             scale_image(table_bbox, vertical_segments, horizontal_segments, pdf_scalers)
         )
 
+        self._compute_table_anchors()
+
+    def _generate_table_bbox_vector(self):
+        """Detect tables from the PDF's vector ruled lines — no rasterisation.
+
+        The render-free ``engine='vector'`` path (#763): read ruled lines
+        from the page layout (already in PDF coordinate space), cluster
+        them into table bounding boxes + joints with the vector-native
+        :func:`find_joints_from_lines`, and build the same
+        ``table_bbox_parses`` structure the raster path produces — but
+        skipping the page render, adaptive threshold, and OpenCV
+        morphology entirely. ``pdf_image`` / ``threshold`` stay ``None``
+        (extraction never needs them; only the debug plots do).
+        """
+        layout = getattr(self, "layout", None)
+        h_lines = find_lines_from_layout(layout, "horizontal") if layout else []
+        v_lines = find_lines_from_layout(layout, "vertical") if layout else []
+
+        if self.table_regions is not None:
+            regions = [bbox_from_str(r) for r in self.table_regions]
+            h_lines = [ln for ln in h_lines if _line_in_any_bbox(ln, regions)]
+            v_lines = [ln for ln in v_lines if _line_in_any_bbox(ln, regions)]
+
+        self.pdf_image = None
+        self.threshold = None
+        self.vertical_segments = v_lines
+        self.horizontal_segments = h_lines
+
+        if self.table_areas is not None:
+            areas = [bbox_from_str(a) for a in self.table_areas]
+            joints_by_bbox = {
+                area: _joints_in_bbox(h_lines, v_lines, area) for area in areas
+            }
+        else:
+            joints_by_bbox = find_joints_from_lines(h_lines, v_lines)
+
+        self.table_bbox_parses = {
+            bbox: {"joints": joints} for bbox, joints in joints_by_bbox.items()
+        }
+        self._compute_table_anchors()
+
+    def _compute_table_anchors(self):
+        """Derive col/row anchors from each table's joints (raster + vector).
+
+        Operates in place on ``self.table_bbox_parses`` — shared by both
+        the raster/combined and the vector paths, which differ only in how
+        the ``{bbox: {"joints": [...]}}`` mapping is built.
+        """
+        line_tol = self.line_tol
         for bbox, parse in self.table_bbox_parses.items():
             joints = parse["joints"]
 
-            # Merge x coordinates that are close together
-            line_tol = self.line_tol
-            # Sort the joints, make them a list of lists (instead of sets)
+            # Merge x coordinates that are close together. Sort the joints,
+            # make them a list of lists (instead of sets).
             joints_normalized = list(
                 map(lambda x: list(x), sorted(joints, key=lambda j: -j[0]))
             )
@@ -462,8 +534,6 @@ class Lattice(BaseParser):
                 if y_bottom - line_tol <= y_top <= y_bottom + line_tol:
                     joints_normalized[idx][1] = y_bottom
 
-            # TODO: check this is useful, otherwise get rid of the code
-            # above
             parse["joints_normalized"] = joints_normalized
 
             cols = list(map(lambda coords: coords[0], joints))

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -66,7 +66,7 @@ The ``engine`` keyword lets you choose how lines are detected:
 - ``'raster'`` *(default)* — OpenCV on the rendered page. The long-standing behaviour.
 - ``'combined'`` — run raster detection **and** union in the ruled lines read straight from the PDF's vector graphics before the grid is reconstructed. A table whose rules are vector strokes is then found even when it renders faintly.
 - ``'auto'`` — use ``'combined'`` when the page actually carries vector ruled lines, otherwise fall back to ``'raster'``.
-- ``'vector'`` — *(reserved)* read lines only from the vector graphics, skipping rasterisation entirely. Not yet wired; raises ``NotImplementedError`` for now.
+- ``'vector'`` — detect tables purely from the PDF's vector ruled lines, skipping rasterisation entirely. The fastest engine (no page render, no OpenCV), for PDFs whose tables are drawn with real vector strokes. A page with no vector ruled lines yields no tables, so prefer ``'auto'`` / ``'combined'`` for mixed documents.
 
 .. code-block:: pycon
 

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -72,12 +72,29 @@ def test_lattice_default_engine_is_raster():
     assert Lattice().engine == "raster"
 
 
-def test_explicit_vector_engine_not_yet_implemented(testdir, foo_pdf):
-    """engine='vector' surfaces a clear NotImplementedError pointing at #763."""
+def test_vector_engine_extracts_without_rendering(foo_pdf):
+    """engine='vector' parses foo.pdf and never rasterises the page."""
     import camelot
 
-    with pytest.raises(NotImplementedError, match="#763"):
-        camelot.read_pdf(foo_pdf, flavor="lattice", engine="vector")
+    tables = camelot.read_pdf(foo_pdf, flavor="lattice", engine="vector")
+    assert len(tables) == 1
+    assert tables[0].shape[0] >= 2 and tables[0].shape[1] >= 2
+
+
+def test_vector_engine_matches_raster_on_vector_ruled_pdf(foo_pdf):
+    """Vector output equals raster on a crisp vector-ruled PDF.
+
+    foo.pdf's rules are real vector strokes, so detecting from them
+    directly (no render) should reconstruct the same grid the raster
+    pipeline finds — the strict oracle for the render-free path.
+    """
+    import camelot
+
+    raster = camelot.read_pdf(foo_pdf, flavor="lattice", engine="raster")
+    vector = camelot.read_pdf(foo_pdf, flavor="lattice", engine="vector")
+    assert len(vector) == len(raster) == 1
+    assert vector[0].shape == raster[0].shape
+    assert vector[0].df.equals(raster[0].df)
 
 
 def test_auto_engine_runs(foo_pdf):


### PR DESCRIPTION
The final piece of #763: a **render-free** `engine='vector'` for `flavor='lattice'` — detect tables straight from the PDF's native vector ruled lines, skipping the page render, adaptive threshold, and OpenCV morphology entirely. This is the path that targets camelot's biggest weakness in the [tablers benchmark](https://github.com/monchin/tablers-benchmark) (camelot 1.0.9 was ~100s vs tablers ~1s — dominated by per-page rasterisation).

## How it works
`_generate_table_bbox` dispatches to `_generate_table_bbox_vector` when the engine resolves to `vector`:
- reads h/v ruled lines via `find_lines_from_layout` (PDF coords, #764),
- **auto-detect** → clusters them into table bboxes + joints with `find_joints_from_lines` (#774),
- **table_areas** → collects line crossings inside each user box (`_joints_in_bbox`),
- **table_regions** → filters lines to the region(s) first (`_line_in_any_bbox`),
- builds the same `table_bbox_parses` structure the raster path produces.

The col/row-anchor derivation is extracted to a shared `_compute_table_anchors()` (raster + vector use it), keeping the two consistent.

## Why it's safe
`pdf_image` / `threshold` stay `None` in vector mode — I traced the whole extraction flow (`base.extract_tables` → `_generate_columns_and_rows` → `_generate_table` → `record_parse_metadata`) and it reads **only** `table_bbox_parses` + PDF-coord segments; `pdf_image` is **plotting-only**. (Plot kinds that need the raster aren't available under `engine='vector'`, by design.)

## Tests
- `engine='vector'` extracts foo.pdf (≥2×2);
- **strict oracle**: `vector df == raster df` on foo.pdf — its rules are real vector strokes, so the render-free path must reconstruct the *same* grid. A wrong cluster/anchor would fail this.

## Verification note
I can't run camelot in my dev env, so **CI's strict `vector==raster` oracle is the correctness gate**, and the **local ICDAR-2013 benchmark** (tracked task) will measure the speed/accuracy delta vs the published 1.0.9 numbers. Logic verified by tracing the data flow + standalone checks of the helpers.

Refs #763.