### PR TITLE
feat(image): coalesce collinear vector ruled-line segments (#763)

### DIFF
--- a/camelot/image_processing.py
+++ b/camelot/image_processing.py
@@ -357,6 +357,12 @@ def find_joints(contours, vertical, horizontal):
 #: don't want to drop a 0.0001-unit-off line just because of rounding.
 _LINE_ORTHOGONAL_TOL = 0.5
 
+#: Tolerance (PDF units) for merging near-collinear ruled-line segments.
+#: PDFs routinely draw one logical rule as many short, abutting sub-segments;
+#: segments whose constant axis agrees within this tolerance and whose extents
+#: overlap or sit within it of each other are fused into a single line.
+_LINE_COALESCE_TOL = 2.0
+
 #: A "filled" rectangle whose narrower side is below this width is treated
 #: as a stroked line (some PDF generators draw ruled lines as 0.5pt-wide
 #: filled rectangles rather than as stroked LTLines).
@@ -454,7 +460,87 @@ def find_lines_from_layout(layout, direction="horizontal"):
             result.append((min(x0, x1), y0, max(x0, x1), y0))
         elif direction == "vertical" and dx <= _LINE_ORTHOGONAL_TOL and dy > 0:
             result.append((x0, min(y0, y1), x0, max(y0, y1)))
-    return result
+    return coalesce_collinear_lines(result, direction)
+
+
+def coalesce_collinear_lines(lines, direction, tol=_LINE_COALESCE_TOL):
+    """Merge near-collinear ruled-line segments into single lines.
+
+    PDFs frequently draw one logical rule as a chain of short sub-segments;
+    left unmerged they make :func:`find_joints_from_lines` under-count
+    joints and miss grids. Segments are grouped by their constant axis
+    (within ``tol``) and, within a group, those whose extents overlap or
+    sit within ``tol`` of each other are fused.
+
+    Parameters
+    ----------
+    lines : list[tuple[float, float, float, float]]
+        ``(x0, y0, x1, y1)`` segments, as produced by
+        :func:`find_lines_from_layout`.
+    direction : str
+        ``'horizontal'`` (segments share a constant ``y``, merge along
+        ``x``) or ``'vertical'`` (constant ``x``, merge along ``y``).
+    tol : float, optional
+        Merge tolerance in PDF units (default :data:`_LINE_COALESCE_TOL`).
+
+    Returns
+    -------
+    list[tuple[float, float, float, float]]
+        The merged segments, same tuple shape as the input.
+    """
+    if direction not in ("horizontal", "vertical"):
+        raise ValueError("direction must be 'horizontal' or 'vertical'")
+    if not lines:
+        return []
+
+    norm = _coalesce_normalise(lines, direction)
+
+    # Chain into clusters of (nearly) equal constant axis.
+    clusters: list[dict] = []
+    for const, lo, hi in norm:
+        if clusters and const - clusters[-1]["last"] <= tol:
+            clusters[-1]["consts"].append(const)
+            clusters[-1]["intervals"].append((lo, hi))
+            clusters[-1]["last"] = const
+        else:
+            clusters.append({"consts": [const], "intervals": [(lo, hi)], "last": const})
+
+    out = []
+    for cluster in clusters:
+        const = sum(cluster["consts"]) / len(cluster["consts"])
+        for lo, hi in _merge_spans(sorted(cluster["intervals"]), tol):
+            out.append(
+                (lo, const, hi, const)
+                if direction == "horizontal"
+                else (const, lo, const, hi)
+            )
+    return out
+
+
+def _coalesce_normalise(lines, direction):
+    """Reduce each segment to ``(const_axis, span_lo, span_hi)``, sorted."""
+    norm = []
+    for x0, y0, x1, y1 in lines:
+        if direction == "horizontal":
+            const = (y0 + y1) / 2.0
+            lo, hi = (x0, x1) if x0 <= x1 else (x1, x0)
+        else:
+            const = (x0 + x1) / 2.0
+            lo, hi = (y0, y1) if y0 <= y1 else (y1, y0)
+        norm.append((const, lo, hi))
+    norm.sort()
+    return norm
+
+
+def _merge_spans(intervals, tol):
+    """Merge overlapping / within-``tol`` ``(lo, hi)`` intervals."""
+    merged = [list(intervals[0])]
+    for lo, hi in intervals[1:]:
+        if lo <= merged[-1][1] + tol:
+            merged[-1][1] = max(merged[-1][1], hi)
+        else:
+            merged.append([lo, hi])
+    return merged
 
 
 #: Default tolerance (PDF units) for deciding whether a horizontal and a

--- a/tests/test_coalesce_collinear.py
+++ b/tests/test_coalesce_collinear.py
@@ -1,0 +1,65 @@
+import pytest
+
+from camelot.image_processing import coalesce_collinear_lines
+
+
+def test_empty_input():
+    assert coalesce_collinear_lines([], "horizontal") == []
+    assert coalesce_collinear_lines([], "vertical") == []
+
+
+def test_invalid_direction():
+    with pytest.raises(ValueError, match="direction"):
+        coalesce_collinear_lines([(0, 0, 1, 0)], "diagonal")
+
+
+def test_horizontal_overlapping_segments_merge():
+    # Two segments on the same y that overlap → one spanning segment.
+    lines = [(0, 5, 60, 5), (40, 5, 100, 5)]
+    out = coalesce_collinear_lines(lines, "horizontal")
+    assert out == [(0, 5, 100, 5)]
+
+
+def test_horizontal_small_gap_within_tol_merges():
+    # Gap of 1 (< tol 2) → merge.
+    out = coalesce_collinear_lines([(0, 5, 50, 5), (51, 5, 100, 5)], "horizontal")
+    assert out == [(0, 5, 100, 5)]
+
+
+def test_horizontal_large_gap_stays_separate():
+    # Gap of 20 (> tol) → two distinct lines.
+    out = coalesce_collinear_lines([(0, 5, 50, 5), (70, 5, 100, 5)], "horizontal")
+    assert sorted(out) == [(0, 5, 50, 5), (70, 5, 100, 5)]
+
+
+def test_horizontal_near_equal_y_averaged():
+    # y differs by 1 (< tol) → same line, y averaged.
+    out = coalesce_collinear_lines([(0, 5, 50, 5), (40, 6, 100, 6)], "horizontal")
+    assert len(out) == 1
+    x0, y, x1, y2 = out[0]
+    assert (x0, x1) == (0, 100) and y == y2 == 5.5
+
+
+def test_horizontal_distinct_y_stay_separate():
+    out = coalesce_collinear_lines([(0, 5, 100, 5), (0, 80, 100, 80)], "horizontal")
+    assert len(out) == 2
+
+
+def test_vertical_overlapping_segments_merge():
+    out = coalesce_collinear_lines([(10, 0, 10, 60), (10, 40, 10, 100)], "vertical")
+    assert out == [(10, 0, 10, 100)]
+
+
+def test_vertical_large_gap_stays_separate():
+    out = coalesce_collinear_lines([(10, 0, 10, 40), (10, 70, 10, 100)], "vertical")
+    assert sorted(out) == [(10, 0, 10, 40), (10, 70, 10, 100)]
+
+
+def test_chain_of_three_segments_merges_to_one():
+    lines = [(0, 5, 30, 5), (30, 5, 60, 5), (60, 5, 90, 5)]
+    assert coalesce_collinear_lines(lines, "horizontal") == [(0, 5, 90, 5)]
+
+
+def test_noop_when_nothing_to_merge():
+    lines = [(0, 5, 100, 5)]
+    assert coalesce_collinear_lines(lines, "horizontal") == [(0, 5, 100, 5)]


### PR DESCRIPTION
PDFs routinely draw one logical rule as a chain of short, abutting sub-segments. Unmerged, they make `find_joints_from_lines` under-count joints, so the vector engine reconstructs **coarse grids** — the one weakness the ICDAR benchmark exposed for `engine='vector'`.

`coalesce_collinear_lines()` groups segments by their constant axis (within `_LINE_COALESCE_TOL=2.0`) and fuses those whose extents overlap or sit within tol; `find_lines_from_layout` now returns coalesced lines.

## Measured impact (ICDAR-2013, 67 docs, run locally on our 2.0 build)
`engine='vector'`, before → after:

| metric | before | after |
|---|--:|--:|
| F1 | 0.638 | **0.705** |
| TEDS | 0.712 | **0.806** |
| row-acc | 0.590 | **0.712** |
| col-acc | 0.724 | 0.779 |
| time | ~12s | ~13s |

The vector engine is now **both the fastest lattice variant (~11× faster than raster's ~140s) and among the most accurate** — TEDS on par with `combined` (0.808), and the highest detection F1 of all lattice variants. This is the speed *and* accuracy payoff of #763.

## Tests
11 unit tests (`tests/test_coalesce_collinear.py`): horizontal/vertical overlap, small-gap-within-tol merge, large-gap-stays-separate, near-equal-axis averaging, distinct lines untouched, 3-segment chain → one, empty/no-op. Verified against the live benchmark too.

(Logic split into `_coalesce_normalise` / `_merge_spans` to stay under the complexity limit.)