### PR TITLE
feat: log per-page progress during read_pdf for large documents

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import multiprocessing as mp
 import os
 import tempfile
@@ -38,6 +39,8 @@ PARSERS = {
     "hybrid": Hybrid,
     "ml": MachineLearning,
 }
+
+logger = logging.getLogger("camelot")
 
 
 FilepathOrBuffer = str | Path | bytes | bytearray | memoryview | IO[bytes]
@@ -453,6 +456,7 @@ class PDFHandler:
                         flavor=flavor,
                         base_kwargs=kwargs,
                         per_page=per_page,
+                        suppress_stdout=suppress_stdout,
                     )
                 )
         except PDFPasswordIncorrect as e:
@@ -469,6 +473,7 @@ class PDFHandler:
         flavor: str = "lattice",
         base_kwargs: dict[str, Any] | None = None,
         per_page: dict[int, dict[str, Any]] | None = None,
+        suppress_stdout: bool = False,
     ):
         """Extract tables by calling parser.get_tables on a single page PDF.
 
@@ -489,6 +494,8 @@ class PDFHandler:
             per-page override to construct a fresh parser for that page.
         per_page : dict, optional
             Page-number-keyed kwargs overrides (already validated upstream).
+        suppress_stdout : bool, optional (default: False)
+            Suppress per-page progress logs.
 
         Returns
         -------
@@ -498,6 +505,8 @@ class PDFHandler:
         """
         # playa's page_idx is 0-indexed; user-facing per_page uses 1-indexed.
         page_no = page.page_idx + 1
+        if not suppress_stdout:
+            logger.info("Processing page %d", page_no)
         overrides = (per_page or {}).get(page_no)
         if overrides:
             page_flavor = overrides.get("flavor", flavor)

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -183,7 +183,7 @@ def read_pdf(
           the per-page choices. (More accurate but slower, since it renders
           every page for the probe.)
     suppress_stdout : bool, optional (default: False)
-        Print all logs and warnings.
+        Suppress logs and warnings.
     parallel : bool, optional (default: False)
         Process pages in parallel using all available cpu cores.
     cpu_count : int, optional (default: None)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -13,6 +14,16 @@ from camelot.io import PDFHandler
 from .conftest import skip_on_windows
 from .conftest import skip_pdftopng
 from .data import *
+
+
+def _processing_page_messages(caplog):
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "camelot"
+        and record.levelno == logging.INFO
+        and record.getMessage().startswith("Processing page ")
+    ]
 
 
 @skip_on_windows
@@ -221,6 +232,48 @@ def test_pages_ghostscript_custom_backend():
     assert repr(tables) == "<TableList n=1>"
     assert repr(tables[0]) == "<Table shape=(7, 7)>"
     assert repr(tables[0].cells[0][0]) == "<Cell x1=120 y1=218 x2=165 y2=234>"
+
+
+def test_read_pdf_logs_processing_progress_per_page(testdir, caplog):
+    filename = os.path.join(testdir, "hybrid_multipage.pdf")
+    caplog.set_level(logging.INFO, logger="camelot")
+
+    camelot.read_pdf(filename, pages="1-2")
+
+    assert _processing_page_messages(caplog) == [
+        "Processing page 1",
+        "Processing page 2",
+    ]
+
+
+def test_read_pdf_suppresses_processing_progress(testdir, caplog):
+    filename = os.path.join(testdir, "hybrid_multipage.pdf")
+    caplog.set_level(logging.INFO, logger="camelot")
+
+    camelot.read_pdf(filename, pages="1-2", suppress_stdout=True)
+
+    assert _processing_page_messages(caplog) == []
+
+
+def test_read_pdf_logs_processing_progress_for_page_subset(testdir, caplog):
+    filename = os.path.join(testdir, "vertical_header.pdf")
+    caplog.set_level(logging.INFO, logger="camelot")
+
+    camelot.read_pdf(filename, pages="1,3", flavor="stream")
+
+    assert _processing_page_messages(caplog) == [
+        "Processing page 1",
+        "Processing page 3",
+    ]
+
+
+def test_read_pdf_logs_processing_progress_for_single_page(testdir, caplog):
+    filename = os.path.join(testdir, "foo.pdf")
+    caplog.set_level(logging.INFO, logger="camelot")
+
+    camelot.read_pdf(filename)
+
+    assert _processing_page_messages(caplog) == ["Processing page 1"]
 
 
 def test_table_order():


### PR DESCRIPTION
## Summary
`read_pdf` logs per-page progress so long multi-page extractions show where they are instead of appearing to hang.

## Why this matters
On large PDFs, extraction runs for a long time with no output. Per-page progress logging gives feedback during the run without changing the return value or default verbosity.

## Changes
- Emit a per-page progress log line during `read_pdf` page iteration.

## Testing
Added a test asserting the progress log fires per page.

Fixes #507

AI was used for assistance.
