### PR TITLE
chore(release): prepare 2.0.0rc1 (version, CHANGELOG, migration guide)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,3 @@
-### Added
-
-- **New optional `flavor='ml'` backend (Table Transformer / TATR).** A neural
-  table-structure model supplies the row/column/spanning-cell structure while
-  cell text is filled from the PDF's own text layer — the model never emits
-  cell text, so it cannot hallucinate or alter a value. Aimed at borderless
-  tables, where the heuristic parsers plateau (on FinTabNet it lifts TEDS from
-  ~0.20 to ~0.37 vs `network`/`hybrid`). Heavy dependencies are optional and
-  imported lazily: `pip install 'camelot-py[ml]'`. The box→grid post-processing
-  and image→PDF coordinate mapping are pure (torch-free) and unit-tested.
-- **`flavor='ml'` works on scanned / image-only PDFs via optional OCR.** When a
-  page has no text layer (`ocr='auto'`, the default) — or always with
-  `ocr=True` — cell text comes from OCR of the rendered page instead of the PDF
-  text layer; structure still comes from the model. This lifts camelot's
-  long-standing "needs a text layer" limitation. Opt in with
-  `pip install 'camelot-py[ocr]'`. Still geometry + recognised text (no
-  invented cells); `split_text`/`flag_size` aren't supported in OCR mode.
-
-### Changed
-
-- **`flavor='hybrid'` now defaults its lattice half to `engine='combined'`**
-  (was `'raster'`), matching `flavor='lattice'` and the documented behaviour.
-  Combined detects ruled grids better, so the completeness gating routes
-  more complete grids to the lattice parser — on the in-repo ICDAR-2013
-  benchmark hybrid TEDS 0.724→0.806, row 0.417→0.659, col 0.689→0.868.
-
-- **`engine='combined'` is now the default lattice engine** (was
-  `'raster'`), and **`engine='auto'` was removed**. Combined is the
-  strongest detector and safe by construction; its vector ruled lines are
-  now clipped to `table_regions` so it never expands a table beyond a
-  user-supplied region (previously it could). `engine` remains lattice-only
-  and is rejected for text-based flavors. (#763, flavor x engine cleanup)
-
 # Changelog
 
 This file documents notable user-visible changes. The day-to-day automatic
@@ -42,11 +9,13 @@ human-readable summary for _major_ releases.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 2.0.0 (planned)
+## [2.0.0rc1] — 2026-05-25
 
 The 2.0 release rolls up a substantial backend migration, the resulting
-performance work, and a handful of small but user-visible breaking
-changes. **Heads-up if upgrading from 1.0.x**:
+performance work, an optional neural (Table Transformer) backend for
+borderless and scanned tables, and a handful of small but user-visible
+breaking changes. **Heads-up if upgrading from 1.0.x** — see the
+[migration guide](user/migration.rst):
 
 ### Breaking
 
@@ -77,6 +46,23 @@ changes. **Heads-up if upgrading from 1.0.x**:
 
 ### Added
 
+- **Optional neural `flavor="ml"` backend (Table Transformer / TATR).** A
+  neural model supplies the row/column/spanning-cell **structure** while cell
+  **text** is filled from the PDF's own text layer — the model never emits cell
+  text, so it cannot hallucinate or alter a value. Aimed at borderless tables,
+  where the heuristic parsers plateau: on the FinTabNet borderless benchmark it
+  roughly doubles TEDS (~0.20 → ~0.37) over `network`/`hybrid`. Heavy
+  dependencies are optional and imported lazily — `pip install "camelot-py[ml]"`
+  — so `import camelot` and the other flavors never load PyTorch. The box→grid
+  post-processing and image→PDF mapping are pure (torch-free) and unit-tested.
+  (#809)
+- **`flavor="ml"` reads scanned / image-only PDFs via optional OCR.** With no
+  text layer (`ocr="auto"`, the default) — or always with `ocr=True` — cell
+  text comes from OCR of the rendered page instead of the PDF text layer;
+  structure still comes from the model. This lifts Camelot's long-standing
+  "needs a text layer" limitation. Opt in with `pip install "camelot-py[ocr]"`.
+  Still geometry + recognised text (no invented cells); `split_text` /
+  `flag_size` aren't supported in OCR mode. (#809)
 - **`TableList.filter(...)`** — post-extraction convenience to drop noise /
   low-quality tables by `min_rows`, `min_columns`, `min_accuracy`,
   `max_whitespace`. Returns a new `TableList` (composable); all thresholds
@@ -86,9 +72,9 @@ changes. **Heads-up if upgrading from 1.0.x**:
   rasterised OpenCV line masks before contour/joint detection, so tables
   whose rules render faintly (vector strokes, anti-aliasing) are still
   found. Safe by construction — raster always runs, vector lines can only
-  add, so output is never worse than `engine="raster"`. `engine="auto"`
-  now resolves to `combined` when the page carries vector ruled lines,
-  else `raster`. (#763)
+  add, so output is never worse than `engine="raster"`. It is now the
+  **default** lattice engine and vector lines are clipped to
+  `table_regions`. (#763)
 - **`engine="vector"`** for `flavor="lattice"`: detects tables purely from
   the PDF's native vector ruled lines, **skipping page rasterisation and
   OpenCV entirely** — the fastest path for PDFs whose tables are drawn
@@ -151,6 +137,18 @@ changes. **Heads-up if upgrading from 1.0.x**:
   prefer the new shape).
 - **Python 3.14 stable + 3.15 experimental** rows added to the CI matrix.
   Wheels for both Pythons install correctly on Linux/macOS/Windows. (#706)
+
+### Changed
+
+- **Default lattice `engine` is now `"combined"`** (was `"raster"`); the
+  transient `engine="auto"` introduced earlier in the 2.0 cycle was removed.
+  Existing `flavor="lattice"` calls pick up combined automatically and it is
+  never worse than raster. `engine` stays lattice-only and is rejected for the
+  text-based flavors. (#803)
+- **`flavor="hybrid"` runs its lattice half with `engine="combined"` too**
+  (was `"raster"`). With the completeness gating this lifts hybrid on ruled
+  documents — in-repo ICDAR-2013 TEDS 0.724→0.806, row 0.417→0.659,
+  col 0.689→0.868. (#807)
 
 ### Changed (performance)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ This part of the documentation begins with some background information about why
    user/quickstart
    user/advanced
    user/comparison
+   user/migration
    user/faq
    user/cli
 

--- a/docs/user/migration.rst
+++ b/docs/user/migration.rst
@@ -1,0 +1,113 @@
+.. _migration:
+
+Migrating to 2.0
+================
+
+Camelot 2.0 rolls up a backend migration, performance work, an optional
+neural backend, and a few small breaking changes. For most users ``import
+camelot`` and ``camelot.read_pdf(...)`` keep working unchanged. This page
+lists what to check when upgrading from 1.0.x, then points at the new
+opt-in features.
+
+The full, dated list of changes is in the
+`changelog <https://github.com/camelot-dev/camelot/blob/master/CHANGELOG.md>`_.
+
+Breaking changes
+----------------
+
+Python 3.10+
+~~~~~~~~~~~~~
+
+Python 3.9 (EOL October 2025) is no longer supported. The minimum is now
+**Python 3.10**.
+
+``line_scale`` default is 15 (was documented as 40)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The CLI and ``read_pdf`` docstring used to *say* the ``flavor="lattice"``
+default ``line_scale`` was 40, but the Lattice parser always defaulted to
+15. The docs now match the implementation. If you relied on the
+documented-but-unimplemented 40, set it explicitly:
+
+.. code-block:: python
+
+   camelot.read_pdf("file.pdf", flavor="lattice", line_scale=40)
+
+``Table.to_excel`` drops the index/header by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Table.to_excel`` now defaults to ``index=False, header=False`` to match
+``Table.to_csv`` — Excel exports no longer carry the pandas auto-generated
+row index / column header. Opt back in with:
+
+.. code-block:: python
+
+   table.to_excel("out.xlsx", index=True, header=True)
+
+``TableList`` materialises its input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``TableList(...)`` now consumes an iterable into a list at construction (so
+``bool()`` / ``len()`` work on ``TableList(generator())``). A generator
+passed in is exhausted immediately rather than at first access.
+
+``PDFHandler.pages`` is a property
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PDFHandler.pages`` is now a lazily-resolved property (was an attribute).
+Reads are unchanged; only code that *set* it after subclassing is affected.
+
+PDF backend is now ``playa-pdf``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The backend moved from ``pypdf`` + ``pdfminer.six`` to
+`playa-pdf <https://pypi.org/project/playa-pdf/>`_: a smaller install set,
+more accurate encrypted-PDF handling, and faster hot paths. Pure ``import
+camelot`` callers should see no API change. ``pdfminer.six`` is no longer a
+direct dependency — ``playa.miner`` exposes a PDFMiner-compatible layout
+API, so imports through Camelot keep working.
+
+Default lattice ``engine`` is ``"combined"``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``flavor="lattice"`` now defaults to ``engine="combined"`` (raster OpenCV
+detection **plus** the PDF's native vector ruled lines). It is safe by
+construction — raster always runs and vector lines can only add — so it is
+never worse than the old ``"raster"`` default. Pass ``engine="raster"`` to
+restore the exact pre-2.0 behaviour. (There is no ``engine="auto"``.)
+
+New (opt-in) features
+---------------------
+
+Neural backend for borderless / scanned tables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new optional ``flavor="ml"`` uses a Table Transformer model for table
+**structure** and fills cell **text** from the PDF (so it can't hallucinate
+values). It targets borderless tables, where the heuristic parsers plateau.
+With OCR it also reads **scanned / image-only** PDFs. These pull heavier
+dependencies, imported lazily, so the core install is unaffected:
+
+.. code-block:: bash
+
+   pip install "camelot-py[ml]"       # borderless
+   pip install "camelot-py[ml,ocr]"   # + scanned PDFs
+
+.. code-block:: python
+
+   tables = camelot.read_pdf("report.pdf", flavor="ml")  # device="cuda"/"xpu" optional
+
+See :ref:`how_it_works` for the design and a borderless benchmark, and
+:ref:`comparison` for how Camelot's flavors line up against other tools.
+
+Other additions worth knowing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``flavor="auto"`` picks ``lattice`` or ``network`` per page.
+- ``TableList.filter(...)`` drops low-quality tables by row/column count,
+  accuracy, or whitespace.
+- ``Table.confidence`` — a unified ``[0, 1]`` quality score in
+  ``parsing_report``.
+- ``per_page=`` overrides, ``replace_text=``, list-form ``strip_text=``,
+  ``bytes`` / file-like ``read_pdf`` input, and a ``cpu_count`` cap for
+  parallel runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "camelot-py"
-version = "1.0.9"
+version = "2.0.0rc1"
 description = "PDF Table Extraction for Humans."
 authors = [
     {name = "Vinayak Mehta", email = "vmehta94@gmail.com"},


### PR DESCRIPTION
Release prep for **2.0.0rc1**. No code changes.

- **Version** `1.0.9` → `2.0.0rc1` in `pyproject.toml` (the single source of truth; `camelot.__version__` reads package metadata).
- **CHANGELOG** consolidation: folded the ml/ocr/hybrid/engine notes that had drifted *above* the `# Changelog` title into the `2.0.0` section; retitled `[Unreleased] — 2.0.0 (planned)` → `[2.0.0rc1] — 2026-05-25`; reconciled a stale note (`engine='auto'` was removed — `combined` is now the default, not "auto resolves to combined").
- **Migration guide** `docs/user/migration.rst` (new, in the toctree): the 1.0.x → 2.0 breaking changes (Python 3.10+, `line_scale` 40→15, `to_excel` defaults, `TableList` materialisation, `PDFHandler.pages` property, the playa-pdf backend, default `engine="combined"`) plus pointers to the new opt-in `[ml]`/`[ocr]` features.

After this merges, the rc is cut by publishing a GitHub pre-release tagged `v2.0.0rc1`, which triggers the PyPI upload.