### PR TITLE
docs: add CITATION.cff for academic citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+title: "Camelot: PDF Table Extraction for Humans"
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+authors:
+  - family-names: Mehta
+    given-names: Vinayak
+    email: vmehta94@gmail.com
+repository-code: "https://github.com/camelot-dev/camelot"
+url: "https://camelot-py.readthedocs.io/"
+license: MIT
+version: 2.0.0
+date-released: "2026-06-04"
+abstract: >-
+  Camelot is a Python library that makes it easy to extract tables
+  from PDF files. It provides multiple parsing backends including
+  lattice, stream, network, hybrid, and an optional neural ML backend,
+  along with pandas DataFrame output and multiple export formats.
+keywords:
+  - pdf
+  - table-extraction
+  - python
+  - data-extraction
+  - pandas


### PR DESCRIPTION
Adds a `CITATION.cff` file to the repository root so that users who want to cite Camelot in academic papers or research have a standard, machine-readable reference. GitHub natively detects this file and adds a "Cite this repository" button to the sidebar automatically.



Fixes: #818