### PR TITLE
feat(lattice): precision gate — drop near-empty ruled grids (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ changes. **Heads-up if upgrading from 1.0.x**:
 
 ### Fixed
 
+- **Precision gate for the lattice/combined engine.** Near-empty ruled
+  grids (page borders, form rules, header separators — whitespace ≥ 90 %)
+  are no longer emitted as tables; they were detection noise that
+  false-positived on pages with no real table. On the in-repo ICDAR-2013
+  benchmark this lifts combined detection F1 0.665 → 0.778 with TEDS /
+  row / col all improving too. (#36)
+
 - **`flavor="auto"` was silently broken** — `_detect_flavor` passed a
   non-existent `resolution=` kwarg to the image backend, so the `TypeError`
   was swallowed and _every_ PDF fell back to `network` (never `lattice`).

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -249,6 +249,15 @@ class BaseParser:
         # Pure virtual, must be defined by the derived parser
         raise NotImplementedError()
 
+    def _reject_table(self, table) -> bool:
+        """Hook: return True to drop a freshly built table before it's kept.
+
+        Default keeps everything. Parsers override this to apply a
+        precision gate (e.g. Lattice drops mostly-empty ruled grids that
+        are detection noise rather than real tables).
+        """
+        return False
+
     def extract_tables(self):
         """Extract tables from the document."""
         if self._document_has_no_text():
@@ -283,7 +292,8 @@ class BaseParser:
 
             cols, rows, v_s, h_s = self._generate_columns_and_rows(bbox, user_cols)
             table = self._generate_table(table_idx, bbox, cols, rows, v_s=v_s, h_s=h_s)
-            _tables.append(table)
+            if not self._reject_table(table):
+                _tables.append(table)
 
         return _tables
 

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -25,6 +25,14 @@ from ..utils import segments_in_bbox
 from ..utils import text_in_bbox_per_axis
 from .base import BaseParser
 
+#: Reject a detected ruled grid whose cells are at least this percent empty.
+#: Real data tables are mostly filled; a near-empty grid (whitespace in the
+#: 90s) is almost always ruled *noise* — page borders, form rules, header
+#: separators — that the contour/joint pipeline mistook for a table. Chosen
+#: above the observed real-table whitespace range and below the spurious one
+#: (the false positives measured on the ICDAR set sit at 91-95 %).
+_GRID_WHITESPACE_REJECT = 90.0
+
 
 def _line_in_any_bbox(line, bboxes):
     """True if a ruled line's extent overlaps any of the given bboxes.
@@ -284,6 +292,17 @@ class Lattice(BaseParser):
         super().record_parse_metadata(table)
         # for plotting
         table._segments = (self.vertical_segments, self.horizontal_segments)
+
+    def _reject_table(self, table) -> bool:
+        """Drop near-empty ruled grids — detection noise, not real tables.
+
+        A genuine ruled table is mostly filled; a grid whose cells are
+        ~all empty (whitespace in the 90s) is page borders / form rules /
+        header separators the contour-joint pipeline mistook for a table.
+        Rejecting these is a precision gate that cuts false positives on
+        pages with no real table (#36).
+        """
+        return table.whitespace >= _GRID_WHITESPACE_REJECT
 
     def _resolve_engine(self):
         """Resolve the effective line-detection engine for this page.

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -104,3 +104,25 @@ def test_lattice_split_text(testdir):
     tables = camelot.read_pdf(filename, line_scale=60, split_text=True)
 
     assert_frame_equal(df, tables[0].df)
+
+
+def test_lattice_rejects_mostly_empty_grid():
+    # #36 precision gate: a near-empty ruled grid is detection noise, not a
+    # table, and must be dropped; a normally-filled table is kept.
+    from types import SimpleNamespace
+
+    from camelot.parsers.lattice import _GRID_WHITESPACE_REJECT
+    from camelot.parsers.lattice import Lattice
+
+    parser = Lattice()
+    assert parser._reject_table(SimpleNamespace(whitespace=_GRID_WHITESPACE_REJECT + 1))
+    assert not parser._reject_table(SimpleNamespace(whitespace=40.0))
+
+
+def test_network_keeps_sparse_tables():
+    # The gate is lattice-only — text-based parsers must not inherit it.
+    from types import SimpleNamespace
+
+    from camelot.parsers import Network
+
+    assert not Network()._reject_table(SimpleNamespace(whitespace=99.0))


### PR DESCRIPTION
The contour/joint pipeline sometimes mistakes **page borders, form rules and header separators** for tables, emitting large but **near-empty** grids on pages with no real table — e.g. `us-002` page 4 produced a 14×10 grid that is **91 % whitespace** (12/140 filled). These false positives hurt detection precision (and drag down the structure averages).

Fix: a parser hook `BaseParser._reject_table` (default keeps everything); `Lattice` overrides it to drop tables whose `whitespace ≥ 90 %` (`_GRID_WHITESPACE_REJECT`). Text-based parsers (stream/network) are unaffected — the gate is lattice-only.

## Measured (in-repo ICDAR-2013 benchmark, `bench/benchmark_icdar.py`, `engine='combined'`)
| | F1 | TEDS | row | col |
|---|--:|--:|--:|--:|
| before | 0.665 | 0.757 | 0.726 | 0.802 |
| **after** | **0.778** | **0.789** | **0.762** | **0.829** |

**Every metric improves** — F1 +0.113 from cutting the false positives, and TEDS/row/col rise because the spurious near-empty grids were dragging the averages down. No trade-off.

## Tests
- New unit tests: lattice rejects a ≥-threshold-whitespace grid, keeps a normal one; network does *not* inherit the gate.
- 10 lattice + broader suite still pass (no real tables dropped).

First item from the benchmark-backed backlog (#36). Validated on the self-contained ICDAR runner added in #799.