### PR TITLE
fix(io): flavor='auto' always silently fell back to network

### DIFF
--- a/camelot/io.py
+++ b/camelot/io.py
@@ -44,7 +44,11 @@ def _detect_flavor(filepath, password=None):
         backend = ImageConversionBackend()
         with TemporaryDirectory() as tmpdir:
             png_path = os.path.join(tmpdir, "auto_flavor_probe.png")
-            backend.convert(str(filepath), png_path, resolution=300, page=1)
+            # ImageConversionBackend.convert takes (pdf_path, png_path, page);
+            # it has no `resolution` kwarg — passing one raised TypeError that
+            # the except below silently swallowed, so 'auto' always fell back
+            # to 'network'. (#auto-flavor regression)
+            backend.convert(str(filepath), png_path, page=1)
             if not os.path.exists(png_path):
                 return "network"
             _, threshold = adaptive_threshold(png_path, process_background=False)

--- a/tests/test_auto_flavor.py
+++ b/tests/test_auto_flavor.py
@@ -1,0 +1,21 @@
+"""Regression tests for the flavor='auto' detection probe (_detect_flavor)."""
+
+import camelot
+from camelot.io import _detect_flavor
+
+
+def test_detect_flavor_returns_lattice_for_ruled_pdf(foo_pdf):
+    # foo.pdf is a ruled (lattice) table. The probe must classify it as
+    # 'lattice'. Regression: _detect_flavor passed a non-existent
+    # `resolution=` kwarg to backend.convert(), which raised TypeError that
+    # the bare except swallowed, so 'auto' silently fell back to 'network'
+    # for *every* PDF.
+    assert _detect_flavor(foo_pdf) == "lattice"
+
+
+def test_auto_flavor_extracts_ruled_table(foo_pdf):
+    # End-to-end: flavor='auto' on a ruled PDF should pick lattice and
+    # extract the table (not mis-route to network).
+    tables = camelot.read_pdf(foo_pdf, flavor="auto")
+    assert len(tables) == 1
+    assert tables[0].shape[0] >= 2 and tables[0].shape[1] >= 2


### PR DESCRIPTION
**`flavor='auto'` has been completely broken — it classified *every* PDF as `network`, never once picking `lattice`.**

`_detect_flavor` calls `backend.convert(filepath, png, resolution=300, page=1)`, but `ImageConversionBackend.convert()` takes only `(pdf_path, png_path, page)` — there's **no `resolution` kwarg**. The `TypeError` was swallowed by the probe's bare `except Exception: return "network"`, so the ruled-line probe never ran and auto always returned `network`.

Fix: drop the bad kwarg (matches how the `Lattice` parser itself calls `convert`).

## Measured on ICDAR-2013 (67 docs), `flavor='auto'`
| | before | after |
|---|--:|--:|
| docs detected as lattice | **0 / 67** | **31 / 67** |
| row accuracy | 0.102 | **0.317** |
| TEDS | 0.671 | **0.698** |
| F1 | 0.748 | 0.706 |

(F1 dips because the old network-everything path was over-detecting / inflating recall; the new behaviour is correct.)

## Tests
`test_auto_flavor.py`: asserts `_detect_flavor` returns `'lattice'` for the ruled `foo.pdf`, and that `flavor='auto'` extracts it. Either would have caught this.

## Known remaining limitations (separate follow-ups)
- Flavor is decided from **page 1 only** and applied to all pages — the 36 docs still on `network` are mostly ones whose page 1 is a cover/text page with the tables later.
- `auto`→lattice uses `engine='raster'`; routing it through `engine='combined'` would lift accuracy further.

Found via the local ICDAR benchmark while chasing auto's row-acc=0.102.