### PR TITLE
feat(lattice)!: default engine='combined', drop engine='auto'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### Changed
+
+- **`engine='combined'` is now the default lattice engine** (was
+  `'raster'`), and **`engine='auto'` was removed**. Combined is the
+  strongest detector and safe by construction; its vector ruled lines are
+  now clipped to `table_regions` so it never expands a table beyond a
+  user-supplied region (previously it could). `engine` remains lattice-only
+  and is rejected for text-based flavors. (#763, flavor x engine cleanup)
+
 # Changelog
 
 This file documents notable user-visible changes. The day-to-day automatic

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -294,20 +294,19 @@ def read_pdf(
         Fallback to another backend if unavailable, by default True
     resolution* : int, optional (default: 300)
         Resolution used for PDF to PNG conversion.
-    engine* : str, optional (default: 'raster')
+    engine* : str, optional (default: 'combined')
         Line-detection engine for ``flavor='lattice'`` (and the lattice
         half of ``flavor='hybrid'``):
 
-        - ``'raster'`` (default): render the page and detect ruled lines
-          with OpenCV — the long-standing behaviour.
-        - ``'combined'``: run raster detection **and** union in the ruled
-          lines read from the PDF's native vector graphics, so tables
-          whose rules render faintly (vector strokes, anti-aliasing) are
-          still found. Safe by construction — raster always runs, vector
-          lines can only add, so the result is never worse than
-          ``'raster'`` (#763).
-        - ``'auto'``: use ``'combined'`` when the PDF carries native ruled
-          lines, else fall back to ``'raster'`` (#763).
+        - ``'combined'`` (default): render the page and detect ruled lines
+          with OpenCV **and** union in the ruled lines read from the PDF's
+          native vector graphics, so tables whose rules render faintly
+          (vector strokes, anti-aliasing) are still found. Safe by
+          construction — raster always runs, vector lines can only add, and
+          they're clipped to ``table_regions`` — so it never does worse
+          than ``'raster'`` (#763).
+        - ``'raster'``: render the page and detect ruled lines with OpenCV
+          only — the pre-#763 behaviour.
         - ``'vector'``: detect tables straight from the PDF's vector ruled
           lines, skipping rasterisation entirely — the fastest path, for
           PDFs whose tables are drawn with real vector strokes (#763).

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -15,7 +15,6 @@ from ..image_processing import find_joints
 from ..image_processing import find_joints_from_lines
 from ..image_processing import find_lines
 from ..image_processing import find_lines_from_layout
-from ..image_processing import layout_has_ruled_lines
 from ..utils import bbox_from_str
 from ..utils import build_file_path_in_temp_dir
 from ..utils import merge_close_lines
@@ -137,17 +136,20 @@ class Lattice(BaseParser):
         Fallback to another backend if unavailable, by default True
     resolution : int, optional (default: 300)
         Resolution used for PDF to PNG conversion.
-    engine : str, optional (default: 'raster')
-        Line-detection engine. ``'raster'`` uses OpenCV on the rendered
-        page (the long-standing behaviour). ``'combined'`` additionally
-        unions the PDF's native vector ruled lines into the line masks
-        before contour/joint detection, recovering tables whose rules
-        render faintly; it is safe by construction (raster always runs,
-        vector lines can only add). ``'auto'`` picks ``'combined'`` when
-        the page carries vector ruled lines, else ``'raster'``.
-        ``'vector'`` detects tables purely from the PDF's vector ruled
-        lines, skipping rasterisation entirely — fastest, for PDFs whose
-        tables are drawn with real vector strokes (#763).
+    engine : str, optional (default: 'combined')
+        Line-detection engine (lattice only):
+
+        - ``'combined'`` (default): OpenCV on the rendered page **plus**
+          the PDF's native vector ruled lines unioned into the line masks
+          before contour/joint detection — recovers tables whose rules
+          render faintly. Safe by construction (raster always runs first,
+          vector lines can only add; vector lines are clipped to
+          ``table_regions`` so it never expands a table past the region).
+        - ``'raster'``: OpenCV on the rendered page only (the pre-#763
+          behaviour).
+        - ``'vector'``: detect tables purely from the PDF's vector ruled
+          lines, skipping rasterisation entirely — fastest, for PDFs whose
+          tables are drawn with real vector strokes (#763).
 
     """
 
@@ -172,13 +174,12 @@ class Lattice(BaseParser):
         resolution=300,
         use_fallback=True,
         backend="pdfium",
-        engine="raster",
+        engine="combined",
         **kwargs,
     ):
-        if engine not in ("raster", "vector", "combined", "auto"):
+        if engine not in ("raster", "vector", "combined"):
             raise ValueError(
-                "engine must be 'raster', 'vector', 'combined' or 'auto',"
-                f" got {engine!r}"
+                f"engine must be 'raster', 'vector' or 'combined', got {engine!r}"
             )
         self.engine = engine
         #: Vector ruled lines drawn onto the raster line masks, in image
@@ -308,33 +309,20 @@ class Lattice(BaseParser):
         return table.whitespace >= _GRID_WHITESPACE_REJECT
 
     def _resolve_engine(self):
-        """Resolve the effective line-detection engine for this page.
+        """Return the effective line-detection engine for this page.
 
-        * ``'raster'``   → ``'raster'`` (the OpenCV pipeline only).
-        * ``'combined'`` → ``'combined'`` (raster **plus** the PDF's
-          vector ruled lines unioned into the line masks — #763 Stage 2b).
-        * ``'vector'``   → ``'vector'`` (render-free: detect tables from
-          the PDF's vector ruled lines without rasterising the page — see
-          :meth:`_generate_table_bbox_vector`).
-        * ``'auto'``     → ``'combined'`` when the page layout carries
-          enough ruled lines for the vector union to help, else
-          ``'raster'``.
-
-        ``'combined'`` is safe by construction: raster always runs first,
-        so vector lines can only *add* to the detected masks, never
-        remove — a page with no usable vector lines (or a mis-scaled one)
-        yields the same result as ``'raster'``.
+        * ``'combined'`` (default) → raster OpenCV pipeline **plus** the
+          PDF's vector ruled lines unioned into the line masks (#763). Safe
+          by construction: raster always runs first, so vector lines can
+          only *add* to the detected masks, never remove — a page with no
+          usable vector lines yields the same result as ``'raster'``. The
+          strongest detector, hence the default.
+        * ``'raster'`` → the OpenCV pipeline only (the pre-#763 behaviour).
+        * ``'vector'`` → render-free: detect tables from the PDF's vector
+          ruled lines without rasterising the page (fastest) — see
+          :meth:`_generate_table_bbox_vector`.
         """
-        if self.engine == "vector":
-            return "vector"
-        if self.engine == "combined":
-            return "combined"
-        if self.engine == "auto":
-            self._vector_lines_available = layout_has_ruled_lines(
-                getattr(self, "layout", None)
-            )
-            return "combined" if self._vector_lines_available else "raster"
-        return "raster"
+        return self.engine
 
     def _augment_masks_with_vector_lines(
         self,
@@ -355,20 +343,23 @@ class Lattice(BaseParser):
         them to the segment lists fed to :func:`scale_image`.
 
         A ``None`` layout (no vector graphics available) is a no-op.
+
+        When ``table_regions`` are supplied, the vector lines are clipped to
+        them — mirroring the raster ``find_lines(regions=...)`` mask — so
+        combined never expands a table beyond the user's region (the raster
+        path already respects it; the vector path must too).
         """
         layout = getattr(self, "layout", None)
         if layout is None:
             return [], []
-        v_segments = self._stamp_vector_lines(
-            find_lines_from_layout(layout, direction="vertical"),
-            vertical_mask,
-            image_scalers,
-        )
-        h_segments = self._stamp_vector_lines(
-            find_lines_from_layout(layout, direction="horizontal"),
-            horizontal_mask,
-            image_scalers,
-        )
+        v_lines = find_lines_from_layout(layout, direction="vertical")
+        h_lines = find_lines_from_layout(layout, direction="horizontal")
+        if self.table_regions is not None:
+            region_bboxes = [bbox_from_str(r) for r in self.table_regions]
+            v_lines = [ln for ln in v_lines if _line_in_any_bbox(ln, region_bboxes)]
+            h_lines = [ln for ln in h_lines if _line_in_any_bbox(ln, region_bboxes)]
+        v_segments = self._stamp_vector_lines(v_lines, vertical_mask, image_scalers)
+        h_segments = self._stamp_vector_lines(h_lines, horizontal_mask, image_scalers)
         return v_segments, h_segments
 
     @staticmethod

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -48,7 +48,11 @@ def test_password(testdir):
 def test_repr_pdfium(testdir):
     filename = os.path.join(testdir, "foo.pdf")
     tables = camelot.read_pdf(
-        filename, flavor="lattice", backend="pdfium", use_fallback=False
+        filename,
+        flavor="lattice",
+        backend="pdfium",
+        use_fallback=False,
+        engine="raster",
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
@@ -58,7 +62,7 @@ def test_repr_pdfium(testdir):
 @skip_pdftopng
 def test_repr_poppler(testdir):
     filename = os.path.join(testdir, "foo.pdf")
-    tables = camelot.read_pdf(filename, backend="poppler")
+    tables = camelot.read_pdf(filename, backend="poppler", engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=219 x2=165 y2=234>"
@@ -67,7 +71,7 @@ def test_repr_poppler(testdir):
 @skip_on_windows
 def test_repr_ghostscript(testdir):
     filename = os.path.join(testdir, "foo.pdf")
-    tables = camelot.read_pdf(filename, backend="ghostscript")
+    tables = camelot.read_pdf(filename, backend="ghostscript", engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
@@ -76,7 +80,7 @@ def test_repr_ghostscript(testdir):
 @skip_on_windows
 def test_repr_ghostscript_custom_backend(testdir):
     filename = os.path.join(testdir, "foo.pdf")
-    tables = camelot.read_pdf(filename, backend=GhostscriptBackend())
+    tables = camelot.read_pdf(filename, backend=GhostscriptBackend(), engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
@@ -85,7 +89,7 @@ def test_repr_ghostscript_custom_backend(testdir):
 def test_url_pdfium():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
     tables = camelot.read_pdf(
-        url, flavor="lattice", backend="pdfium", use_fallback=False
+        url, flavor="lattice", backend="pdfium", use_fallback=False, engine="raster"
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
@@ -95,7 +99,7 @@ def test_url_pdfium():
 @skip_pdftopng
 def test_url_poppler():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend="poppler")
+    tables = camelot.read_pdf(url, backend="poppler", engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=219 x2=165 y2=234>"
@@ -104,7 +108,7 @@ def test_url_poppler():
 @skip_on_windows
 def test_url_ghostscript(testdir):
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend="ghostscript")
+    tables = camelot.read_pdf(url, backend="ghostscript", engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
@@ -113,7 +117,7 @@ def test_url_ghostscript(testdir):
 @skip_on_windows
 def test_url_ghostscript_custom_backend(testdir):
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend=GhostscriptBackend())
+    tables = camelot.read_pdf(url, backend=GhostscriptBackend(), engine="raster")
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
@@ -121,17 +125,23 @@ def test_url_ghostscript_custom_backend(testdir):
 
 def test_pages_pdfium():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend="pdfium", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, backend="pdfium", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=121 y1=218 x2=165 y2=234>"
 
-    tables = camelot.read_pdf(url, pages="1-end", backend="pdfium", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, pages="1-end", backend="pdfium", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=121 y1=218 x2=165 y2=234>"
 
-    tables = camelot.read_pdf(url, pages="all", backend="pdfium", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, pages="all", backend="pdfium", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=121 y1=218 x2=165 y2=234>"
@@ -140,17 +150,23 @@ def test_pages_pdfium():
 @skip_pdftopng
 def test_pages_poppler():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend="poppler", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, backend="poppler", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=219 x2=165 y2=234>"
 
-    tables = camelot.read_pdf(url, pages="1-end", backend="poppler", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, pages="1-end", backend="poppler", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=219 x2=165 y2=234>"
 
-    tables = camelot.read_pdf(url, pages="all", backend="poppler", use_fallback=False)
+    tables = camelot.read_pdf(
+        url, pages="all", backend="poppler", use_fallback=False, engine="raster"
+    )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=219 x2=165 y2=234>"
@@ -159,20 +175,22 @@ def test_pages_poppler():
 @skip_on_windows
 def test_pages_ghostscript():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
-    tables = camelot.read_pdf(url, backend="ghostscript", use_fallback=False)
-    assert repr(tables) == "<TableList n=1>"
-    assert repr(tables[0]) == "<Table shape=(7, 7)>"
-    assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
-
     tables = camelot.read_pdf(
-        url, pages="1-end", backend="ghostscript", use_fallback=False
+        url, backend="ghostscript", use_fallback=False, engine="raster"
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
 
     tables = camelot.read_pdf(
-        url, pages="all", backend="ghostscript", use_fallback=False
+        url, pages="1-end", backend="ghostscript", use_fallback=False, engine="raster"
+    )
+    assert repr(tables) == "<TableList n=1>"
+    assert repr(tables[0]) == "<Table shape=(7, 7)>"
+    assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
+
+    tables = camelot.read_pdf(
+        url, pages="all", backend="ghostscript", use_fallback=False, engine="raster"
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
@@ -183,20 +201,22 @@ def test_pages_ghostscript():
 def test_pages_ghostscript_custom_backend():
     url = "https://camelot-py.readthedocs.io/en/latest/_static/pdf/foo.pdf"
     custom_backend = GhostscriptBackend()
-    tables = camelot.read_pdf(url, backend=custom_backend, use_fallback=False)
-    assert repr(tables) == "<TableList n=1>"
-    assert repr(tables[0]) == "<Table shape=(7, 7)>"
-    assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
-
     tables = camelot.read_pdf(
-        url, pages="1-end", backend=custom_backend, use_fallback=False
+        url, backend=custom_backend, use_fallback=False, engine="raster"
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
 
     tables = camelot.read_pdf(
-        url, pages="all", backend=custom_backend, use_fallback=False
+        url, pages="1-end", backend=custom_backend, use_fallback=False, engine="raster"
+    )
+    assert repr(tables) == "<TableList n=1>"
+    assert repr(tables[0]) == "<Table shape=(7, 7)>"
+    assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
+
+    tables = camelot.read_pdf(
+        url, pages="all", backend=custom_backend, use_fallback=False, engine="raster"
     )
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -126,3 +126,47 @@ def test_network_keeps_sparse_tables():
     from camelot.parsers import Network
 
     assert not Network()._reject_table(SimpleNamespace(whitespace=99.0))
+
+
+def test_lattice_engine_default_is_combined():
+    # #763 / item-2: 'combined' is the default lattice engine.
+    from camelot.parsers import Lattice
+
+    assert Lattice().engine == "combined"
+
+
+def test_lattice_engine_auto_rejected():
+    # engine='auto' was dropped in the flavor x engine cleanup.
+    import pytest
+
+    from camelot.parsers import Lattice
+
+    with pytest.raises(ValueError, match="engine must be"):
+        Lattice(engine="auto")
+
+
+def test_engine_rejected_for_non_lattice_flavor(testdir):
+    # engine is lattice-only; passing it to a text-based flavor errors.
+    import pytest
+
+    import camelot
+
+    filename = os.path.join(testdir, "foo.pdf")
+    with pytest.raises(ValueError, match="engine"):
+        camelot.read_pdf(filename, flavor="network", engine="combined")
+
+
+def test_combined_respects_table_regions(testdir):
+    # Regression: combined's vector lines must be clipped to table_regions,
+    # so it never expands the table beyond the region vs raster.
+    import camelot
+
+    filename = os.path.join(testdir, "table_region.pdf")
+    region = ["170,370,560,270"]
+    r = camelot.read_pdf(
+        filename, table_regions=region, engine="raster", suppress_stdout=True
+    )
+    c = camelot.read_pdf(
+        filename, table_regions=region, engine="combined", suppress_stdout=True
+    )
+    assert c[0].shape == r[0].shape

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -58,18 +58,19 @@ def test_probe_custom_threshold(monkeypatch):
 def test_lattice_engine_validation():
     from camelot.parsers.lattice import Lattice
 
-    # Valid values construct fine.
-    for eng in ("raster", "vector", "combined", "auto"):
+    # Valid values construct fine ('auto' was dropped — item-2 cleanup).
+    for eng in ("raster", "vector", "combined"):
         assert Lattice(engine=eng).engine == eng
-    # Invalid value rejected at construction.
-    with pytest.raises(ValueError, match="engine must be"):
-        Lattice(engine="opencv")
+    # Invalid values rejected at construction.
+    for bad in ("opencv", "auto"):
+        with pytest.raises(ValueError, match="engine must be"):
+            Lattice(engine=bad)
 
 
-def test_lattice_default_engine_is_raster():
+def test_lattice_default_engine_is_combined():
     from camelot.parsers.lattice import Lattice
 
-    assert Lattice().engine == "raster"
+    assert Lattice().engine == "combined"
 
 
 def test_vector_engine_extracts_without_rendering(foo_pdf):
@@ -97,12 +98,12 @@ def test_vector_engine_matches_raster_on_vector_ruled_pdf(foo_pdf):
     assert vector[0].df.equals(raster[0].df)
 
 
-def test_auto_engine_runs(foo_pdf):
-    """engine='auto' must not raise — resolves to combined/raster (#763)."""
+def test_auto_engine_removed(foo_pdf):
+    """engine='auto' was dropped; 'combined' is now the default (item-2)."""
     import camelot
 
-    tables = camelot.read_pdf(foo_pdf, flavor="lattice", engine="auto")
-    assert len(tables) == 1
+    with pytest.raises(ValueError, match="engine must be"):
+        camelot.read_pdf(foo_pdf, flavor="lattice", engine="auto")
 
 
 def test_combined_engine_matches_raster_on_vector_ruled_pdf(foo_pdf):


### PR DESCRIPTION
The **flavor × engine** cleanup for 2.0 (architecture item 2).

- **`engine='combined'` is now the default** lattice engine (was `'raster'`). Combined = raster OpenCV **plus** the PDF's vector ruled lines — the strongest detector, and now safe as a default (see the fix below). `'raster'` stays available; `'vector'` is the render-free fast path.
- **`engine='auto'` removed** — it duplicated the flavor-level `auto`. One "auto", at the flavor level. `_resolve_engine` simplifies to returning the engine.
- **`engine` stays lattice-only** and is rejected for text-based flavors (`validate_input` already raises `... cannot be used with flavor='network'`).

## The fix that makes the default safe
Defaulting to combined exposed a real bug: combined's **vector lines weren't clipped to `table_regions`**, while the raster path was (`find_lines(regions=...)`). So combined could leak ruled lines outside a user's region and over-expand the table — `table_region.pdf` went from a clean **4×2** to a **12×5 mess pulling in surrounding text**. Now the vector lines are clipped to `table_regions` (via the existing `_line_in_any_bbox`), so **combined == raster on constrained regions** and never expands past the region.

## Tests
New: default-is-combined, `engine='auto'` rejected, `engine` rejected for non-lattice flavors, and combined-respects-`table_regions`. Updated the #793 probe tests that asserted the old contract. Full lattice/hybrid/common/vector suites pass (combined == raster on the clean fixture PDFs; only `table_region` changed — and that's the bug fix).

## ⚠️ Breaking
Default lattice output may change on PDFs with faint/vector rules (combined detects more than raster). This is the intended 2.0 improvement; `engine='raster'` restores the old behaviour.