### PR TITLE
feat: derive table_area from header/footer text lines in stream parser

### DIFF
--- a/camelot/io.py
+++ b/camelot/io.py
@@ -220,6 +220,18 @@ def read_pdf(
         List of table area strings of the form x1,y1,x2,y2
         where (x1, y1) -> left-top and (x2, y2) -> right-bottom
         in PDF coordinate space.
+    header_text^ : list, optional (default: None)
+        List of substrings identifying a text line above a stream table.
+        When ``table_areas`` is not supplied and a matching line is found,
+        its bottom coordinate becomes the top edge of the derived table
+        area. If no match is found, Camelot falls back to automatic table
+        detection.
+    footer_text^ : list, optional (default: None)
+        List of substrings identifying a text line below a stream table.
+        When ``table_areas`` is not supplied and a matching line is found,
+        its top coordinate becomes the bottom edge of the derived table
+        area. If no match is found, Camelot falls back to automatic table
+        detection.
     columns^ : list, optional (default: None)
         List of column x-coordinates strings where the coordinates
         are comma-separated.

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -26,6 +26,8 @@ class BaseParser:
         parser_id,
         table_regions=None,
         table_areas=None,
+        header_text=None,
+        footer_text=None,
         copy_text=None,
         split_text=False,
         strip_text="",
@@ -37,6 +39,8 @@ class BaseParser:
         self.id = parser_id
         self.table_regions = table_regions
         self.table_areas = table_areas
+        self.header_text = header_text
+        self.footer_text = footer_text
         self.table_bbox_parses = {}
 
         self.columns = None
@@ -350,6 +354,8 @@ class TextBaseParser(BaseParser):
         table_regions=None,
         table_areas=None,
         columns=None,
+        header_text=None,
+        footer_text=None,
         flag_size=False,
         split_text=False,
         strip_text="",
@@ -365,6 +371,8 @@ class TextBaseParser(BaseParser):
             parser_id,
             table_regions=table_regions,
             table_areas=table_areas,
+            header_text=header_text,
+            footer_text=footer_text,
             split_text=split_text,
             strip_text=strip_text,
             replace_text=replace_text,

--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -26,6 +26,14 @@ class Stream(TextBaseParser):
         List of table area strings of the form x1,y1,x2,y2
         where (x1, y1) -> left-top and (x2, y2) -> right-bottom
         in PDF coordinate space.
+    header_text : list, optional (default: None)
+        List of substrings identifying a text line above the table.
+        When table_areas is not set, the matched line's bottom
+        coordinate is used as the table area's top edge.
+    footer_text : list, optional (default: None)
+        List of substrings identifying a text line below the table.
+        When table_areas is not set, the matched line's top coordinate
+        is used as the table area's bottom edge.
     columns : list, optional (default: None)
         List of column x-coordinates strings where the coordinates
         are comma-separated.
@@ -52,6 +60,8 @@ class Stream(TextBaseParser):
         self,
         table_regions=None,
         table_areas=None,
+        header_text=None,
+        footer_text=None,
         columns=None,
         split_text=False,
         flag_size=False,
@@ -66,6 +76,8 @@ class Stream(TextBaseParser):
             "stream",
             table_regions=table_regions,
             table_areas=table_areas,
+            header_text=header_text,
+            footer_text=footer_text,
             columns=columns,
             # _validate_columns()
             split_text=split_text,
@@ -104,6 +116,77 @@ class Stream(TextBaseParser):
 
         return table_bbox
 
+    @staticmethod
+    def _normalize_text_anchors(anchors):
+        if anchors is None:
+            return []
+        if isinstance(anchors, str):
+            anchors = [anchors]
+        return [anchor for anchor in anchors if anchor]
+
+    @staticmethod
+    def _find_text_anchor(textlines, anchors, reverse=False):
+        if not anchors:
+            return None
+        ordered_textlines = sorted(
+            textlines,
+            key=lambda textline: (
+                textline.y0 if reverse else -textline.y0,
+                textline.x0,
+            ),
+        )
+        for textline in ordered_textlines:
+            text = textline.get_text().strip()
+            if any(anchor in text for anchor in anchors):
+                return textline
+        return None
+
+    def _intersect_bbox_with_table_regions(self, bbox):
+        if self.table_regions is None:
+            return [bbox]
+
+        bboxes = []
+        for region_str in self.table_regions:
+            region_bbox = bbox_from_str(region_str)
+            region_intersection = (
+                max(bbox[0], region_bbox[0]),
+                max(bbox[1], region_bbox[1]),
+                min(bbox[2], region_bbox[2]),
+                min(bbox[3], region_bbox[3]),
+            )
+            if (
+                region_intersection[0] < region_intersection[2]
+                and region_intersection[1] < region_intersection[3]
+            ):
+                bboxes.append(region_intersection)
+        return bboxes
+
+    def _generate_table_bbox_from_text_anchors(self):
+        header_anchors = self._normalize_text_anchors(self.header_text)
+        footer_anchors = self._normalize_text_anchors(self.footer_text)
+        if not header_anchors and not footer_anchors:
+            return None
+
+        header_line = self._find_text_anchor(self.horizontal_text, header_anchors)
+        footer_line = self._find_text_anchor(
+            self.horizontal_text, footer_anchors, reverse=True
+        )
+        if (header_anchors and header_line is None) or (
+            footer_anchors and footer_line is None
+        ):
+            return None
+
+        top = header_line.y0 if header_line is not None else self.pdf_height
+        bottom = footer_line.y1 if footer_line is not None else 0
+        if bottom >= top:
+            return None
+
+        bbox = (0, bottom, self.pdf_width, top)
+        bboxes = self._intersect_bbox_with_table_regions(bbox)
+        if not bboxes:
+            return None
+        return {bbox: None for bbox in bboxes}
+
     def record_parse_metadata(self, table):
         """Record data about the origin of the table."""
         super().record_parse_metadata(table)
@@ -111,17 +194,19 @@ class Stream(TextBaseParser):
 
     def _generate_table_bbox(self):
         if self.table_areas is None:
-            hor_text = self.horizontal_text
-            if self.table_regions is not None:
-                # filter horizontal text
-                hor_text = []
-                for region_str in self.table_regions:
-                    region_text = text_in_bbox(
-                        bbox_from_str(region_str), self.horizontal_text
-                    )
-                hor_text.extend(region_text)
-            # find tables based on nurminen's detection algorithm
-            table_bbox_parses = self._nurminen_table_detection(hor_text)
+            table_bbox_parses = self._generate_table_bbox_from_text_anchors()
+            if table_bbox_parses is None:
+                hor_text = self.horizontal_text
+                if self.table_regions is not None:
+                    # filter horizontal text
+                    hor_text = []
+                    for region_str in self.table_regions:
+                        region_text = text_in_bbox(
+                            bbox_from_str(region_str), self.horizontal_text
+                        )
+                        hor_text.extend(region_text)
+                # find tables based on nurminen's detection algorithm
+                table_bbox_parses = self._nurminen_table_detection(hor_text)
         else:
             table_bbox_parses = {}
             for area_str in self.table_areas:

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -125,7 +125,14 @@ common_kwargs = [
     "table_regions",
     "backend",
 ]
-text_kwargs = common_kwargs + ["columns", "edge_tol", "row_tol", "column_tol"]
+text_kwargs = common_kwargs + [
+    "columns",
+    "header_text",
+    "footer_text",
+    "edge_tol",
+    "row_tol",
+    "column_tol",
+]
 lattice_kwargs = common_kwargs + [
     "process_background",
     "line_scale",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 import camelot
@@ -58,6 +59,79 @@ def test_stream_table_areas(testdir):
         filename, flavor="stream", table_areas=["320,500,573,335"]
     )
     assert_frame_equal(df, tables[0].df)
+
+
+def test_stream_header_footer_text(testdir):
+    df = pd.DataFrame(data_stream)
+
+    filename = os.path.join(testdir, "health.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="stream",
+        header_text=["Public Health Outlay"],
+        footer_text=["Health Sector Financing"],
+    )
+
+    assert len(tables) == 1
+    table = tables[0]
+    assert table._bbox[0] == pytest.approx(0)
+    assert table._bbox[1] > 0
+    assert table._bbox[2] == pytest.approx(table.pdf_size[0])
+    assert table._bbox[3] < table.pdf_size[1]
+    assert_frame_equal(df, table.df)
+    table_text = table.df.to_string()
+    assert "Public Health Outlay" not in table_text
+    assert "Health Sector Financing" not in table_text
+
+
+def test_stream_header_text_only_defaults_to_page_bottom(testdir):
+    filename = os.path.join(testdir, "health.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="stream",
+        header_text=["Public Health Outlay"],
+    )
+
+    assert len(tables) == 1
+    table = tables[0]
+    assert table._bbox[0] == pytest.approx(0)
+    assert table._bbox[1] == pytest.approx(0)
+    assert table._bbox[2] == pytest.approx(table.pdf_size[0])
+    assert table._bbox[3] < table.pdf_size[1]
+
+
+def test_stream_missing_header_text_falls_back_to_auto_detection(testdir):
+    df = pd.DataFrame(data_stream)
+
+    filename = os.path.join(testdir, "health.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="stream",
+        header_text=["not a real heading on this page"],
+    )
+
+    assert len(tables) == 1
+    assert_frame_equal(df, tables[0].df)
+
+
+def test_stream_table_areas_take_precedence_over_header_text(testdir):
+    df = pd.DataFrame(data_stream_table_areas)
+
+    filename = os.path.join(testdir, "tabula/us-007.pdf")
+    tables = camelot.read_pdf(
+        filename,
+        flavor="stream",
+        table_areas=["320,500,573,335"],
+        header_text=["Instructions."],
+    )
+
+    assert_frame_equal(df, tables[0].df)
+
+
+def test_header_text_rejected_for_lattice(testdir):
+    filename = os.path.join(testdir, "health.pdf")
+    with pytest.raises(ValueError, match="header_text cannot be used"):
+        camelot.read_pdf(filename, header_text=["Public Health Outlay"])
 
 
 def test_stream_columns(testdir):


### PR DESCRIPTION
## Summary
The stream parser can derive `table_area` from header and footer text lines, so tables bounded by repeated headers/footers are detected without hand-specifying coordinates.

## Why this matters
Stream parsing relies on whitespace gaps and often needs an explicit `table_areas`. For documents with consistent header/footer text framing each table, deriving the area from those text lines removes the manual coordinate step.

## Changes
- Add header/footer text-line detection in the stream parser and use it to compute `table_area`.
- Thread the option through `io.py`, the base parser, and `utils.py`.

## Testing
Added a stream test exercising the header/footer-derived area path.

Fixes #658

AI was used for assistance.
