### PR TITLE
perf(io): reuse the auto probe's render in the lattice parse

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -366,6 +366,7 @@ class PDFHandler:
         layout_kwargs: dict[str, Any] | None = None,
         per_page: dict[int, dict[str, Any]] | None = None,
         pages: list[int] | None = None,
+        render_cache: dict[int, str] | None = None,
         **kwargs,
     ):
         """Extract tables by calling parser.get_tables on all single page PDFs.
@@ -403,6 +404,10 @@ class PDFHandler:
         # Default parser used by any page without a per_page override.
         parser_obj = PARSERS[flavor]
         parser = parser_obj(debug=self.debug, **kwargs)
+        if render_cache and hasattr(parser, "_render_cache"):
+            # Pre-rendered page images (page_no -> png path) from the
+            # flavor='auto' probe, so the parser skips re-rasterising them.
+            parser._render_cache = render_cache
 
         # Compute worker count up-front so we can pass it to playa.open(). The
         # old code also gated the parallel branch on len(self.pages) > 1, but

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -19,7 +19,7 @@ from .utils import validate_input
 _AUTO_FLAVOR_LINE_THRESHOLD = 2
 
 
-def _detect_flavor(filepath, password=None, page=1):
+def _detect_flavor(filepath, password=None, page=1, png_path=None):
     """Pick the most appropriate flavor for a single PDF page.
 
     Renders ``page``, thresholds it, and counts ruled horizontal and
@@ -43,23 +43,30 @@ def _detect_flavor(filepath, password=None, page=1):
     from .image_processing import adaptive_threshold
     from .image_processing import find_lines
 
+    def _probe(target_png):
+        # ImageConversionBackend.convert takes (pdf_path, png_path, page); it
+        # has no `resolution` kwarg — passing one raised TypeError that the
+        # except below silently swallowed, so 'auto' always fell back to
+        # 'network'. (#auto-flavor regression)
+        ImageConversionBackend().convert(str(filepath), target_png, page=page)
+        if not os.path.exists(target_png):
+            return None
+        _, threshold = adaptive_threshold(target_png, process_background=False)
+        # Use the Lattice default line_scale (15) — picking 40 here excludes
+        # legitimate small/medium ruled tables.
+        _, v = find_lines(threshold, direction="vertical", line_scale=15)
+        _, h = find_lines(threshold, direction="horizontal", line_scale=15)
+        return len(v), len(h)
+
     try:
-        backend = ImageConversionBackend()
-        with TemporaryDirectory() as tmpdir:
-            png_path = os.path.join(tmpdir, "auto_flavor_probe.png")
-            # ImageConversionBackend.convert takes (pdf_path, png_path, page);
-            # it has no `resolution` kwarg — passing one raised TypeError that
-            # the except below silently swallowed, so 'auto' always fell back
-            # to 'network'. (#auto-flavor regression)
-            backend.convert(str(filepath), png_path, page=page)
-            if not os.path.exists(png_path):
-                return "network"
-            _, threshold = adaptive_threshold(png_path, process_background=False)
-            # Use the Lattice default line_scale (15) — picking 40 here
-            # excludes legitimate small/medium ruled tables. The same
-            # value the lattice parser itself uses by default.
-            _, v_segments = find_lines(threshold, direction="vertical", line_scale=15)
-            _, h_segments = find_lines(threshold, direction="horizontal", line_scale=15)
+        if png_path is None:
+            # No reuse requested: render to a throwaway temp file.
+            with TemporaryDirectory() as tmpdir:
+                counts = _probe(os.path.join(tmpdir, "auto_flavor_probe.png"))
+        else:
+            # Render to the caller-owned path so the rendered page can be
+            # reused by the parser (avoids a second render — see _parse_auto).
+            counts = _probe(png_path)
     except Exception:
         # Any failure on the probe (no usable backend, encrypted page, broken
         # PDF, OpenCV import surprise) is *not* fatal — the user asked us to
@@ -67,9 +74,12 @@ def _detect_flavor(filepath, password=None, page=1):
         # the real error if any.
         return "network"
 
+    if counts is None:
+        return "network"
+    v_count, h_count = counts
     has_grid = (
-        len(v_segments) >= _AUTO_FLAVOR_LINE_THRESHOLD
-        and len(h_segments) >= _AUTO_FLAVOR_LINE_THRESHOLD
+        v_count >= _AUTO_FLAVOR_LINE_THRESHOLD
+        and h_count >= _AUTO_FLAVOR_LINE_THRESHOLD
     )
     return "lattice" if has_grid else "network"
 
@@ -398,40 +408,55 @@ def _parse_auto(
     ruled pages via ``lattice`` with ``engine='combined'`` (the most
     accurate detector), the rest via ``network``. Results are merged into a
     single page/order-sorted :class:`~camelot.core.TableList`.
-    """
-    page_flavor = {
-        pg: _detect_flavor(handler.filepath, password=handler.password or None, page=pg)
-        for pg in handler.pages
-    }
-    warnings.warn(
-        f"camelot.read_pdf: auto-detected per-page flavors {page_flavor}",
-        UserWarning,
-        stacklevel=3,
-    )
 
-    collected = []
-    for fl in ("lattice", "network"):
-        group_pages = sorted(pg for pg, f in page_flavor.items() if f == fl)
-        if not group_pages:
-            continue
-        group_kwargs = remove_extra(dict(kwargs), flavor=fl)
-        if fl == "lattice":
-            # Use the combined raster+vector engine — the strongest lattice
-            # detector — for the ruled pages auto routes here.
-            group_kwargs.setdefault("engine", "combined")
-        _validate_per_page(per_page_norm, fl)
-        collected.extend(
-            handler.parse(
-                flavor=fl,
-                suppress_stdout=suppress_stdout,
-                parallel=parallel,
-                cpu_count=cpu_count,
-                layout_kwargs=layout_kwargs,
-                per_page=per_page_norm,
-                pages=group_pages,
-                **group_kwargs,
+    The page rendered for each lattice page's probe is kept and handed to
+    the parser via ``render_cache``, so that page isn't rasterised a second
+    time during parsing.
+    """
+    with TemporaryDirectory() as cache_dir:
+        page_flavor = {}
+        render_cache: dict[int, str] = {}
+        for pg in handler.pages:
+            probe_png = os.path.join(cache_dir, f"auto-probe-page-{pg}.png")
+            fl = _detect_flavor(
+                handler.filepath,
+                password=handler.password or None,
+                page=pg,
+                png_path=probe_png,
             )
+            page_flavor[pg] = fl
+            if fl == "lattice" and os.path.exists(probe_png):
+                render_cache[pg] = probe_png
+        warnings.warn(
+            f"camelot.read_pdf: auto-detected per-page flavors {page_flavor}",
+            UserWarning,
+            stacklevel=3,
         )
 
-    collected.sort(key=lambda t: (t.page, t.order))
-    return TableList(collected)
+        collected = []
+        for fl in ("lattice", "network"):
+            group_pages = sorted(pg for pg, f in page_flavor.items() if f == fl)
+            if not group_pages:
+                continue
+            group_kwargs = remove_extra(dict(kwargs), flavor=fl)
+            if fl == "lattice":
+                # Use the combined raster+vector engine — the strongest
+                # lattice detector — for the ruled pages auto routes here.
+                group_kwargs.setdefault("engine", "combined")
+            _validate_per_page(per_page_norm, fl)
+            collected.extend(
+                handler.parse(
+                    flavor=fl,
+                    suppress_stdout=suppress_stdout,
+                    parallel=parallel,
+                    cpu_count=cpu_count,
+                    layout_kwargs=layout_kwargs,
+                    per_page=per_page_norm,
+                    pages=group_pages,
+                    render_cache=render_cache if fl == "lattice" else None,
+                    **group_kwargs,
+                )
+            )
+
+        collected.sort(key=lambda t: (t.page, t.order))
+        return TableList(collected)

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -177,6 +177,9 @@ class Lattice(BaseParser):
         #: coords, accumulated by the 'combined' engine for diagnostics /
         #: plotting. Populated per page in :meth:`_detect_line_masks`.
         self._vector_segments: list[tuple[int, int, int, int]] = []
+        #: Optional {page_no: png_path} of pages already rendered elsewhere
+        #: (e.g. the flavor='auto' probe), reused to skip re-rasterising.
+        self._render_cache: dict[int, str] = {}
         super().__init__("lattice", replace_text=replace_text)
         self.table_regions = table_regions
         self.table_areas = table_areas
@@ -416,10 +419,16 @@ class Lattice(BaseParser):
                 scaled_areas.append((x1, y1, abs(x2 - x1), abs(y2 - y1)))
             return scaled_areas
 
-        self.image_path = build_file_path_in_temp_dir(
-            f"{os.path.basename(self.filename)}-page{self.page}", ".png"
-        )
-        self.icb.convert(self.filename, self.image_path, self.page)
+        cached_image = self._render_cache.get(self.page)
+        if cached_image and os.path.exists(cached_image):
+            # Reuse a page already rendered upstream (flavor='auto' probe) —
+            # skip the second, redundant rasterisation.
+            self.image_path = cached_image
+        else:
+            self.image_path = build_file_path_in_temp_dir(
+                f"{os.path.basename(self.filename)}-page{self.page}", ".png"
+            )
+            self.icb.convert(self.filename, self.image_path, self.page)
 
         self.pdf_image, self.threshold = adaptive_threshold(
             self.image_path,

--- a/tests/test_auto_flavor.py
+++ b/tests/test_auto_flavor.py
@@ -37,3 +37,20 @@ def test_auto_routes_lattice_pages_through_combined_engine(foo_pdf, monkeypatch)
     monkeypatch.setattr(handlers_mod.PDFHandler, "parse", spy)
     camelot.read_pdf(foo_pdf, flavor="auto")
     assert seen.get("engine") == "combined"
+
+
+def test_auto_render_cache_avoids_double_render(foo_pdf, monkeypatch):
+    # The page rendered for the auto probe is reused by the lattice parse,
+    # so a ruled page is rasterised exactly once, not twice.
+    import camelot.backends.image_conversion as ic
+
+    rendered_pages = []
+    original = ic.ImageConversionBackend.convert
+
+    def spy(self, pdf_path, png_path, page=1):
+        rendered_pages.append(page)
+        return original(self, pdf_path, png_path, page=page)
+
+    monkeypatch.setattr(ic.ImageConversionBackend, "convert", spy)
+    camelot.read_pdf(foo_pdf, flavor="auto")  # foo.pdf: 1 ruled page
+    assert rendered_pages.count(1) == 1


### PR DESCRIPTION
`flavor='auto'` (per-page, #796) rendered each page **twice** — once for the per-page flavor probe, then again when the lattice parser parsed it. This caches the probe's render and reuses it.

- `_parse_auto` keeps each lattice page's probe-rendered PNG in a scoped temp dir and passes a `{page: png}` map to `parse(render_cache=...)`.
- `parse` sets it on the parser (`Lattice._render_cache`); `_generate_table_bbox` uses the cached image instead of calling `icb.convert` when present.
- `_detect_flavor` gains an optional `png_path` to render to a caller-owned location (else a throwaway temp, as before).

## Measured (ICDAR-2013, `flavor='auto'`)
| | time | F1 | TEDS | row | col |
|---|--:|--:|--:|--:|--:|
| no cache | 207s | 0.742 | 0.793 | 0.517 | 0.768 |
| **render-cache** | **177s** | 0.742 | 0.793 | 0.517 | 0.768 |

~15% faster, **identical** accuracy. New test asserts a ruled page is rasterised exactly once, not twice.

(The probe still renders every page — a bigger win would be a render-free vector probe via `layout_has_ruled_lines`, but that risks mis-routing raster-ruled tables to network; this cache is the behaviour-preserving optimization.)