### PR TITLE
Fix typo in README: 'seperate' -> 'separate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ Camelot uses [Semantic Versioning](https://semver.org/). For the available versi
 
 This project is licensed under the MIT License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/master/LICENSE) file for details.
 
-The documentation theme is licensed under a seperate BSD-like License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/master/docs/_themes/LICENSE) file for details.
+The documentation theme is licensed under a separate BSD-like License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/master/docs/_themes/LICENSE) file for details.


### PR DESCRIPTION
## Description

Fixed a typo in the README file.

**Before:** `a seperate BSD-like License`
**After:** `a separate BSD-like License`

The word "separate" was misspelled as "seperate" in the documentation license section (line 164).

## Changes
- Fixed typo in README.md: `seperate` → `separate`
