### PR TITLE
fix(release): --clobber the GitHub-release asset upload (unblocks PyPI publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,14 @@ jobs:
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        # --clobber: the Sigstore action above already attaches the signed
+        # dists to the release, so a plain upload errors with "asset already
+        # exists" and skips the PyPI publish below. Overwrite instead.
         run: >-
           gh release upload
           "${{ github.event.release.tag_name }}" ./dist/*
           --repo "$GITHUB_REPOSITORY"
+          --clobber
 
       - name: Remove Sigstore files
         run: rm -f dist/*.sig dist/*.crt dist/*.sigstore.json


### PR DESCRIPTION
The Sigstore step (`sigstore/gh-action-sigstore-python`) already attaches the signed dists to the GitHub Release on a `release` event. The next step then runs `gh release upload ./dist/*` **without `--clobber`**, so it fails with *"asset under the same name already exists"* — failing the job and **skipping the `Publish to PyPI` step**.

This is why the **v2.0.0rc1** publish failed (build + sign succeeded, PyPI step skipped; nothing reached PyPI). Adding `--clobber` makes the upload overwrite instead of erroring, so the PyPI step runs.

After this merges I'll re-fire the `v2.0.0rc1` release to publish it.