### PR TITLE
feat(hybrid): gate network-split augmentation by lattice completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,18 @@ changes. **Heads-up if upgrading from 1.0.x**:
   (keep the larger). On the in-repo ICDAR-2013 benchmark this lifts
   flavor='auto' across the board — F1 0.742→0.765, TEDS 0.744→0.763,
   row 0.517→0.540 — and ~20 % faster. (#35)
+- **`flavor="hybrid"`: gate the network-split augmentation by lattice
+  completeness.** Hybrid used to _union_ network's text-derived column
+  splits onto lattice's boundaries and parse the merged table with the
+  network parser (text-grouped rows) — which over-segmented and wrecked the
+  row structure of fully-ruled tables. Now, when lattice already resolved a
+  complete ruled grid (interior rules in both directions, joints covering
+  the grid, and a row count commensurate with the table's column-aligned
+  text rows), that grid is routed to the lattice parser untouched;
+  partially-ruled / borderless tables still take the network-augmented path,
+  so hybrid's niche wins are preserved. On the in-repo ICDAR-2013 benchmark
+  this lifts hybrid TEDS 0.654→0.724 and **row 0.172→0.417** (ruled-doc
+  subset row 0.19→0.60) with F1 unchanged. (#805, mitigates #38 for hybrid)
 
 - **`flavor="auto"` was silently broken** — `_detect_flavor` passed a
   non-existent `resolution=` kwarg to the image backend, so the `TypeError`

--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -2,9 +2,33 @@
 
 from ..utils import bboxes_overlap
 from ..utils import boundaries_to_split_lines
+from ..utils import text_in_bbox
 from .base import BaseParser
 from .lattice import Lattice
 from .network import Network
+
+#: Minimum fraction of a lattice grid's (cols x rows) crossing points that
+#: must carry an actual joint for the grid to count as "complete" — a real
+#: lattice of ruled lines rather than a couple of stray rules. Below this,
+#: hybrid keeps augmenting lattice's boundaries with network's text splits.
+_LATTICE_GRID_COVERAGE = 0.5
+
+#: A complete grid's row count must stay *commensurate* with the
+#: column-aligned text rows inside it: at least ``_LATTICE_ROW_MATCH`` of them
+#: (else lattice is a partially-ruled fragment dropping unruled rows — the
+#: us-008 / us-033 failure mode) and at most ``_LATTICE_ROW_CEIL`` times them
+#: (else lattice's interior rules don't separate real multi-column rows —
+#: spurious rules or a complex multi-level header that network handles
+#: better, e.g. the vertical_header fixture). Outside the band, hybrid keeps
+#: the network-augmented path. See :meth:`Hybrid._count_column_aligned_rows`.
+_LATTICE_ROW_MATCH = 0.55
+_LATTICE_ROW_CEIL = 1.5
+
+#: The row-match band is only trusted when a grid has at least this many
+#: column-aligned rows — below it the count is too small to be meaningful
+#: (e.g. a list-like ruled table with one multi-column row), so the band is
+#: skipped and the grid kept on its joint-coverage merit alone.
+_MIN_ALIGNED_ROWS = 3
 
 
 class Hybrid(BaseParser):
@@ -228,6 +252,93 @@ class Hybrid(BaseParser):
                     idx_splits = idx_splits - 1
         return boundaries
 
+    def _count_column_aligned_rows(self, lattice_bbox, col_anchors):
+        """Count text rows inside ``lattice_bbox`` that populate >=2 columns.
+
+        Used to tell a complete ruled grid from a *partially*-ruled fragment.
+        A horizontal rule lattice missed leaves text in **several** columns at
+        the same y; a multi-line cell only adds extra text in **one** column.
+        So clustering the bbox's textlines by y and counting the clusters that
+        span at least two of lattice's columns approximates the table's true
+        row count — robust to multi-line cells (which inflate a naive y-count).
+        """
+        tls = [
+            t
+            for t in text_in_bbox(
+                lattice_bbox, self.horizontal_text + self.vertical_text
+            )
+            if t.get_text().strip()
+        ]
+        if not tls:
+            return 0
+
+        def column_of(textline):
+            xc = (textline.x0 + textline.x1) / 2.0
+            for i in range(len(col_anchors) - 1):
+                if col_anchors[i] <= xc <= col_anchors[i + 1]:
+                    return i
+            return None
+
+        rows = self.network_parser._group_rows(tls, row_tol=self.network_parser.row_tol)
+        aligned = 0
+        for row in rows:
+            cols = {column_of(t) for t in row}
+            cols.discard(None)
+            if len(cols) >= 2:
+                aligned += 1
+        return aligned
+
+    def _lattice_grid_is_complete(self, lattice_bbox):
+        """Whether lattice already resolved a full ruled grid for this bbox.
+
+        The combine ``_augment_boundaries_with_splits`` *unions* network's
+        text-derived column splits onto lattice's. On a partial / borderless
+        table that recovers columns lattice couldn't see — the niche hybrid
+        is for. But on an **already-complete** ruled grid the union only adds
+        spurious splits and, because the merged bbox is then parsed by the
+        *network* parser (text-grouped rows), it also throws away lattice's
+        exact ruled rows — the over-split that sinks fully-ruled docs (#38).
+
+        So gate the augmentation. A grid counts as complete only when:
+
+        1. lattice found genuine ruled lines in **both** directions (interior
+           column *and* row anchors, not just the two bbox edges);
+        2. its joints actually cover that grid (a real lattice of crossings,
+           not a couple of stray rules); and
+        3. lattice's row lines account for the table's text rows — i.e. it is
+           not a *partially*-ruled fragment whose unruled rows lattice would
+           silently drop (the us-008 / us-033 failure mode). Network handles
+           those better, so they stay on the augmented path.
+
+        Complete grids are routed to the lattice parser as-is; incomplete ones
+        keep the network-augmented path.
+        """
+        parse = self.lattice_parser.table_bbox_parses[lattice_bbox]
+        col_anchors = parse["col_anchors"]
+        row_anchors = parse["row_anchors"]
+        # Need at least one interior line in *each* direction (more than the
+        # two bbox edges) — otherwise lattice has no grid of its own to keep.
+        if len(col_anchors) <= 2 or len(row_anchors) <= 2:
+            return False
+        joints_normalized = parse.get("joints_normalized", [])
+        unique_joints = {(round(j[0], 1), round(j[1], 1)) for j in joints_normalized}
+        grid_points = len(col_anchors) * len(row_anchors)
+        coverage = len(unique_joints) / grid_points if grid_points else 0.0
+        if coverage < _LATTICE_GRID_COVERAGE:
+            return False
+        # Lattice's row count must stay commensurate with the column-aligned
+        # text rows: too few => partially-ruled fragment (us-008); too many
+        # => interior rules that don't separate real rows (vertical headers).
+        lattice_rows = len(row_anchors) - 1
+        aligned_rows = self._count_column_aligned_rows(lattice_bbox, col_anchors)
+        if aligned_rows >= _MIN_ALIGNED_ROWS and not (
+            _LATTICE_ROW_MATCH * aligned_rows
+            <= lattice_rows
+            <= _LATTICE_ROW_CEIL * aligned_rows
+        ):
+            return False
+        return True
+
     def _merge_bbox_analysis(self, lattice_bbox, network_bbox):
         """Identify splits that were only detected by lattice or by network."""
         lattice_parse = self.lattice_parser.table_bbox_parses[lattice_bbox]
@@ -239,6 +350,10 @@ class Hybrid(BaseParser):
         # Favor network, but complete or adjust its columns based on the
         # splits identified by lattice.
         if network_cols_boundaries is None:
+            self.table_bbox_parses[lattice_bbox] = self.lattice_parser
+        elif self._lattice_grid_is_complete(lattice_bbox):
+            # Lattice already has a full ruled grid here — keep it intact
+            # instead of unioning network's splits on top (#38 over-split).
             self.table_bbox_parses[lattice_bbox] = self.lattice_parser
         else:
             network_cols_boundaries = self._augment_boundaries_with_splits(

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -149,3 +149,47 @@ def test_hybrid_multipage(testdir):
     filename = os.path.join(testdir, "hybrid_multipage.pdf")
     tables = camelot.read_pdf(filename, flavor="hybrid", pages="1-2")
     assert len(tables) == 2  # not 3
+
+
+_ICDAR = "tabula/icdar2013-dataset"
+
+
+def test_hybrid_gates_complete_ruled_grid_to_lattice(testdir):
+    """A complete ruled grid is parsed by lattice, not over-split by network.
+
+    Regression for the #38 over-split: hybrid used to *union* network's
+    text-derived column splits onto an already-complete lattice grid and
+    then parse the merged bbox with the network parser (text-grouped rows),
+    wrecking fully-ruled tables (row accuracy collapsed). The completeness
+    gate now routes a complete grid to the lattice parser untouched.
+    """
+    filename = os.path.join(testdir, _ICDAR, "competition-dataset-eu/eu-009a.pdf")
+    hybrid = camelot.read_pdf(filename, flavor="hybrid")
+    lattice = camelot.read_pdf(filename, flavor="lattice")
+    network = camelot.read_pdf(filename, flavor="network")
+
+    ruled_shape = lattice[0].df.shape  # (9, 4): the clean ruled grid
+    hybrid_shapes = {t.df.shape for t in hybrid}
+    # hybrid reproduces lattice's clean grid ...
+    assert ruled_shape in hybrid_shapes
+    # ... and that grid is not something the network parser produced on its
+    # own, so the gate genuinely re-routed this table.
+    assert ruled_shape not in {t.df.shape for t in network}
+
+
+def test_hybrid_keeps_partial_ruled_grid_on_network(testdir):
+    """A partially-ruled table stays on the network-augmented path.
+
+    Here lattice only finds a small ruled fragment (the top rows); routing
+    the whole table to it would silently drop the unruled rows. The
+    completeness gate rejects such fragments, so hybrid keeps network's
+    full-table extent — and must not regress this niche win.
+    """
+    filename = os.path.join(testdir, _ICDAR, "competition-dataset-us/us-008.pdf")
+    hybrid = camelot.read_pdf(filename, flavor="hybrid")
+    lattice = camelot.read_pdf(filename, flavor="lattice")
+    network = camelot.read_pdf(filename, flavor="network")
+
+    # hybrid keeps network's full table, not lattice's smaller fragment.
+    assert hybrid[0].df.shape == network[0].df.shape
+    assert hybrid[0].df.shape != lattice[0].df.shape


### PR DESCRIPTION
## Problem

`flavor="hybrid"` merges the Lattice and Network parsers. The combine
(`_augment_boundaries_with_splits`) **unions** network's text-derived column
splits onto lattice's boundaries and then parses the merged bbox with the
**network** parser (text-grouped rows). On a partially-ruled / borderless
table that's exactly the niche — network recovers columns lattice can't see.
But on an **already-complete ruled grid** the union only adds spurious column
splits, and routing to the network parser throws away lattice's exact ruled
rows. The result is the #38 over-split: fully-ruled tables lose their row
structure.

On the in-repo ICDAR-2013 benchmark, hybrid's row-count accuracy was a dismal
**0.172** (vs lattice/combined's ~0.76) — per-doc, hybrid destroyed rows on
~27 ruled docs (row-acc 0.0) while lattice got them perfect.

## Fix

Gate the augmentation. A bbox is routed to the lattice parser **untouched**
only when lattice resolved a genuine grid:

1. interior ruled lines in **both** directions (more than the two bbox edges);
2. joints actually covering that grid (a real lattice of crossings, ≥ 50 % of
   the `cols × rows` points), not a couple of stray rules; and
3. a row count **commensurate** with the table's column-aligned text rows —
   not a *partially*-ruled fragment whose unruled rows lattice would silently
   drop (the us-008 / us-033 failure mode), nor a complex multi-level header
   whose interior rules don't separate real rows (the `vertical_header`
   fixture).

Everything else keeps the network-augmented path, so hybrid's borderless /
partial-ruled wins are preserved.

The completeness signal that turned out to matter is **column-aligned rows**:
a horizontal rule lattice *missed* leaves text in several columns at the same
y, whereas a multi-line cell only adds text in one column — so counting y
clusters that span ≥ 2 of lattice's columns approximates the true row count
without being fooled by multi-line cells.

## Results — ICDAR-2013 (`bench/benchmark_icdar.py --flavor hybrid`)

| metric | before | after |
| ------ | ------ | ----- |
| F1     | 0.664  | 0.670 |
| TEDS   | 0.654  | 0.724 |
| row    | 0.172  | **0.417** |
| col    | 0.682  | 0.689 |

Ruled-doc subset (lattice/combined TEDS ≥ 0.6, N=37): row **0.19 → 0.60**,
TEDS 0.63 → 0.80 — climbing toward combined (0.76 / 0.89). The named
borderless win docs (eu-016/017/019/026/027, us-002/003/008, …) are preserved
**byte-for-byte** (verified per-doc before/after).

## Tests

- `tests/test_hybrid.py::test_hybrid_gates_complete_ruled_grid_to_lattice` —
  a complete ruled grid (eu-009a) is reproduced as lattice sees it, which the
  network parser does not produce on its own.
- `tests/test_hybrid.py::test_hybrid_keeps_partial_ruled_grid_on_network` —
  a partially-ruled table (us-008) keeps network's full extent, not lattice's
  smaller fragment.
- Full suite green (267 passed, ghostscript/poppler env-skipped locally).