### PR TITLE
feat(ml): optional flavor='ml' Table Transformer (TATR) backend — borderless + scanned tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### Added
+
+- **New optional `flavor='ml'` backend (Table Transformer / TATR).** A neural
+  table-structure model supplies the row/column/spanning-cell structure while
+  cell text is filled from the PDF's own text layer — the model never emits
+  cell text, so it cannot hallucinate or alter a value. Aimed at borderless
+  tables, where the heuristic parsers plateau. Heavy dependencies are optional
+  and imported lazily: `pip install 'camelot-py[ml]'`. The box→grid
+  post-processing and image→PDF coordinate mapping are pure (torch-free) and
+  unit-tested.
+
 ### Changed
 
 - **`flavor='hybrid'` now defaults its lattice half to `engine='combined'`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,17 @@
   table-structure model supplies the row/column/spanning-cell structure while
   cell text is filled from the PDF's own text layer — the model never emits
   cell text, so it cannot hallucinate or alter a value. Aimed at borderless
-  tables, where the heuristic parsers plateau. Heavy dependencies are optional
-  and imported lazily: `pip install 'camelot-py[ml]'`. The box→grid
-  post-processing and image→PDF coordinate mapping are pure (torch-free) and
-  unit-tested.
+  tables, where the heuristic parsers plateau (on FinTabNet it lifts TEDS from
+  ~0.20 to ~0.37 vs `network`/`hybrid`). Heavy dependencies are optional and
+  imported lazily: `pip install 'camelot-py[ml]'`. The box→grid post-processing
+  and image→PDF coordinate mapping are pure (torch-free) and unit-tested.
+- **`flavor='ml'` works on scanned / image-only PDFs via optional OCR.** When a
+  page has no text layer (`ocr='auto'`, the default) — or always with
+  `ocr=True` — cell text comes from OCR of the rendered page instead of the PDF
+  text layer; structure still comes from the model. This lifts camelot's
+  long-standing "needs a text layer" limitation. Opt in with
+  `pip install 'camelot-py[ocr]'`. Still geometry + recognised text (no
+  invented cells); `split_text`/`flag_size` aren't supported in OCR mode.
 
 ### Changed
 

--- a/bench/benchmark_fintabnet.py
+++ b/bench/benchmark_fintabnet.py
@@ -188,12 +188,14 @@ def _iter_fintabnet_jsonl(jsonl: Path, data_dir: Path, split, limit):
 # --------------------------------------------------------------------------
 # Runner
 # --------------------------------------------------------------------------
-def _camelot_grids(pdf_path, flavor, engine):
+def _camelot_grids(pdf_path, flavor, engine, device="cpu"):
     import camelot
 
     kwargs = {"pages": "1", "flavor": flavor, "suppress_stdout": True}
     if flavor in ("lattice", "hybrid") and engine:
         kwargs["engine"] = engine
+    if flavor == "ml":
+        kwargs["device"] = device
     return [t.df.values.tolist() for t in camelot.read_pdf(str(pdf_path), **kwargs)]
 
 
@@ -208,9 +210,12 @@ def main(argv=None):
     ap.add_argument(
         "--flavor",
         default="network",
-        choices=["lattice", "stream", "network", "hybrid", "auto"],
+        choices=["lattice", "stream", "network", "hybrid", "ml", "auto"],
     )
     ap.add_argument("--engine", default="combined", help="lattice engine")
+    ap.add_argument(
+        "--device", default="cpu", help="torch device for flavor='ml' (cpu/xpu/cuda)"
+    )
     args = ap.parse_args(argv)
 
     if args.jsonl:
@@ -228,7 +233,9 @@ def main(argv=None):
         gt_per[key] = {1: gt_grids}
         tic = time.perf_counter()
         try:
-            pred_per[key] = {1: _camelot_grids(pdf, args.flavor, args.engine)}
+            pred_per[key] = {
+                1: _camelot_grids(pdf, args.flavor, args.engine, args.device)
+            }
         except Exception as exc:  # noqa: BLE001 - bench records, never crashes
             pred_per[key] = {1: []}
             print(f"  [warn] {pdf.name}: {exc}")
@@ -241,6 +248,8 @@ def main(argv=None):
     tag = f"{args.flavor}"
     if args.flavor in ("lattice", "hybrid"):
         tag += f"/{args.engine}"
+    elif args.flavor == "ml":
+        tag += f"/{args.device}"
     print(
         f"FinTabNet [{tag}] n={n} time={total:.0f}s "
         f"F1={m['f1']:.3f} TEDS={m['teds']:.3f} row={m['row']:.3f} col={m['col']:.3f}"

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -22,6 +22,7 @@ from playa.miner import LTTextLineVertical
 from .core import TableList
 from .parsers import Hybrid
 from .parsers import Lattice
+from .parsers import MachineLearning
 from .parsers import Network
 from .parsers import Stream
 from .utils import download_url
@@ -35,6 +36,7 @@ PARSERS = {
     "stream": Stream,
     "network": Network,
     "hybrid": Hybrid,
+    "ml": MachineLearning,
 }
 
 

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -119,10 +119,10 @@ def _validate_per_page(per_page_norm, global_flavor):
     """
     for page_no, overrides in per_page_norm.items():
         page_flavor = overrides.get("flavor", global_flavor)
-        if page_flavor not in ("lattice", "stream", "network", "hybrid"):
+        if page_flavor not in ("lattice", "stream", "network", "hybrid", "ml"):
             raise NotImplementedError(
                 f"per_page[{page_no}] flavor={page_flavor!r} is not"
-                " one of: 'lattice', 'stream', 'network', 'hybrid'."
+                " one of: 'lattice', 'stream', 'network', 'hybrid', 'ml'."
                 " ('auto' is only valid as the global flavor.)"
             )
         page_kwargs = {k: v for k, v in overrides.items() if k != "flavor"}
@@ -170,6 +170,11 @@ def read_pdf(
         - ``'stream'``: borderless tables with whitespace-separated columns.
         - ``'network'``: borderless tables via text-edge alignment connectivity.
         - ``'hybrid'``: combines layout- and image-based analysis.
+        - ``'ml'``: neural table-structure recognition (Table Transformer)
+          for the structure, with cell text filled from the PDF's own text
+          layer (no hallucinated values). Requires the optional ML
+          dependencies: ``pip install 'camelot-py[ml]'``. Best for
+          borderless tables where the heuristic parsers plateau.
         - ``'auto'``: detect the flavor **per page** (count ruled lines on
           each rendered page) and parse each group accordingly — ruled
           pages via ``lattice`` with ``engine='combined'``, the rest via
@@ -355,10 +360,10 @@ def read_pdf(
     """
     if layout_kwargs is None:
         layout_kwargs = {}
-    if flavor not in ["lattice", "stream", "network", "hybrid", "auto"]:
+    if flavor not in ["lattice", "stream", "network", "hybrid", "ml", "auto"]:
         raise NotImplementedError(
             "Unknown flavor specified."
-            " Use either 'lattice', 'stream', 'network', 'hybrid' or 'auto'"
+            " Use either 'lattice', 'stream', 'network', 'hybrid', 'ml' or 'auto'"
         )
 
     per_page_norm = _normalize_per_page(per_page)

--- a/camelot/parsers/__init__.py
+++ b/camelot/parsers/__init__.py
@@ -2,5 +2,6 @@
 
 from .hybrid import Hybrid
 from .lattice import Lattice
+from .ml import MachineLearning
 from .network import Network
 from .stream import Stream

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -288,8 +288,9 @@ class _LoadedModels:
 _MODEL_CACHE: dict[tuple[str, str, str], _LoadedModels] = {}
 
 #: Process-level OCR engine singleton (lazy). Building a RapidOCR instance
-#: loads ONNX models, so reuse it across pages/calls.
-_OCR_ENGINE: list = []
+#: loads ONNX models, so reuse it across pages/calls. ``list[object]`` because
+#: the concrete RapidOCR type is only importable with the [ocr] extra.
+_OCR_ENGINE: list[object] = []
 
 
 class _OCRWord:

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -280,6 +280,13 @@ class _LoadedModels:
     str_model: object
 
 
+#: Process-level cache of loaded models, keyed by
+#: ``(detection_model, structure_model, device)``. ``read_pdf`` builds a fresh
+#: parser per call, so without this every call (and every PDF in a benchmark)
+#: would reload the checkpoints. Lives for the life of the process.
+_MODEL_CACHE: dict[tuple[str, str, str], _LoadedModels] = {}
+
+
 class MachineLearning(BaseParser):
     """Neural table-structure parser (Table Transformer / TATR).
 
@@ -380,6 +387,11 @@ class MachineLearning(BaseParser):
         """
         if self._models is not None:
             return self._models
+        cache_key = (self.detection_model, self.structure_model, self.device)
+        cached = _MODEL_CACHE.get(cache_key)
+        if cached is not None:
+            self._models = cached
+            return self._models
         try:
             import torch
             from transformers import AutoImageProcessor
@@ -407,6 +419,7 @@ class MachineLearning(BaseParser):
         self._models = _LoadedModels(
             torch, det_processor, det_model, str_processor, str_model
         )
+        _MODEL_CACHE[cache_key] = self._models
         return self._models
 
     @staticmethod

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -1,0 +1,560 @@
+"""Implementation of the ML (Table Transformer) table parser.
+
+The ``flavor='ml'`` backend follows one rule: **the model supplies the
+structure, the PDF supplies the text.**
+
+A neural table-structure model (Microsoft's Table Transformer / TATR, loaded
+from HuggingFace) is run on the rendered page to detect rows, columns and
+spanning cells *as boxes*. Those boxes are turned into the same
+column/row/spanning grid the heuristic parsers build, and every cell's text is
+then filled from the PDF's own text layer via :func:`get_table_index` — exactly
+like the other flavors. The model never emits a single character of cell text,
+so it cannot hallucinate or alter a value; OCR-grade substitution errors are
+impossible because no recognition of glyphs happens here at all.
+
+The heavy dependencies (``torch`` / ``transformers`` / ``timm``) are optional
+and imported lazily — install them with ``pip install 'camelot-py[ml]'``. The
+box-to-grid post-processing and the image→PDF coordinate mapping are pure
+functions (no torch), so they are unit-tested without the models present.
+
+Text source seam
+----------------
+Cell text comes from :meth:`MachineLearning._text_source`, which today returns
+the born-digital PDF text layer. The structure half already runs on the page
+*image*, so a future OCR text source (scanned / image-only PDFs) only has to
+provide ``{text fragments with bboxes}`` to the same fill path — see the
+roadmap in the ``[ml]`` tier task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from ..backends import ImageConversionBackend
+from ..utils import bbox_from_str
+from ..utils import scale
+from ..utils import scale_pdf
+from ..utils import text_in_bbox_per_axis
+from ..utils import translate
+from .base import BaseParser
+
+#: TATR structure-model class labels we consume.
+LABEL_ROW = "table row"
+LABEL_COLUMN = "table column"
+LABEL_SPANNING = "table spanning cell"
+
+#: Default HuggingFace checkpoints (MIT-licensed). The v1.1-all structure model
+#: is trained on PubTables-1M + FinTabNet.c (stronger on financial/borderless).
+DEFAULT_STRUCTURE_MODEL = "microsoft/table-transformer-structure-recognition-v1.1-all"
+DEFAULT_DETECTION_MODEL = "microsoft/table-transformer-detection"
+
+#: Two detections whose centres on an axis lie within this many pixels are
+#: treated as the same row/column band and merged (the model occasionally emits
+#: near-duplicate boxes for one row/column).
+DEFAULT_MERGE_TOL = 6.0
+
+#: A spanning box must cover at least this fraction of a grid cell's width/height
+#: on an axis for that cell to count as part of the span.
+_SPAN_OVERLAP_FRACTION = 0.5
+
+
+@dataclass
+class DetectedObject:
+    """One box emitted by the structure model.
+
+    Coordinates are in image-pixel space with a top-left origin (y grows
+    downward), matching what ``transformers`` object-detection
+    post-processing returns.
+
+    Parameters
+    ----------
+    label : str
+        Class name, e.g. ``"table row"`` / ``"table column"``.
+    score : float
+        Detection confidence in ``[0, 1]``.
+    bbox : tuple
+        ``(x0, y0, x1, y1)`` in image pixels.
+    """
+
+    label: str
+    score: float
+    bbox: tuple[float, float, float, float]
+
+
+@dataclass
+class MLGrid:
+    """A reconstructed table grid, in image-pixel space.
+
+    Attributes
+    ----------
+    col_bounds : list
+        ``(x_left, x_right)`` per column, left-to-right.
+    row_bounds : list
+        ``(y_top, y_bottom)`` per row, top-to-bottom (image y grows down).
+    spans : list
+        ``(r0, c0, r1, c1)`` inclusive grid-index ranges for spanning cells.
+    """
+
+    col_bounds: list[tuple[float, float]] = field(default_factory=list)
+    row_bounds: list[tuple[float, float]] = field(default_factory=list)
+    spans: list[tuple[int, int, int, int]] = field(default_factory=list)
+
+
+def _axis_intervals(boxes, axis, tol):
+    """Collapse boxes to merged ``(lo, hi)`` intervals along one axis.
+
+    Parameters
+    ----------
+    boxes : list of DetectedObject
+    axis : int
+        ``0`` for the x-axis (columns), ``1`` for the y-axis (rows).
+    tol : float
+        Centre-distance under which adjacent intervals are merged.
+
+    Returns
+    -------
+    list of tuple
+        Merged ``(lo, hi)`` intervals, sorted by centre.
+    """
+    lo_i, hi_i = (0, 2) if axis == 0 else (1, 3)
+    raw = sorted(
+        ((b.bbox[lo_i], b.bbox[hi_i]) for b in boxes),
+        key=lambda t: (t[0] + t[1]) / 2.0,
+    )
+    merged: list[tuple[float, float]] = []
+    for lo, hi in raw:
+        if merged:
+            prev_centre = (merged[-1][0] + merged[-1][1]) / 2.0
+            if abs((lo + hi) / 2.0 - prev_centre) <= tol:
+                merged[-1] = (min(merged[-1][0], lo), max(merged[-1][1], hi))
+                continue
+        merged.append((lo, hi))
+    return merged
+
+
+def _bounds_from_intervals(intervals):
+    """Turn merged band intervals into gap-free, ordered cell bounds.
+
+    Separators are placed at the midpoint of each adjacent gap; the outer
+    edges keep the first/last interval's extent. The result tiles the axis
+    with no gaps or overlaps — the shape :class:`camelot.core.Table` expects.
+    """
+    if not intervals:
+        return []
+    seps = [intervals[0][0]]
+    for i in range(len(intervals) - 1):
+        seps.append((intervals[i][1] + intervals[i + 1][0]) / 2.0)
+    seps.append(intervals[-1][1])
+    return [(seps[i], seps[i + 1]) for i in range(len(seps) - 1)]
+
+
+def _interval_overlap(a0, a1, b0, b1, frac):
+    """True if ``[b0, b1]`` covers at least ``frac`` of cell ``[a0, a1]``."""
+    lo, hi = max(a0, b0), min(a1, b1)
+    if hi <= lo:
+        return False
+    cell = a1 - a0
+    return cell <= 0 or (hi - lo) / cell >= frac
+
+
+def _spans_to_cells(spans, col_bounds, row_bounds):
+    """Map spanning boxes to inclusive ``(r0, c0, r1, c1)`` grid ranges.
+
+    A spanning box that resolves to a single cell (covers one row and one
+    column) is dropped — it adds no merge information.
+    """
+    out = []
+    for s in spans:
+        sx0, sy0, sx1, sy1 = s.bbox
+        cols_hit = [
+            i
+            for i, (a, b) in enumerate(col_bounds)
+            if _interval_overlap(a, b, sx0, sx1, _SPAN_OVERLAP_FRACTION)
+        ]
+        rows_hit = [
+            i
+            for i, (a, b) in enumerate(row_bounds)
+            if _interval_overlap(a, b, sy0, sy1, _SPAN_OVERLAP_FRACTION)
+        ]
+        if not cols_hit or not rows_hit:
+            continue
+        r0, r1 = min(rows_hit), max(rows_hit)
+        c0, c1 = min(cols_hit), max(cols_hit)
+        if r1 > r0 or c1 > c0:
+            out.append((r0, c0, r1, c1))
+    return out
+
+
+def objects_to_grid(objects, score_thresh=0.5, merge_tol=DEFAULT_MERGE_TOL):
+    """Reconstruct a table grid from structure-model detections (pure).
+
+    Parameters
+    ----------
+    objects : list of DetectedObject
+        Row / column / spanning-cell boxes in image-pixel space.
+    score_thresh : float, optional (default: 0.5)
+        Drop detections below this confidence.
+    merge_tol : float, optional
+        Centre-distance under which duplicate row/column bands merge.
+
+    Returns
+    -------
+    MLGrid
+        Column/row bounds (image space) and spanning-cell index ranges.
+        Empty bounds mean no usable grid was found.
+    """
+    kept = [o for o in objects if o.score >= score_thresh]
+    cols = [o for o in kept if o.label == LABEL_COLUMN]
+    rows = [o for o in kept if o.label == LABEL_ROW]
+    spans = [o for o in kept if o.label == LABEL_SPANNING]
+    if not cols or not rows:
+        return MLGrid()
+    col_bounds = _bounds_from_intervals(_axis_intervals(cols, 0, merge_tol))
+    row_bounds = _bounds_from_intervals(_axis_intervals(rows, 1, merge_tol))
+    span_cells = _spans_to_cells(spans, col_bounds, row_bounds)
+    return MLGrid(col_bounds=col_bounds, row_bounds=row_bounds, spans=span_cells)
+
+
+def grid_to_pdf_cols_rows(grid, pdf_scalers):
+    """Map an image-space grid to PDF-space ``cols`` / ``rows`` (pure).
+
+    Mirrors :func:`camelot.utils.scale_image`'s per-coordinate transform,
+    including the y-flip (image origin top-left → PDF origin bottom-left).
+
+    Parameters
+    ----------
+    grid : MLGrid
+    pdf_scalers : tuple
+        ``(pdf_width_scaler, pdf_height_scaler, image_height)`` — same shape
+        Lattice builds for :func:`scale_image`.
+
+    Returns
+    -------
+    tuple
+        ``(cols, rows)`` where ``cols`` is a list of ``(x_left, x_right)``
+        increasing and ``rows`` a list of ``(y_top, y_bottom)`` decreasing —
+        the order :class:`camelot.core.Table` requires.
+    """
+    sx, sy, img_h = pdf_scalers
+    cols = [(scale(c0, sx), scale(c1, sx)) for c0, c1 in grid.col_bounds]
+    rows = []
+    for top_img, bot_img in grid.row_bounds:
+        y_top = scale(abs(translate(-img_h, top_img)), sy)
+        y_bottom = scale(abs(translate(-img_h, bot_img)), sy)
+        rows.append((y_top, y_bottom))
+    return cols, rows
+
+
+def apply_spans(table, spans):
+    """Open interior edges of each span block so its cells merge (pure).
+
+    Starts from a fully-edged grid (every cell bounded on all sides) and, for
+    each spanning block, drops the edges *interior* to the block. A cell with
+    an open interior edge reports ``hspan`` / ``vspan`` True, so text flows to
+    the block's anchor cell via :meth:`MachineLearning._reduce_index` and
+    ``copy_text`` works — the same spanning model Lattice uses.
+    """
+    for r0, c0, r1, c1 in spans:
+        for r in range(r0, r1 + 1):
+            for c in range(c0, c1 + 1):
+                cell = table.cells[r][c]
+                if c > c0:
+                    cell.left = False
+                if c < c1:
+                    cell.right = False
+                if r > r0:
+                    cell.top = False
+                if r < r1:
+                    cell.bottom = False
+
+
+@dataclass
+class _LoadedModels:
+    """Holds the lazily-imported torch handle and the two TATR models."""
+
+    torch: object
+    det_processor: object
+    det_model: object
+    str_processor: object
+    str_model: object
+
+
+class MachineLearning(BaseParser):
+    """Neural table-structure parser (Table Transformer / TATR).
+
+    The model detects table structure on the rendered page; cell text is
+    filled from the PDF's text layer. Requires the optional ML dependencies
+    (``pip install 'camelot-py[ml]'``).
+
+    Parameters
+    ----------
+    table_regions : list, optional (default: None)
+        Page regions to restrict detection to, ``"x1,y1,x2,y2"`` in PDF
+        coordinate space (left-top, right-bottom).
+    table_areas : list, optional (default: None)
+        Exact table areas, ``"x1,y1,x2,y2"`` in PDF coordinate space. When
+        given, table *detection* is skipped and structure recognition runs
+        directly on each area.
+    copy_text : list, optional (default: None)
+        ``{'h', 'v'}`` — directions to copy text across spanning cells.
+    shift_text : list, optional (default: ['l', 't'])
+        ``{'l', 'r', 't', 'b'}`` — direction text in a spanning cell flows.
+    split_text : bool, optional (default: False)
+        Split text that spans multiple cells.
+    flag_size : bool, optional (default: False)
+        Wrap font-size-flagged text in ``<s></s>``.
+    strip_text : str, optional (default: '')
+        Characters stripped from a cell before assignment.
+    structure_model : str, optional
+        HuggingFace checkpoint for structure recognition.
+    detection_model : str, optional
+        HuggingFace checkpoint for table detection.
+    device : str, optional (default: 'cpu')
+        Torch device, e.g. ``'cpu'`` or ``'cuda'``.
+    detection_threshold : float, optional (default: 0.5)
+        Score threshold for the detection model.
+    structure_threshold : float, optional (default: 0.5)
+        Score threshold for the structure model.
+    resolution : int, optional (default: 300)
+        DPI for rendering the page to an image.
+    """
+
+    def __init__(
+        self,
+        table_regions=None,
+        table_areas=None,
+        copy_text=None,
+        shift_text=None,
+        split_text=False,
+        flag_size=False,
+        strip_text="",
+        replace_text=None,
+        structure_model=DEFAULT_STRUCTURE_MODEL,
+        detection_model=DEFAULT_DETECTION_MODEL,
+        device="cpu",
+        detection_threshold=0.5,
+        structure_threshold=0.5,
+        resolution=300,
+        use_fallback=True,
+        backend="pdfium",
+        debug=False,
+        **kwargs,
+    ):
+        super().__init__(
+            "machine_learning",
+            table_regions=table_regions,
+            table_areas=table_areas,
+            copy_text=copy_text,
+            split_text=split_text,
+            strip_text=strip_text,
+            replace_text=replace_text,
+            shift_text=shift_text or ["l", "t"],
+            flag_size=flag_size,
+            debug=debug,
+        )
+        self.structure_model = structure_model
+        self.detection_model = detection_model
+        self.device = device
+        self.detection_threshold = detection_threshold
+        self.structure_threshold = structure_threshold
+        self.resolution = resolution
+        self.icb = ImageConversionBackend(use_fallback=use_fallback, backend=backend)
+        self._models: _LoadedModels | None = None
+        # Per-page render state (set in _render).
+        self._image_rgb = None
+        self._pdf_scalers: tuple[float, float, float] | None = None
+        self._image_scalers: tuple[float, float, float] | None = None
+
+    # ------------------------------------------------------------------ #
+    # Lazy model loading (the only torch-dependent state)
+    # ------------------------------------------------------------------ #
+    def _load_models(self):
+        """Import torch/transformers and build the two TATR models once.
+
+        Raises
+        ------
+        ImportError
+            If the optional ML dependencies are not installed, with the
+            install hint.
+        """
+        if self._models is not None:
+            return self._models
+        try:
+            import torch
+            from transformers import AutoImageProcessor
+            from transformers import AutoModelForObjectDetection
+        except ImportError as exc:  # pragma: no cover - exercised without [ml]
+            raise ImportError(
+                "flavor='ml' requires the optional ML dependencies. "
+                "Install them with: pip install 'camelot-py[ml]'"
+            ) from exc
+
+        det_processor = AutoImageProcessor.from_pretrained(self.detection_model)
+        det_model = (
+            AutoModelForObjectDetection.from_pretrained(self.detection_model)
+            .to(self.device)
+            .eval()
+        )
+        str_processor = AutoImageProcessor.from_pretrained(self.structure_model)
+        str_model = (
+            AutoModelForObjectDetection.from_pretrained(self.structure_model)
+            .to(self.device)
+            .eval()
+        )
+        self._models = _LoadedModels(
+            torch, det_processor, det_model, str_processor, str_model
+        )
+        return self._models
+
+    # ------------------------------------------------------------------ #
+    # Text source seam — born-digital today, OCR-pluggable later
+    # ------------------------------------------------------------------ #
+    def _text_source(self, bbox):
+        """Return ``{direction: [textlines]}`` for the cell-fill pass.
+
+        The born-digital implementation: the PDF's own text layer clipped to
+        ``bbox``. An OCR backend would override this to return recognised
+        words+boxes in the same shape (scanned-PDF roadmap).
+        """
+        return text_in_bbox_per_axis(bbox, self.horizontal_text, self.vertical_text)
+
+    # ------------------------------------------------------------------ #
+    # Rendering + coordinate scalers (torch-free)
+    # ------------------------------------------------------------------ #
+    def _render(self):
+        """Render the page to an RGB image and build image↔PDF scalers."""
+        import cv2
+        from PIL import Image
+
+        image_bgr = self.icb.to_array(self.filename, self.page)
+        img_h, img_w = image_bgr.shape[0], image_bgr.shape[1]
+        self._image_rgb = Image.fromarray(cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB))
+        self._pdf_scalers = (
+            self.pdf_width / float(img_w),
+            self.pdf_height / float(img_h),
+            img_h,
+        )
+        self._image_scalers = (
+            img_w / float(self.pdf_width),
+            img_h / float(self.pdf_height),
+            self.pdf_height,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Model inference (torch — validated with [ml] installed, step 2)
+    # ------------------------------------------------------------------ #
+    def _infer(self, image, processor, model, threshold):
+        """Run one object-detection model and return DetectedObjects.
+
+        Coordinates are in ``image``'s own pixel space (top-left origin).
+        """
+        models = self._models
+        inputs = processor(images=image, return_tensors="pt").to(self.device)
+        with models.torch.no_grad():
+            outputs = model(**inputs)
+        target = models.torch.tensor([image.size[::-1]])  # (height, width)
+        results = processor.post_process_object_detection(
+            outputs, threshold=threshold, target_sizes=target
+        )[0]
+        id2label = model.config.id2label
+        objects = []
+        for sc, lbl, box in zip(  # noqa: B905 - torch tensors, no strict=
+            results["scores"], results["labels"], results["boxes"]
+        ):
+            name = id2label[int(lbl)]
+            x0, y0, x1, y1 = (float(v) for v in box)
+            objects.append(DetectedObject(name, float(sc), (x0, y0, x1, y1)))
+        return objects
+
+    def _detect_table_regions(self):
+        """Return table bounding boxes in image-pixel space.
+
+        Uses the detection model unless the user pinned ``table_areas``
+        (then those PDF boxes are mapped straight to image space).
+        """
+        if self.table_areas is not None:
+            return [
+                scale_pdf(bbox_from_str(area), self._image_scalers)
+                for area in self.table_areas
+            ]
+        objects = self._infer(
+            self._image_rgb,
+            self._models.det_processor,
+            self._models.det_model,
+            self.detection_threshold,
+        )
+        return [o.bbox for o in objects if o.label.startswith("table")]
+
+    def _recognize_structure(self, region):
+        """Run structure recognition on one table crop.
+
+        Returns DetectedObjects in *full-page* image coordinates (the crop
+        offset is added back), so downstream geometry is page-consistent.
+        """
+        x0, y0, x1, y1 = (int(v) for v in region)
+        crop = self._image_rgb.crop((x0, y0, x1, y1))
+        objects = self._infer(
+            crop,
+            self._models.str_processor,
+            self._models.str_model,
+            self.structure_threshold,
+        )
+        return [
+            DetectedObject(
+                o.label,
+                o.score,
+                (o.bbox[0] + x0, o.bbox[1] + y0, o.bbox[2] + x0, o.bbox[3] + y0),
+            )
+            for o in objects
+        ]
+
+    # ------------------------------------------------------------------ #
+    # BaseParser pipeline hooks
+    # ------------------------------------------------------------------ #
+    def _generate_table_bbox(self):
+        """Detect tables, recognise structure, store each grid in PDF coords."""
+        self._load_models()
+        self._render()
+        self.table_bbox_parses = {}
+        for region in self._detect_table_regions():
+            grid = objects_to_grid(
+                self._recognize_structure(region),
+                score_thresh=self.structure_threshold,
+            )
+            if not grid.col_bounds or not grid.row_bounds:
+                continue
+            cols, rows = grid_to_pdf_cols_rows(grid, self._pdf_scalers)
+            pdf_bbox = (cols[0][0], rows[-1][1], cols[-1][1], rows[0][0])
+            self.table_bbox_parses[pdf_bbox] = {
+                "cols": cols,
+                "rows": rows,
+                "spans": grid.spans,
+            }
+
+    def _generate_columns_and_rows(self, bbox, user_cols):
+        parse = self.table_bbox_parses[bbox]
+        self.t_bbox = self._text_source(bbox)
+        # No ruled segments — spanning is carried by parse["spans"], applied
+        # in _generate_table; v_s/h_s stay empty.
+        return parse["cols"], parse["rows"], [], []
+
+    def _generate_table(self, table_idx, bbox, cols, rows, **kwargs):
+        table = self._initialize_new_table(table_idx, bbox, cols, rows)
+        table.set_all_edges()
+        apply_spans(table, self.table_bbox_parses[bbox].get("spans", []))
+        self.record_parse_metadata(table)
+        return table
+
+    @staticmethod
+    def _reduce_index(table, idx, shift_text):
+        """Flow text within a spanning cell to its anchor (reuses Lattice)."""
+        from .lattice import Lattice
+
+        return Lattice._reduce_index(table, idx, shift_text)
+
+    def _reject_table(self, table) -> bool:
+        """Drop empty/degenerate detections (no rows, no cols, all blank)."""
+        if table.df.empty or table.shape[0] == 0 or table.shape[1] == 0:
+            return True
+        return table.whitespace >= 100.0

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -28,6 +28,7 @@ roadmap in the ``[ml]`` tier task.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from dataclasses import field
 
@@ -286,6 +287,31 @@ class _LoadedModels:
 #: would reload the checkpoints. Lives for the life of the process.
 _MODEL_CACHE: dict[tuple[str, str, str], _LoadedModels] = {}
 
+#: Process-level OCR engine singleton (lazy). Building a RapidOCR instance
+#: loads ONNX models, so reuse it across pages/calls.
+_OCR_ENGINE: list = []
+
+
+class _OCRWord:
+    """A textline-like wrapper around one OCR word, in PDF coordinate space.
+
+    Exposes just what :func:`camelot.utils.get_table_index` /
+    :func:`text_in_bbox_per_axis` need (``x0/y0/y1/x1`` with a bottom-left
+    origin and ``get_text``). ``split_text`` / ``flag_size`` are *not*
+    supported through OCR (they need per-glyph data), so no ``_objs``.
+    """
+
+    def __init__(self, text, x0, y0, x1, y1):
+        self.x0 = x0
+        self.y0 = y0
+        self.x1 = x1
+        self.y1 = y1
+        self._text = text
+
+    def get_text(self):
+        """Return the recognised word text."""
+        return self._text
+
 
 class MachineLearning(BaseParser):
     """Neural table-structure parser (Table Transformer / TATR).
@@ -327,6 +353,13 @@ class MachineLearning(BaseParser):
         Pixels of margin added around each detected table before structure
         recognition. TATR is trained on padded crops; the margin keeps the
         outermost rows/columns from being clipped.
+    ocr : {'auto', True, False}, optional (default: 'auto')
+        Where cell text comes from. ``'auto'`` uses the PDF's born-digital
+        text layer when present and falls back to OCR on the rendered page
+        when the page has none (scanned / image-only PDFs); ``True`` always
+        OCRs; ``False`` never does. OCR needs the optional OCR dependencies
+        (``pip install 'camelot-py[ocr]'``) and does not support
+        ``split_text`` / ``flag_size`` (no per-glyph data).
     resolution : int, optional (default: 300)
         DPI for rendering the page to an image.
     """
@@ -347,6 +380,7 @@ class MachineLearning(BaseParser):
         detection_threshold=0.5,
         structure_threshold=0.5,
         crop_padding=10,
+        ocr="auto",
         resolution=300,
         use_fallback=True,
         backend="pdfium",
@@ -371,11 +405,14 @@ class MachineLearning(BaseParser):
         self.detection_threshold = detection_threshold
         self.structure_threshold = structure_threshold
         self.crop_padding = crop_padding
+        self.ocr = ocr
         self.resolution = resolution
         self.icb = ImageConversionBackend(use_fallback=use_fallback, backend=backend)
         self._models: _LoadedModels | None = None
-        # Per-page render state (set in _render).
+        self._ocr_engine = None
+        # Per-page render state (set in _render); _ocr_cache reset per page.
         self._image_rgb = None
+        self._ocr_cache: list[_OCRWord] | None = None
         self._pdf_scalers: tuple[float, float, float] | None = None
         self._image_scalers: tuple[float, float, float] | None = None
 
@@ -451,11 +488,80 @@ class MachineLearning(BaseParser):
     def _text_source(self, bbox):
         """Return ``{direction: [textlines]}`` for the cell-fill pass.
 
-        The born-digital implementation: the PDF's own text layer clipped to
-        ``bbox``. An OCR backend would override this to return recognised
-        words+boxes in the same shape (scanned-PDF roadmap).
+        Two sources behind one seam:
+
+        * **born-digital** — the PDF's own text layer clipped to ``bbox``
+          (exact characters, the default).
+        * **OCR** — words recognised from the page image (scanned / image-only
+          PDFs), used when :meth:`_use_ocr` resolves true. OCR words are
+          horizontal-only; the vertical axis is empty.
         """
+        if self._use_ocr():
+            return text_in_bbox_per_axis(bbox, self._ocr_words(), [])
         return text_in_bbox_per_axis(bbox, self.horizontal_text, self.vertical_text)
+
+    def _use_ocr(self) -> bool:
+        """Resolve whether this page's cells are filled from OCR.
+
+        ``ocr=True`` always; ``ocr='auto'`` only when the page has no
+        born-digital text layer (the scanned case); ``ocr=False`` never.
+        """
+        if self.ocr is True:
+            return True
+        if self.ocr == "auto":
+            return not self.horizontal_text
+        return False
+
+    def _document_has_no_text(self):
+        """Don't bail on a text-less page when OCR can supply the text.
+
+        BaseParser short-circuits ``extract_tables`` when the page has no
+        text layer; with OCR enabled a scanned page is exactly what we want
+        to process, so override that for the OCR case.
+        """
+        if self._use_ocr():
+            return False
+        return super()._document_has_no_text()
+
+    def _get_ocr_engine(self):
+        """Lazily build (and process-cache) the OCR engine."""
+        if self._ocr_engine is not None:
+            return self._ocr_engine
+        if _OCR_ENGINE:
+            self._ocr_engine = _OCR_ENGINE[0]
+            return self._ocr_engine
+        try:
+            from rapidocr_onnxruntime import RapidOCR
+        except ImportError as exc:
+            raise ImportError(
+                "flavor='ml' with OCR (scanned PDFs) requires the optional OCR "
+                "dependencies. Install them with: pip install 'camelot-py[ocr]'"
+            ) from exc
+        self._ocr_engine = RapidOCR()
+        _OCR_ENGINE.append(self._ocr_engine)
+        return self._ocr_engine
+
+    def _ocr_words(self):
+        """OCR the page image once; return words as PDF-coord :class:`_OCRWord`s."""
+        if self._ocr_cache is not None:
+            return self._ocr_cache
+        import numpy as np
+
+        engine = self._get_ocr_engine()
+        result, _ = engine(np.asarray(self._image_rgb))
+        words: list[_OCRWord] = []
+        sx, sy, img_h = self._pdf_scalers
+        for box, text, _score in result or []:
+            xs = [pt[0] for pt in box]
+            ys = [pt[1] for pt in box]
+            # image px (top-left origin) -> PDF coords (bottom-left), y flipped.
+            x0 = scale(min(xs), sx)
+            x1 = scale(max(xs), sx)
+            y_top = scale(abs(translate(-img_h, min(ys))), sy)
+            y_bottom = scale(abs(translate(-img_h, max(ys))), sy)
+            words.append(_OCRWord(text, x0, y_bottom, x1, y_top))
+        self._ocr_cache = words
+        return words
 
     # ------------------------------------------------------------------ #
     # Rendering + coordinate scalers (torch-free)
@@ -468,6 +574,7 @@ class MachineLearning(BaseParser):
         image_bgr = self.icb.to_array(self.filename, self.page)
         img_h, img_w = image_bgr.shape[0], image_bgr.shape[1]
         self._image_rgb = Image.fromarray(cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB))
+        self._ocr_cache = None  # OCR is per-page; clear any previous page's words
         self._pdf_scalers = (
             self.pdf_width / float(img_w),
             self.pdf_height / float(img_h),
@@ -562,6 +669,16 @@ class MachineLearning(BaseParser):
         """Detect tables, recognise structure, store each grid in PDF coords."""
         self._load_models()
         self._render()
+        if self._use_ocr() and (self.split_text or self.flag_size):
+            # OCR words carry no per-glyph data, so split_text / flag_size
+            # can't apply; disable them for this page rather than crash.
+            warnings.warn(
+                "flavor='ml' OCR mode does not support split_text / flag_size "
+                "(no per-glyph data); ignoring them for this page.",
+                stacklevel=2,
+            )
+            self.split_text = False
+            self.flag_size = False
         self.table_bbox_parses = {}
         for region in self._detect_table_regions():
             grid = objects_to_grid(

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -402,10 +402,29 @@ class MachineLearning(BaseParser):
             .to(self.device)
             .eval()
         )
+        self._normalize_processor_size(det_processor)
+        self._normalize_processor_size(str_processor)
         self._models = _LoadedModels(
             torch, det_processor, det_model, str_processor, str_model
         )
         return self._models
+
+    @staticmethod
+    def _normalize_processor_size(processor):
+        """Make a ``longest_edge``-only resize config transformers accepts.
+
+        The TATR structure checkpoint ships ``size={'longest_edge': 800}`` (a
+        max-longest-edge resize), but DETR's image processor in transformers
+        >= 4.x requires ``{height, width}`` or ``{shortest_edge,
+        longest_edge}``. Setting both edges to the same value reproduces a
+        longest-edge cap exactly — the scale that makes the shortest edge that
+        big would push the longest past the cap, so it falls back to capping
+        the longest edge, aspect ratio preserved. No-op for valid configs.
+        """
+        size = getattr(processor, "size", None)
+        if isinstance(size, dict) and set(size) == {"longest_edge"}:
+            edge = size["longest_edge"]
+            processor.size = {"shortest_edge": edge, "longest_edge": edge}
 
     # ------------------------------------------------------------------ #
     # Text source seam — born-digital today, OCR-pluggable later

--- a/camelot/parsers/ml.py
+++ b/camelot/parsers/ml.py
@@ -323,6 +323,10 @@ class MachineLearning(BaseParser):
         Score threshold for the detection model.
     structure_threshold : float, optional (default: 0.5)
         Score threshold for the structure model.
+    crop_padding : int, optional (default: 10)
+        Pixels of margin added around each detected table before structure
+        recognition. TATR is trained on padded crops; the margin keeps the
+        outermost rows/columns from being clipped.
     resolution : int, optional (default: 300)
         DPI for rendering the page to an image.
     """
@@ -342,6 +346,7 @@ class MachineLearning(BaseParser):
         device="cpu",
         detection_threshold=0.5,
         structure_threshold=0.5,
+        crop_padding=10,
         resolution=300,
         use_fallback=True,
         backend="pdfium",
@@ -365,6 +370,7 @@ class MachineLearning(BaseParser):
         self.device = device
         self.detection_threshold = detection_threshold
         self.structure_threshold = structure_threshold
+        self.crop_padding = crop_padding
         self.resolution = resolution
         self.icb = ImageConversionBackend(use_fallback=use_fallback, backend=backend)
         self._models: _LoadedModels | None = None
@@ -521,10 +527,18 @@ class MachineLearning(BaseParser):
     def _recognize_structure(self, region):
         """Run structure recognition on one table crop.
 
-        Returns DetectedObjects in *full-page* image coordinates (the crop
+        The crop is padded by ``crop_padding`` px (clamped to the image) —
+        TATR's structure model was trained on padded table crops, and without
+        the margin the outermost rows/columns get clipped. Returns
+        DetectedObjects in *full-page* image coordinates (the padded-crop
         offset is added back), so downstream geometry is page-consistent.
         """
-        x0, y0, x1, y1 = (int(v) for v in region)
+        pad = self.crop_padding
+        width, height = self._image_rgb.size
+        x0 = max(0, int(region[0]) - pad)
+        y0 = max(0, int(region[1]) - pad)
+        x1 = min(width, int(region[2]) + pad)
+        y1 = min(height, int(region[3]) + pad)
         crop = self._image_rgb.crop((x0, y0, x1, y1))
         objects = self._infer(
             crop,

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -141,11 +141,26 @@ lattice_kwargs = common_kwargs + [
     "use_fallback",
     "engine",
 ]
+# The ML parser (flavor='ml', optional [ml] extra) gets its structure from a
+# neural model, so it shares the common text-handling kwargs (split/strip/flag/
+# regions/areas) + the spanning-text controls, plus a few model-specific knobs.
+ml_kwargs = common_kwargs + [
+    "copy_text",
+    "shift_text",
+    "resolution",
+    "use_fallback",
+    "device",
+    "structure_model",
+    "detection_model",
+    "detection_threshold",
+    "structure_threshold",
+]
 flavor_to_kwargs = {
     "stream": text_kwargs,
     "network": text_kwargs,
     "lattice": lattice_kwargs,
     "hybrid": text_kwargs + lattice_kwargs,
+    "ml": ml_kwargs,
 }
 
 

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -154,6 +154,7 @@ ml_kwargs = common_kwargs + [
     "detection_model",
     "detection_threshold",
     "structure_threshold",
+    "crop_padding",
 ]
 flavor_to_kwargs = {
     "stream": text_kwargs,

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -155,6 +155,7 @@ ml_kwargs = common_kwargs + [
     "detection_threshold",
     "structure_threshold",
     "crop_padding",
+    "ocr",
 ]
 flavor_to_kwargs = {
     "stream": text_kwargs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ plot = [
 # the other flavors never load torch.
 ml = [
     "torch>=2.0",
-    "transformers>=4.40",
+    # <5: transformers v5 strict-validates configs and rejects the TATR
+    # checkpoints (published for v4, e.g. `dilation: None`). The whole TATR
+    # ecosystem pins to v4; revisit when the checkpoints are v5-clean.
+    "transformers>=4.40,<5",
     "timm>=0.9",
     "pillow>=10.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,12 @@ ml = [
     "timm>=0.9",
     "pillow>=10.4.0",
 ]
+# Optional OCR text source for flavor='ml' on scanned / image-only PDFs
+# (structure still from TATR; text from OCR instead of the PDF text layer).
+# Pip-only, no system tesseract binary. `pip install 'camelot-py[ocr]'`.
+ocr = [
+    "rapidocr-onnxruntime>=1.3",
+]
 ghostscript = [
     "ghostscript>=0.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,16 @@ plot = [
     "matplotlib>=3.7.5; python_version < '3.12'",
     "matplotlib>=3.8.0; python_version >= '3.12'",
 ]
+# Optional neural backend for flavor='ml' (Table Transformer / TATR via
+# HuggingFace transformers). Heavy (pulls torch); opt in explicitly with
+# `pip install 'camelot-py[ml]'`. Imported lazily so the core install and
+# the other flavors never load torch.
+ml = [
+    "torch>=2.0",
+    "transformers>=4.40",
+    "timm>=0.9",
+    "pillow>=10.4.0",
+]
 ghostscript = [
     "ghostscript>=0.7",
 ]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,7 +15,7 @@ from tests.conftest import skip_on_windows
 def test_unknown_flavor(foo_pdf):
     message = (
         "Unknown flavor specified."
-        " Use either 'lattice', 'stream', 'network', 'hybrid' or 'auto'"
+        " Use either 'lattice', 'stream', 'network', 'hybrid', 'ml' or 'auto'"
     )
     with pytest.raises(NotImplementedError, match=message):
         camelot.read_pdf(foo_pdf, flavor="chocolate")

--- a/tests/test_ml_backend.py
+++ b/tests/test_ml_backend.py
@@ -14,6 +14,7 @@ import pytest
 from camelot.core import Table
 from camelot.parsers.ml import DetectedObject
 from camelot.parsers.ml import MachineLearning
+from camelot.parsers.ml import _OCRWord
 from camelot.parsers.ml import apply_spans
 from camelot.parsers.ml import grid_to_pdf_cols_rows
 from camelot.parsers.ml import objects_to_grid
@@ -151,3 +152,48 @@ def test_ml_read_pdf_surfaces_install_hint(foo_pdf):
 
     with pytest.raises(ImportError, match=r"camelot-py\[ml\]"):
         camelot.read_pdf(foo_pdf, flavor="ml")
+
+
+# --------------------------------------------------------------------------- #
+# OCR text-source plumbing (torch-free; engine not required)
+# --------------------------------------------------------------------------- #
+def test_ocrword_exposes_textline_interface():
+    w = _OCRWord("hi", 1.0, 2.0, 3.0, 4.0)
+    assert (w.x0, w.y0, w.x1, w.y1) == (1.0, 2.0, 3.0, 4.0)
+    assert w.get_text() == "hi"
+
+
+def test_ml_use_ocr_modes():
+    # ocr=True -> always; ocr=False -> never (regardless of text layer).
+    always = MachineLearning(ocr=True)
+    always.horizontal_text = []
+    assert always._use_ocr() is True
+    never = MachineLearning(ocr=False)
+    never.horizontal_text = []
+    assert never._use_ocr() is False
+    # ocr='auto' -> only when the page has no born-digital text layer.
+    auto = MachineLearning(ocr="auto")
+    auto.horizontal_text = []
+    assert auto._use_ocr() is True
+    auto.horizontal_text = ["a textline"]
+    assert auto._use_ocr() is False
+
+
+def test_ml_document_has_no_text_defers_to_ocr():
+    # With OCR available a text-less page is processed, not skipped.
+    ocr_on = MachineLearning(ocr=True)
+    ocr_on.horizontal_text, ocr_on.images, ocr_on.page = [], [], 1
+    assert ocr_on._document_has_no_text() is False
+    # Without OCR, a text-less page still short-circuits (base behaviour).
+    ocr_off = MachineLearning(ocr=False)
+    ocr_off.horizontal_text, ocr_off.images, ocr_off.page = [], [], 1
+    assert ocr_off._document_has_no_text() is True
+
+
+def test_ml_ocr_requires_engine_when_missing():
+    """If rapidocr isn't installed, asking for OCR gives the [ocr] hint."""
+    if importlib.util.find_spec("rapidocr_onnxruntime") is not None:
+        pytest.skip("rapidocr installed; the import guard is moot")
+    parser = MachineLearning(ocr=True)
+    with pytest.raises(ImportError, match=r"camelot-py\[ocr\]"):
+        parser._get_ocr_engine()

--- a/tests/test_ml_backend.py
+++ b/tests/test_ml_backend.py
@@ -1,0 +1,153 @@
+"""Torch-free tests for the ML (Table Transformer) backend — flavor='ml'.
+
+These cover the pieces that do not need the optional ML dependencies:
+the pure box->grid post-processing, the image->PDF coordinate mapping, the
+spanning-cell edge application, parser registration, and the friendly error
+raised when torch/transformers are missing. Live model inference is validated
+separately once the [ml] extra is installed.
+"""
+
+import importlib.util
+
+import pytest
+
+from camelot.core import Table
+from camelot.parsers.ml import DetectedObject
+from camelot.parsers.ml import MachineLearning
+from camelot.parsers.ml import apply_spans
+from camelot.parsers.ml import grid_to_pdf_cols_rows
+from camelot.parsers.ml import objects_to_grid
+
+_HAS_TORCH = importlib.util.find_spec("torch") is not None
+
+
+def _col(x0, x1, y0=0.0, y1=100.0, score=0.99):
+    return DetectedObject("table column", score, (x0, y0, x1, y1))
+
+
+def _row(y0, y1, x0=0.0, x1=100.0, score=0.99):
+    return DetectedObject("table row", score, (x0, y0, x1, y1))
+
+
+def _span(x0, y0, x1, y1, score=0.99):
+    return DetectedObject("table spanning cell", score, (x0, y0, x1, y1))
+
+
+# --------------------------------------------------------------------------- #
+# objects_to_grid
+# --------------------------------------------------------------------------- #
+def test_objects_to_grid_clean_2x2():
+    objects = [_col(0, 50), _col(50, 100), _row(0, 50), _row(50, 100)]
+    grid = objects_to_grid(objects)
+    assert grid.col_bounds == [(0.0, 50.0), (50.0, 100.0)]
+    assert grid.row_bounds == [(0.0, 50.0), (50.0, 100.0)]
+    assert grid.spans == []
+
+
+def test_objects_to_grid_gap_split_at_midpoint():
+    # Columns separated by a gap -> the separator lands in the gap centre.
+    objects = [_col(0, 40), _col(60, 100), _row(0, 50), _row(50, 100)]
+    grid = objects_to_grid(objects)
+    assert grid.col_bounds == [(0.0, 50.0), (50.0, 100.0)]
+
+
+def test_objects_to_grid_spanning_cell():
+    objects = [
+        _col(0, 30),
+        _col(30, 60),
+        _col(60, 90),
+        _row(0, 40),
+        _row(40, 80),
+        _span(0, 0, 60, 40),  # row 0 spans columns 0 and 1
+    ]
+    grid = objects_to_grid(objects)
+    assert len(grid.col_bounds) == 3
+    assert len(grid.row_bounds) == 2
+    assert grid.spans == [(0, 0, 0, 1)]
+
+
+def test_objects_to_grid_score_threshold_drops_low_confidence():
+    objects = [
+        _col(0, 50),
+        _col(50, 100, score=0.10),  # below threshold -> ignored
+        _row(0, 100),
+    ]
+    grid = objects_to_grid(objects, score_thresh=0.5)
+    assert len(grid.col_bounds) == 1
+
+
+def test_objects_to_grid_merges_duplicate_bands():
+    # Two near-identical detections of the same column collapse to one.
+    objects = [_col(0, 50), _col(2, 52), _col(50, 100), _row(0, 100)]
+    grid = objects_to_grid(objects, merge_tol=6.0)
+    assert len(grid.col_bounds) == 2
+
+
+def test_objects_to_grid_empty_without_rows_or_cols():
+    assert objects_to_grid([]).col_bounds == []
+    assert objects_to_grid([_col(0, 50)]).row_bounds == []  # cols but no rows
+    assert objects_to_grid([_row(0, 50)]).col_bounds == []  # rows but no cols
+
+
+# --------------------------------------------------------------------------- #
+# grid_to_pdf_cols_rows
+# --------------------------------------------------------------------------- #
+def test_grid_to_pdf_cols_rows_flips_y_and_orders():
+    grid = objects_to_grid([_col(0, 50), _col(50, 100), _row(0, 40), _row(40, 80)])
+    # pdf_scalers = (sx, sy, image_height)
+    cols, rows = grid_to_pdf_cols_rows(grid, (0.5, 0.5, 80))
+    # x just scales; columns stay increasing.
+    assert cols == [(0.0, 25.0), (25.0, 50.0)]
+    # y flips (image top-left -> pdf bottom-left): rows decreasing by y_top.
+    assert rows == [(40.0, 20.0), (20.0, 0.0)]
+    assert rows[0][0] > rows[1][0]  # top row sits higher in PDF space
+
+
+# --------------------------------------------------------------------------- #
+# apply_spans
+# --------------------------------------------------------------------------- #
+def test_apply_spans_opens_interior_edges():
+    table = Table([(0, 1), (1, 2), (2, 3)], [(1, 0)]).set_all_edges()
+    apply_spans(table, [(0, 0, 0, 1)])  # merge the first two cells of row 0
+    assert table.cells[0][0].hspan  # right edge opened
+    assert table.cells[0][1].hspan  # left edge opened
+    assert not table.cells[0][2].hspan  # untouched cell stays bounded
+
+
+# --------------------------------------------------------------------------- #
+# registration + wiring
+# --------------------------------------------------------------------------- #
+def test_ml_flavor_registered():
+    from camelot.handlers import PARSERS
+    from camelot.utils import flavor_to_kwargs
+    from camelot.utils import validate_input
+
+    assert PARSERS["ml"] is MachineLearning
+    assert "ml" in flavor_to_kwargs
+    # Common + ML-specific kwargs validate; an unrelated one is rejected.
+    validate_input({"split_text": True, "device": "cpu"}, flavor="ml")
+    with pytest.raises(ValueError, match="cannot be used with flavor='ml'"):
+        validate_input({"line_scale": 40}, flavor="ml")
+
+
+def test_ml_constructs_without_torch():
+    parser = MachineLearning(device="cpu", structure_threshold=0.7)
+    assert parser.id == "machine_learning"
+    assert parser.structure_threshold == 0.7
+    assert parser.shift_text == ["l", "t"]
+
+
+@pytest.mark.skipif(_HAS_TORCH, reason="torch installed; the import guard is moot")
+def test_ml_without_deps_raises_helpful_error():
+    parser = MachineLearning()
+    with pytest.raises(ImportError, match=r"camelot-py\[ml\]"):
+        parser._load_models()
+
+
+@pytest.mark.skipif(_HAS_TORCH, reason="torch installed; would fetch real models")
+def test_ml_read_pdf_surfaces_install_hint(foo_pdf):
+    """End-to-end dispatch wiring: read_pdf -> handler -> ML parser -> hint."""
+    import camelot
+
+    with pytest.raises(ImportError, match=r"camelot-py\[ml\]"):
+        camelot.read_pdf(foo_pdf, flavor="ml")


### PR DESCRIPTION
## What

A new **optional** `flavor='ml'` parser that uses a neural table-structure model (Microsoft **Table Transformer / TATR**, MIT, via HuggingFace `transformers`) to recover structure on **borderless** tables — and, with optional OCR, on **scanned / image-only** PDFs too.

```
pip install 'camelot-py[ml]'                 # neural structure backend
pip install 'camelot-py[ocr]'                # + OCR for scanned PDFs
camelot.read_pdf("report.pdf", flavor="ml")  # cpu default; device="xpu"/"cuda" too
```

## Why

Borderless column/row structure is heuristic-capped (~0.20 TEDS on FinTabNet; see #38 et al.). Dedicated TSR models are the only way past it. This adds that path **without compromising camelot's identity** — the core stays lean, deterministic, CPU, MIT; `torch`/`transformers`/`timm` (and OCR) are optional extras, imported lazily, so `import camelot` and every existing flavor are unaffected (**CI never installs them**).

## Design — *model supplies structure, the page supplies text*

TATR detects rows / columns / spanning-cells **as boxes**; camelot fills each cell from the **PDF's own text layer** via the existing `get_table_index`. The model never emits cell text, so it **cannot hallucinate or alter a value**. The box→grid output is camelot's usual column/row/spanning representation, so it reuses `Table`/`Cell`, accuracy/whitespace, `_reject_table`, and the text pipeline.

## Results — FinTabNet (borderless, 545 PDFs)

| flavor | F1 | TEDS | row | col |
|---|---|---|---|---|
| **ml** | **0.750** | **0.371** | **0.235** | **0.570** |
| network | 0.725 | 0.200 | 0.109 | 0.220 |
| hybrid (combined) | 0.658 | 0.198 | 0.109 | 0.217 |

ML wins every quality metric — **TEDS ~+85%**, col ~2.6×, row ~+115% — breaking the heuristic ceiling. (Absolute TEDS is modest because `bench/_metrics.py`'s `simple_teds` is a difflib proxy and the GT blanks spans; the **relative win on the same set** is the point.) ~1.1 s/page on an Intel Arc GPU (XPU); CPU works too. The `crop_padding` default (TATR trains on padded crops) is what lifts row from 0.191→0.235.

## Scanned / image-only PDFs (optional OCR)

When a page has **no text layer** (`ocr='auto'`, the default) — or always with `ocr=True` — cell text comes from **OCR** of the rendered page (rapidocr, the `[ocr]` extra: pip-only, no system tesseract) instead of the PDF text layer; structure still comes from the model. This lifts camelot's long-standing *needs-a-text-layer* limitation. Still geometry + recognised text (no invented cells). Validated: an image-only render of `health.pdf` (which `network` extracts nothing from) → **25×8, accuracy 99.1**, matching the born-digital result. `split_text`/`flag_size` aren't supported in OCR mode (no per-glyph data).

## Notes

- New `camelot/parsers/ml.py`. Box→grid postproc (`objects_to_grid`), image→PDF mapping (`grid_to_pdf_cols_rows`), spanning-edge application (`apply_spans`), the OCR plumbing (`_use_ocr`/`_OCRWord`) — all **pure / unit-tested without torch or OCR** (16 tests; CI runs them dependency-free).
- Process-level model + OCR-engine caches avoid reloading per `read_pdf`.
- `transformers` pinned `<5` in the extra: v5 strict-validates the TATR configs and rejects them (`dilation: None`).
- Default checkpoints are MIT (`…-detection` + `…-structure-recognition-v1.1-all`); swappable via kwargs.

## Roadmap (follow-ups, not in this PR)

- Header metadata from TATR's column-header / projected-row-header classes.
- Deskew/rotation + per-cell OCR for harder scans; pluggable OCR engine (tesseract/easyocr).
- Optional `flavor='auto'` routing of borderless/low-confidence pages to `ml` when the extra is installed.