### PR TITLE
fix(hybrid): default lattice half to engine='combined'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changed
 
+- **`flavor='hybrid'` now defaults its lattice half to `engine='combined'`**
+  (was `'raster'`), matching `flavor='lattice'` and the documented behaviour.
+  Combined detects ruled grids better, so the completeness gating routes
+  more complete grids to the lattice parser — on the in-repo ICDAR-2013
+  benchmark hybrid TEDS 0.724→0.806, row 0.417→0.659, col 0.689→0.868.
+
 - **`engine='combined'` is now the default lattice engine** (was
   `'raster'`), and **`engine='auto'` was removed**. Combined is the
   strongest detector and safe by construction; its vector ruled lines are

--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -64,14 +64,14 @@ class Hybrid(BaseParser):
     column_tol : int, optional (default: 0)
         Tolerance parameter used to combine text horizontally,
         to generate columns.
-    engine : str, optional (default: 'raster')
+    engine : str, optional (default: 'combined')
         Line-detection engine for hybrid's **lattice half** (the network
         half is text-based and unaffected):
 
-        - ``'raster'`` (default): detect ruled lines with OpenCV on the
-          rendered page.
-        - ``'combined'``: OpenCV **plus** the PDF's native vector ruled
-          lines unioned in — recovers faintly-rendered rules.
+        - ``'combined'`` (default): OpenCV on the rendered page **plus** the
+          PDF's native vector ruled lines unioned in — recovers
+          faintly-rendered rules. Matches the ``flavor='lattice'`` default.
+        - ``'raster'``: detect ruled lines with OpenCV only (pre-#763).
         - ``'vector'``: detect ruled lines **straight from the PDF's vector
           graphics, skipping rasterisation and OpenCV entirely** — the
           render-free hybrid (network text-edge alignment merged with vector
@@ -93,7 +93,7 @@ class Hybrid(BaseParser):
         row_tol=2,
         column_tol=0,
         debug=False,
-        engine="raster",
+        engine="combined",
         **kwargs,
     ):
         super().__init__(

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -45,8 +45,11 @@ def test_hybrid_vertical_header(testdir):
     df = pd.DataFrame(data_hybrid_vertical_headers)
 
     filename = os.path.join(testdir, "vertical_header.pdf")
+    # engine='raster' pins this fixture to the engine it was recorded under;
+    # the hybrid default is now 'combined' (covered by the benchmark + the
+    # other hybrid tests).
     tables = camelot.read_pdf(
-        filename, flavor="hybrid", backend="pdfium", use_fallback=False
+        filename, flavor="hybrid", backend="pdfium", use_fallback=False, engine="raster"
     )
     assert len(tables) == 1
     assert_frame_equal(df, tables[0].df)
@@ -56,7 +59,9 @@ def test_hybrid_process_background(testdir):
     df = pd.DataFrame(data_hybrid_process_background)
 
     filename = os.path.join(testdir, "background_lines_1.pdf")
-    tables = camelot.read_pdf(filename, flavor="hybrid", process_background=True)
+    tables = camelot.read_pdf(
+        filename, flavor="hybrid", process_background=True, engine="raster"
+    )
     assert_frame_equal(df, tables[1].df)
 
 

--- a/tests/test_vector_engine_probe.py
+++ b/tests/test_vector_engine_probe.py
@@ -136,12 +136,12 @@ def test_hybrid_forwards_engine_to_lattice():
     """Hybrid constructs its Lattice sub-parser with the requested engine."""
     from camelot.parsers.hybrid import Hybrid
 
-    h = Hybrid(engine="combined")
-    assert h.lattice_parser.engine == "combined"
+    h = Hybrid(engine="raster")
+    assert h.lattice_parser.engine == "raster"
     # vector half: the render-free hybrid (#39)
     assert Hybrid(engine="vector").lattice_parser.engine == "vector"
-    # default stays raster
-    assert Hybrid().lattice_parser.engine == "raster"
+    # default is 'combined', matching flavor='lattice'
+    assert Hybrid().lattice_parser.engine == "combined"
 
 
 def test_vector_engine_through_hybrid(foo_pdf):


### PR DESCRIPTION
`flavor='hybrid'` forwarded `engine='raster'` to its lattice half by default, despite the `io.py`/hybrid docstrings stating `'combined'` (the `flavor='lattice'` default since the engine cleanup, #803). This aligns it.

**More than a consistency fix** — combined detects ruled grids better, so the completeness gating (#805) routes more complete grids to the lattice parser:

| ICDAR-2013, `flavor='hybrid'` | F1 | TEDS | row | col |
|---|--:|--:|--:|--:|
| raster lattice-half | 0.702 | 0.724 | 0.417 | 0.689 |
| **combined lattice-half (new default)** | 0.714 | **0.806** | **0.659** | **0.868** |

Two raster-recorded regression fixtures (`test_hybrid_vertical_header`, `test_hybrid_process_background`) are pinned to `engine='raster'` — combined shifts their output on those specific PDFs (a row re-baseline; an extra 1-row strip), and the aggregate combined win is covered by the benchmark + the other hybrid tests. `test_hybrid_forwards_engine_to_lattice` updated for the new default.

31 hybrid/vector tests pass; ruff clean.