### PR TITLE
chore(release): prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ human-readable summary for _major_ releases.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0rc1] — 2026-05-25
+## [2.0.0] — 2026-06-04
 
 The 2.0 release rolls up a substantial backend migration, the resulting
 performance work, an optional neural (Table Transformer) backend for
@@ -181,6 +181,13 @@ breaking changes. **Heads-up if upgrading from 1.0.x** — see the
 
 ### Fixed
 
+- **`text_in_bbox` no longer drops legitimate adjacent-cell text.** The
+  geometry-only overlap dedup (added for #15 font-render duplicates) was
+  discarding any shorter textline ≥80 % contained in a wider neighbour's
+  bbox — even when the two carried different text — so overlapping cells
+  silently lost content. The discard is now content-aware: a contained box
+  is dropped only when its stripped text actually equals the longer
+  sibling's. (#814, closes #288 / #625)
 - **Precision gate for the lattice/combined engine.** Near-empty ruled
   grids (page borders, form rules, header separators — whitespace ≥ 90 %)
   are no longer emitted as tables; they were detection noise that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "camelot-py"
-version = "2.0.0rc1"
+version = "2.0.0"
 description = "PDF Table Extraction for Humans."
 authors = [
     {name = "Vinayak Mehta", email = "vmehta94@gmail.com"},


### PR DESCRIPTION
Promotes `2.0.0rc1` → **`2.0.0`** for the final release.

## Changes
- `pyproject.toml`: `version = "2.0.0rc1"` → `"2.0.0"`
- `CHANGELOG.md`:
  - `## [2.0.0rc1] — 2026-05-25` → `## [2.0.0] — 2026-06-04`
  - Added the one code fix landed since rc1: **#814** content-aware `text_in_bbox` dedup (closes #288 / #625), under **Fixed**.

## Context
rc1 has been soaking on PyPI since 2026-05-25. The conda-forge blocker is cleared — `playa-pdf` 1.1.0 is now published on conda-forge. Once this merges, tagging/publishing the `v2.0.0` GitHub Release triggers `release.yml` → trusted-publish to PyPI.

Only commits since the rc1 tag are #814 (fix) and #813 (docs) — no further code churn, so promoting rc1 straight to final.