### PR TITLE
feat(network): suppress nested/overlapping duplicate tables (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,13 @@ changes. **Heads-up if upgrading from 1.0.x**:
   false-positived on pages with no real table. On the in-repo ICDAR-2013
   benchmark this lifts combined detection F1 0.665 → 0.778 with TEDS /
   row / col all improving too. (#36)
+- **Network parser: suppress nested/overlapping duplicate tables.** The
+  connectivity search sometimes emitted a partial copy of a table nested
+  inside the full detection (same columns, fewer rows), inflating the
+  table count and mangling row structure. These are now suppressed
+  (keep the larger). On the in-repo ICDAR-2013 benchmark this lifts
+  flavor='auto' across the board — F1 0.742→0.765, TEDS 0.744→0.763,
+  row 0.517→0.540 — and ~20 % faster. (#35)
 
 - **`flavor="auto"` was silently broken** — `_detect_flavor` passed a
   non-existent `resolution=` kwarg to the image backend, so the `TypeError`

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -258,6 +258,15 @@ class BaseParser:
         """
         return False
 
+    def _postprocess_tables(self, tables):
+        """Hook: transform the per-page table list before it's returned.
+
+        Default returns it unchanged. Parsers override this to apply
+        cross-table cleanups (e.g. Network suppresses nested/overlapping
+        duplicate detections of the same table).
+        """
+        return tables
+
     def extract_tables(self):
         """Extract tables from the document."""
         if self._document_has_no_text():
@@ -295,7 +304,7 @@ class BaseParser:
             if not self._reject_table(table):
                 _tables.append(table)
 
-        return _tables
+        return self._postprocess_tables(_tables)
 
     def record_parse_metadata(self, table):
         """Record data about the origin of the table."""

--- a/camelot/parsers/network.py
+++ b/camelot/parsers/network.py
@@ -759,6 +759,29 @@ class TextNetworks(TextAlignments):
         self._compute_alignment_counts()
 
 
+#: Suppress a Network table whose bbox is at least this fraction covered by a
+#: larger detected table. The connectivity search sometimes emits a *partial*
+#: copy nested inside the full table (same columns, same top, fewer rows),
+#: which both inflates the table count (false positive) and mismatches row
+#: structure when matched against ground truth. (#35)
+_OVERLAP_SUPPRESS = 0.6
+
+
+def _bbox_area(bbox):
+    x1, y1, x2, y2 = bbox
+    return max(0.0, x2 - x1) * max(0.0, y2 - y1)
+
+
+def _overlap_fraction(inner, outer):
+    """Fraction of ``inner``'s area that lies within ``outer`` (x1,y1,x2,y2)."""
+    ix1, iy1 = max(inner[0], outer[0]), max(inner[1], outer[1])
+    ix2, iy2 = min(inner[2], outer[2]), min(inner[3], outer[3])
+    if ix2 <= ix1 or iy2 <= iy1:
+        return 0.0
+    area = _bbox_area(inner)
+    return (ix2 - ix1) * (iy2 - iy1) / area if area else 0.0
+
+
 class Network(TextBaseParser):
     """Network method looks for spaces between text to parse the table.
 
@@ -954,6 +977,27 @@ class Network(TextBaseParser):
         if self.table_areas is not None:
             return [bbox_from_str(area_str) for area_str in self.table_areas]
         return None
+
+    def _postprocess_tables(self, tables):
+        """Suppress nested/overlapping duplicate detections of one table.
+
+        Keeps the larger of any two tables whose smaller member is mostly
+        (>= ``_OVERLAP_SUPPRESS``) covered by it, preserving reading order.
+        """
+        if len(tables) < 2 or any(t._bbox is None for t in tables):
+            return tables
+        by_size = sorted(tables, key=lambda t: _bbox_area(t._bbox), reverse=True)
+        kept = []
+        for t in by_size:
+            if any(
+                _overlap_fraction(t._bbox, k._bbox) >= _OVERLAP_SUPPRESS for k in kept
+            ):
+                continue
+            kept.append(t)
+        if len(kept) == len(tables):
+            return tables
+        kept_ids = {id(t) for t in kept}
+        return [t for t in tables if id(t) in kept_ids]
 
     def _generate_columns_and_rows(self, bbox, user_cols):
         # select elements which lie within table_bbox

--- a/tests/test_network_overlap.py
+++ b/tests/test_network_overlap.py
@@ -1,0 +1,51 @@
+"""#35: Network suppresses nested/overlapping duplicate table detections."""
+
+from types import SimpleNamespace
+
+from camelot.parsers import Network
+from camelot.parsers.network import _overlap_fraction
+
+
+def _t(x1, y1, x2, y2):
+    return SimpleNamespace(_bbox=(x1, y1, x2, y2))
+
+
+def test_overlap_fraction_identical():
+    assert _overlap_fraction((0, 0, 10, 10), (0, 0, 10, 10)) == 1.0
+
+
+def test_overlap_fraction_disjoint():
+    assert _overlap_fraction((0, 0, 10, 10), (20, 20, 30, 30)) == 0.0
+
+
+def test_overlap_fraction_nested():
+    # inner fully inside outer -> 1.0
+    assert _overlap_fraction((2, 2, 4, 4), (0, 0, 10, 10)) == 1.0
+
+
+def test_suppresses_nested_duplicate():
+    # 'nested' shares the top of 'big' and is fully within its x/y -> dropped.
+    big = _t(0, 0, 100, 100)
+    nested = _t(0, 40, 100, 100)  # 60% of big's height, fully inside
+    out = Network()._postprocess_tables([big, nested])
+    assert out == [big]
+
+
+def test_keeps_disjoint_tables():
+    top = _t(0, 60, 100, 100)
+    bottom = _t(0, 0, 100, 40)  # no y-overlap
+    out = Network()._postprocess_tables([top, bottom])
+    assert len(out) == 2
+
+
+def test_preserves_input_order():
+    a = _t(0, 60, 100, 100)
+    b = _t(0, 0, 100, 40)
+    assert Network()._postprocess_tables([a, b]) == [a, b]
+
+
+def test_noop_with_single_or_missing_bbox():
+    one = _t(0, 0, 10, 10)
+    assert Network()._postprocess_tables([one]) == [one]
+    no_bbox = [SimpleNamespace(_bbox=None), SimpleNamespace(_bbox=None)]
+    assert Network()._postprocess_tables(no_bbox) == no_bbox


### PR DESCRIPTION
The network connectivity search sometimes emits a **partial copy of a table nested inside the full detection** (same columns, same top, fewer rows) — e.g. `us-018` page 1: a 23-row fragment whose bbox sits entirely within the 55-row full table. These duplicates inflate the table count (false positives) and mismatch row structure.

Fix: a `BaseParser._postprocess_tables` hook (default identity) called at the end of `extract_tables`; `Network` overrides it to drop a table whose bbox is ≥ `_OVERLAP_SUPPRESS` (60 %) covered by a larger detection — keeping the larger, preserving reading order.

## Measured (in-repo ICDAR-2013, `bench/benchmark_icdar.py`, `flavor='auto'`)
where network handles the borderless pages:

| | time | F1 | TEDS | row | col |
|---|--:|--:|--:|--:|--:|
| baseline | 209s | 0.742 | 0.744 | 0.517 | 0.768 |
| **+ suppression** | **167s** | **0.765** | **0.763** | **0.540** | **0.773** |

Every metric up **and ~20 % faster** (fewer duplicate tables to build). This is the #35 lever from the benchmark-backed backlog — diagnosed from the worst-doc analysis (network was fragmenting one table into nested copies).

## Tests
7 new unit tests (overlap geometry + suppression: nested dropped, disjoint kept, order preserved, no-op without bbox). Network suite passes — a previously-xfailed #585 case now xpasses.