### PR TITLE
feat: add image_bbox_to_pdf helper for image-pixel to PDF table_areas

### DIFF
--- a/camelot/__init__.py
+++ b/camelot/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from .io import read_pdf
 from .plotting import PlotMethods
+from .utils import image_bbox_to_pdf
 
 
 def get_version() -> str | None:

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -553,6 +553,72 @@ def bbox_from_str(bbox_str):
     return (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
 
 
+def image_bbox_to_pdf(bbox, image_size, pdf_size, as_string=False):
+    """Convert an image-space bbox to a PDF-space table area.
+
+    Parameters
+    ----------
+    bbox : tuple
+        Tuple (x1, y1, x2, y2) in image-pixel space, where the origin is the
+        top-left corner of the image.
+    image_size : tuple
+        Tuple (img_w, img_h) containing the rendered image width and height in
+        pixels.
+    pdf_size : tuple
+        Tuple (pdf_w, pdf_h) containing the PDF page width and height in
+        points.
+    as_string : bool, optional
+        If True, return the converted bbox as "x1,y1,x2,y2", suitable for use
+        as an entry in ``table_areas``. The default is False.
+
+    Returns
+    -------
+    bbox : tuple or str
+        Tuple (x1, y1, x2, y2) in PDF coordinate space, where the origin is the
+        bottom-left corner and y1 is greater than y2, or the same coordinates
+        serialized as "x1,y1,x2,y2" when ``as_string`` is True.
+
+    Raises
+    ------
+    ValueError
+        If an image or PDF dimension is zero or negative, or if ``bbox`` has
+        zero width or height in image-pixel space.
+
+    """
+    x1, y1, x2, y2 = bbox
+    img_w, img_h = image_size
+    pdf_w, pdf_h = pdf_size
+
+    if img_w <= 0 or img_h <= 0:
+        raise ValueError(
+            "image_size dimensions must be positive; pass the rendered image "
+            "size as (img_w, img_h)."
+        )
+    if pdf_w <= 0 or pdf_h <= 0:
+        raise ValueError(
+            "pdf_size dimensions must be positive; pass the PDF page size in "
+            "points as (pdf_w, pdf_h)."
+        )
+    if x1 == x2 or y1 == y2:
+        raise ValueError(
+            "bbox must have non-zero width and height in image-pixel space; "
+            "pass (x1, y1, x2, y2) from the rendered image."
+        )
+
+    scaling_factor_x = pdf_w / img_w
+    scaling_factor_y = pdf_h / img_h
+
+    left = scale(min(x1, x2), scaling_factor_x)
+    right = scale(max(x1, x2), scaling_factor_x)
+    top = translate(-scale(min(y1, y2), scaling_factor_y), pdf_h)
+    bottom = translate(-scale(max(y1, y2), scaling_factor_y), pdf_h)
+
+    pdf_bbox = (left, top, right, bottom)
+    if as_string:
+        return ",".join(str(coord) for coord in pdf_bbox)
+    return pdf_bbox
+
+
 def bboxes_overlap(bbox1, bbox2):
     """Check if boundingboxes overlap.
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -304,6 +304,13 @@ Table areas that you want camelot to analyze can be passed as a list of comma-se
 
 .. note:: ``table_areas`` accepts strings of the form x1,y1,x2,y2 where (x1, y1) -> top-left and (x2, y2) -> bottom-right in PDF coordinate space. In PDF coordinate space, the bottom-left corner of the page is the origin, with coordinates (0, 0).
 
+If your coordinates come from a rendered page image, use ``camelot.image_bbox_to_pdf()`` to convert the image-pixel bounding box into the PDF-space string expected by ``table_areas``:
+
+.. code-block:: pycon
+
+    >>> area = camelot.image_bbox_to_pdf((300, 600, 1800, 1500), (2550, 3300), (612, 792), as_string=True)
+    >>> tables = camelot.read_pdf('table_areas.pdf', flavor='stream', table_areas=[area])
+
 Specify table regions
 ---------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,10 @@ import pytest
 from playa.miner import LAParams
 from playa.miner import LTTextBoxHorizontal
 
+import camelot
 from camelot.utils import bbox_from_str
 from camelot.utils import bbox_intersection_area
+from camelot.utils import image_bbox_to_pdf
 
 
 def get_text_from_pdf(filename):
@@ -220,3 +222,59 @@ def test_bbox_from_str_rejects_malformed():
         bbox_from_str("1,2,3")
     with pytest.raises(ValueError, match="must be numbers"):
         bbox_from_str("a,b,c,d")
+
+
+def test_image_bbox_to_pdf_300_dpi_letter_page():
+    pdf_bbox = image_bbox_to_pdf((300, 600, 1800, 1500), (2550, 3300), (612, 792))
+
+    assert pdf_bbox == pytest.approx((72.0, 648.0, 432.0, 432.0))
+    assert pdf_bbox[0] < pdf_bbox[2]
+    assert pdf_bbox[1] > pdf_bbox[3]
+
+
+def test_image_bbox_to_pdf_identity_scale_flips_y_axis():
+    pdf_bbox = image_bbox_to_pdf((10, 20, 110, 70), (200, 100), (200, 100))
+
+    assert pdf_bbox == pytest.approx((10.0, 80.0, 110.0, 30.0))
+
+
+def test_image_bbox_to_pdf_string_round_trips_through_bbox_from_str():
+    area = image_bbox_to_pdf(
+        (300, 600, 1800, 1500), (2550, 3300), (612, 792), as_string=True
+    )
+
+    assert isinstance(area, str)
+    assert bbox_from_str(area) == pytest.approx((72.0, 432.0, 432.0, 648.0))
+    assert camelot.image_bbox_to_pdf((10, 20, 110, 70), (200, 100), (200, 100)) == (
+        pytest.approx((10.0, 80.0, 110.0, 30.0))
+    )
+
+
+def test_image_bbox_to_pdf_top_and_bottom_edges():
+    top_edge = image_bbox_to_pdf((10, 0, 110, 25), (200, 100), (200, 100))
+    bottom_edge = image_bbox_to_pdf((10, 75, 110, 100), (200, 100), (200, 100))
+
+    assert top_edge == pytest.approx((10.0, 100.0, 110.0, 75.0))
+    assert bottom_edge == pytest.approx((10.0, 25.0, 110.0, 0.0))
+
+
+def test_image_bbox_to_pdf_scales_axes_independently():
+    pdf_bbox = image_bbox_to_pdf((20, 40, 120, 240), (200, 400), (100, 300))
+
+    assert pdf_bbox == pytest.approx((10.0, 270.0, 60.0, 120.0))
+
+
+@pytest.mark.parametrize(
+    ("bbox", "image_size", "pdf_size", "message"),
+    [
+        ((10, 20, 10, 70), (200, 100), (200, 100), "non-zero width and height"),
+        ((10, 20, 110, 20), (200, 100), (200, 100), "non-zero width and height"),
+        ((10, 20, 110, 70), (0, 100), (200, 100), "image_size dimensions"),
+        ((10, 20, 110, 70), (200, 100), (0, 100), "pdf_size dimensions"),
+    ],
+)
+def test_image_bbox_to_pdf_rejects_degenerate_input(
+    bbox, image_size, pdf_size, message
+):
+    with pytest.raises(ValueError, match=message):
+        image_bbox_to_pdf(bbox, image_size, pdf_size)


### PR DESCRIPTION
## Summary

Users who detect table regions with an external image-based tool (Table Transformers, a pdf2image + detector pipeline, etc.) get bounding boxes in image-pixel space and can now convert them into PDF-space `table_areas` with a single call: `camelot.image_bbox_to_pdf(bbox, image_size, pdf_size)`.

## Why this matters

Issue #377 asks how to feed image-pixel bounding boxes to `read_pdf(table_areas=...)`. Camelot already fully supports manual table-area selection; as bosd (COLLABORATOR) confirmed on 2026-05-21, the only missing piece is the coordinate conversion. Image space and PDF space differ in two ways: the origin (image is top-left, PDF is bottom-left) and the units (pixels vs points). Bridging them needs a y-axis flip plus an x/y scale by the page-to-image ratio. There was no public helper for this, and the internal `scale_image` requires a precomputed `factors` tuple and is not exposed for this purpose.

## Changes

- `camelot/utils.py`: new public `image_bbox_to_pdf(bbox, image_size, pdf_size, as_string=False)`. Reuses the existing `scale`/`translate` primitives, scales x by `pdf_w/img_w` and y by `pdf_h/img_h`, and flips the y-axis so the returned `(x1, y1, x2, y2)` has bottom-left origin with `y1 > y2` - exactly what `bbox_from_str` and `read_pdf(table_areas=...)` expect. `as_string=True` returns the `"x1,y1,x2,y2"` form for direct use as a `table_areas` entry. Raises a clear `ValueError` on a zero/negative image or PDF dimension, or a zero-width/zero-height pixel bbox.
- `camelot/__init__.py`: export the helper as `camelot.image_bbox_to_pdf`.
- `tests/test_utils.py`: coverage for the happy path (300 DPI US-Letter), identity scale (y-flip only), string round-trip through `bbox_from_str`, top/bottom edge mapping, independent non-square x/y scaling, and the degenerate-input error paths.

## Testing

- `pytest tests/test_utils.py` -> 18 passed
- `ruff check` and `ruff format --check` on the changed files -> clean

Fixes #377
