### PR TITLE
docs: parser-selection guide + reflect the ml/ocr backend (benchmark, comparison matrix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 ## Features
 
-- 📊 **Four parsers** — `lattice` (ruled tables), `stream` (whitespace), and the text-alignment `network` / `hybrid`, plus `flavor="auto"` to pick one for you.
+- 📊 **Five parsers** — `lattice` (ruled tables), `stream` (whitespace), the text-alignment `network` / `hybrid`, and the optional neural `ml` (Table Transformer) for hard borderless tables — plus `flavor="auto"` to pick one for you.
+- 🤖 **Borderless & scanned** — the optional `ml` backend (`pip install "camelot-py[ml]"`) recovers structure that the heuristic parsers can't on borderless tables; add `[ocr]` to read **scanned / image-only PDFs** with no text layer.
 - 🧠 **Vector + raster line detection** — `engine="combined"` unions the PDF's native vector ruled lines with OpenCV detection, so faintly-ruled tables are still found.
 - 🐼 **pandas output** — every table is a `DataFrame`, ready for analysis.
 - 📤 **Many export formats** — CSV, JSON, Excel, HTML, Markdown, and SQLite.
@@ -66,9 +67,23 @@ Refer to the [QuickStart Guide](https://github.com/camelot-dev/camelot/blob/mast
 
 **Tip:** Visit the `parser-comparison-notebook` to get an overview of all the packed parsers and their features. [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/camelot-dev/camelot/blob/master/examples/parser-comparison-notebook.ipynb)
 
-**Note:** Camelot only works with text-based PDFs and not scanned documents. (As Tabula [explains](https://github.com/tabulapdf/tabula#why-tabula), "If you can click and drag to select text in your table in a PDF viewer, then your PDF is text-based".)
+**Note:** The built-in parsers need a text-based PDF (as Tabula [explains](https://github.com/tabulapdf/tabula#why-tabula), "If you can click and drag to select text in your table in a PDF viewer, then your PDF is text-based"). For **scanned / image-only** PDFs, install the neural backend with OCR — `pip install "camelot-py[ml,ocr]"` — and use `camelot.read_pdf(..., flavor="ml")`: the model reads the structure from the page image and OCR supplies the text.
 
 You can check out some frequently asked questions [here](https://camelot-py.readthedocs.io/en/latest/user/faq.html).
+
+## Which parser should I use?
+
+| Your PDF                                      | Use                                                | Why                                                                                                                                                               |
+| --------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Ruled tables** (lines between cells)        | `flavor="lattice"` (default)                       | Deterministic; detects the grid from the ruled lines. `engine="combined"` also catches faint vector rules.                                                        |
+| **Borderless tables** (whitespace-separated)  | `flavor="network"` or `"stream"`                   | Text-alignment / whitespace heuristics — fast, no extra dependencies.                                                                                             |
+| **Borderless tables, best quality**           | `flavor="ml"` (`pip install "camelot-py[ml]"`)     | A Table Transformer model recovers structure heuristics can't — on FinTabNet it roughly doubles borderless TEDS vs `network`/`hybrid`. Heavier (PyTorch); opt-in. |
+| **Scanned / image-only PDFs** (no text layer) | `flavor="ml"` + `pip install "camelot-py[ml,ocr]"` | Structure from the model, text from OCR.                                                                                                                          |
+| **Mixed / not sure**                          | `flavor="auto"`                                    | Picks `lattice` or `network` per page.                                                                                                                            |
+
+The `ml` backend keeps Camelot honest: the model only supplies the table
+**structure**, while cell **text** comes from the PDF's own text layer (or OCR
+for scans) — so it never invents or alters a value.
 
 ## Why Camelot?
 
@@ -117,6 +132,18 @@ git clone https://github.com/camelot-dev/camelot.git
 cd camelot
 uv pip install "."  # or: pip install "."
 ```
+
+### Optional extras
+
+```bash
+pip install "camelot-py[ml]"      # neural flavor='ml' (Table Transformer; pulls PyTorch)
+pip install "camelot-py[ocr]"     # OCR text source for scanned PDFs (use with [ml])
+pip install "camelot-py[ml,ocr]"  # both — borderless + scanned
+pip install "camelot-py[plot]"    # matplotlib debug plots
+```
+
+The core install stays light: `[ml]`/`[ocr]` are imported lazily, so a plain
+`import camelot` never loads PyTorch or OCR.
 
 ## Documentation
 

--- a/docs/user/comparison.rst
+++ b/docs/user/comparison.rst
@@ -78,7 +78,7 @@ workaround required".
           </tr>
           <tr>
             <th scope="row">Borderless / whitespace tables</th>
-            <td><span class="cm-yes" title="stream / network / hybrid">&#10003;</span></td>
+            <td><span class="cm-yes" title="stream / network / hybrid; flavor='ml' for the hardest">&#10003;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
             <td><span class="cm-partial">&#9680;</span></td>
             <td><span class="cm-yes">&#10003;</span></td>
@@ -98,12 +98,22 @@ workaround required".
           </tr>
           <tr>
             <th scope="row">Scanned PDFs (no text layer)</th>
-            <td><span class="cm-no" title="preprocess with ocrmypdf">&#10007;</span></td>
+            <td><span class="cm-yes" title="flavor='ml' + [ocr] extra">&#10003;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
             <td><span class="cm-partial" title="via OCR plugin">&#9680;</span></td>
             <td><span class="cm-yes" title="vision model">&#10003;</span></td>
             <td><span class="cm-yes" title="Tesseract plugin">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Neural / model-based structure</th>
+            <td><span class="cm-yes" title="optional flavor='ml' (Table Transformer)">&#10003;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-no">&#10007;</span></td>
+            <td><span class="cm-yes" title="Table Transformer">&#10003;</span></td>
+            <td><span class="cm-partial" title="via model backends">&#9680;</span></td>
             <td><span class="cm-no">&#10007;</span></td>
           </tr>
           <tr>
@@ -252,17 +262,19 @@ Tables" — is a 2024-era tool that runs Microsoft's Table Transformer
 neural network for table detection plus structure recognition. A
 different shape from the rule-based tools above.
 
-* **When gmft wins.** Visually-complex tables where a human would
-  agree "the cell boundaries are kinda fuzzy" — bank statements,
-  forms, OCR'd scans. The vision model handles whitespace, merged
-  cells, and even some skew. Works on scanned PDFs unchanged.
-* **When Camelot wins.** Predictable per-cell behaviour and
-  per-extraction kwargs; no GPU / no half-gigabyte model download;
-  stable output for typesetter-generated tables (where the vision
-  model is sometimes weirdly creative).
-* **Resource cost.** First call downloads a Table Transformer
-  checkpoint (~400 MB); inference benefits from a GPU. Camelot runs
-  on CPU with no model weights.
+* **When gmft wins.** A pure model-first workflow on visually-complex
+  tables — bank statements, forms — where you want the neural network
+  to drive the whole extraction.
+* **When Camelot wins.** Heuristic-first by default (predictable,
+  CPU-only, no model weights) — and when you *do* want a model,
+  Camelot's optional ``flavor='ml'`` runs the same Table Transformer
+  family but fills cell **text from the PDF's own text layer** (or OCR
+  for scans) instead of letting the model emit it, so it can't
+  hallucinate or alter a value. Plus per-extraction kwargs and a
+  per-table ``confidence`` score.
+* **Resource cost.** gmft always pulls a Table Transformer checkpoint
+  (~hundreds of MB) and benefits from a GPU. Camelot's core needs
+  neither; that cost applies only if you opt into ``camelot-py[ml]``.
 
 *Last verified: 2026-05-21 against gmft 0.4.x.*
 

--- a/docs/user/how-it-works.rst
+++ b/docs/user/how-it-works.rst
@@ -152,3 +152,70 @@ The hybrid parser aims to combine the strengths of the Network parser (identifyi
 1. Hybrid calls both parsers, to get a) the standard table parse, b) the coordinates of the rows and columns boundaries, and c) the table boundaries (or contour).
 
 2. If there are areas in the document where both lattice and network found a table, the hybrid parser uses the results from network, but enhances them based on the rows/columns boundaries identified by lattice in the area. Because lattice uses the solid lines detected on the document, the coordinates for b) and c) detected by Lattice are generally more precise. See the "_merge_bbox_analysis" method.
+
+.. _ml:
+
+ML (Table Transformer)
+----------------------
+
+``flavor='ml'`` is an **optional** neural backend for the tables the
+heuristic parsers find hardest — dense **borderless** tables — and, with
+OCR, for **scanned / image-only** PDFs. It is opt-in because it pulls
+PyTorch: ``pip install 'camelot-py[ml]'`` (add ``[ocr]`` for scans).
+
+Its guiding rule is **the model supplies the structure, the page supplies
+the text**:
+
+1. The page is rendered to an image. A `Table Transformer (TATR)
+   <https://github.com/microsoft/table-transformer>`_ detection model finds
+   the table region(s); a second TATR model recognises the **structure** —
+   rows, columns and spanning cells — as bounding boxes.
+2. Those boxes are turned into the same column/row/spanning grid the other
+   parsers build, then mapped from image space back to PDF coordinates.
+3. Each cell's **text** is filled from the PDF's own text layer (the exact
+   characters), reusing the same assignment step as every other flavor — so
+   the model never emits a character of cell text and **cannot hallucinate
+   or alter a value**. For scanned pages with no text layer, ``ocr='auto'``
+   reads the text from the rendered image instead (still geometry +
+   recognised text, never invented cells).
+
+Because the structure half runs on the page image, ``flavor='ml'`` is the
+only parser that works without a text layer at all.
+
+Borderless accuracy
+~~~~~~~~~~~~~~~~~~~~~
+
+On the borderless `FinTabNet.c <https://github.com/ibm-aur-nlp/PubTabNet>`_
+benchmark (545 financial PDFs, ``bench/benchmark_fintabnet.py``), the model
+backend clears the ceiling the heuristic parsers plateau at:
+
+.. list-table::
+   :header-rows: 1
+
+   * - flavor
+     - F1
+     - TEDS
+     - row
+     - col
+   * - **ml**
+     - 0.750
+     - 0.371
+     - 0.235
+     - 0.570
+   * - network
+     - 0.725
+     - 0.200
+     - 0.109
+     - 0.220
+   * - hybrid (combined)
+     - 0.658
+     - 0.198
+     - 0.109
+     - 0.217
+
+(``TEDS``/``row``/``col`` from ``bench/_metrics.py``; ``TEDS`` here is a
+difflib cell-text proxy, not exact tree-edit distance, so the absolute
+values are conservative — the point is the **relative** gap: ``ml`` roughly
+doubles borderless ``TEDS`` over ``network``/``hybrid``.) The trade-off is
+speed (~1 s/page with a GPU vs tens of ms for ``network``) and the optional
+PyTorch dependency, which is why it is opt-in rather than the default.


### PR DESCRIPTION
Follow-up to #809. The `flavor='ml'` tier shipped with only a docstring + CHANGELOG, so the user-facing docs lagged. This closes three gaps:

### README
- "Four parsers" → **"Five parsers"** (adds the optional neural `ml`).
- New **"Which parser should I use?"** decision table: ruled → `lattice`, borderless → `network`/`stream` or `ml` for best quality, **scanned → `ml` + `[ocr]`**, mixed → `auto`.
- Fixes the now-incorrect note *"Camelot only works with text-based PDFs and not scanned documents"* — scanned PDFs are supported via `[ml]`+`[ocr]`.
- Lists the `[ml]` / `[ocr]` / `[plot]` optional extras.

### Comparison page (`comparison.rst`)
- Camelot's **"Scanned PDFs (no text layer)"** cell: ✗ → **✓** (`flavor='ml'` + `[ocr]`).
- New **"Neural / model-based structure"** capability row.
- Refreshed the **gmft** section: Camelot is heuristic-first with an *optional, same–Table-Transformer* ML tier — but it fills cell text from the PDF (or OCR), so unlike a pure vision pipeline it can't hallucinate a value.

### How it works (`how-it-works.rst`)
- New **"ML (Table Transformer)"** section: the *structure-from-model / text-from-PDF* design, scanned/OCR, and the **FinTabNet borderless benchmark**:

  | flavor | F1 | TEDS | row | col |
  |---|---|---|---|---|
  | **ml** | 0.750 | 0.371 | 0.235 | 0.570 |
  | network | 0.725 | 0.200 | 0.109 | 0.220 |
  | hybrid (combined) | 0.658 | 0.198 | 0.109 | 0.217 |

  (TEDS is the repo's difflib proxy, so absolute values are conservative; the point is the ~2× relative borderless gain.)

Docs-only; no code changes.