### PR TITLE
docs: add CITATION.cff (#818)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "Camelot: PDF Table Extraction for Humans"
+abstract: "Camelot is a Python library that can extract tables from text-based PDF files."
+type: software
+authors:
+  - family-names: Mehta
+    given-names: Vinayak
+    email: vmehta94@gmail.com
+  - name: "The Camelot contributors"
+repository-code: "https://github.com/camelot-dev/camelot"
+url: "https://camelot-py.readthedocs.io/"
+license: MIT
+version: 2.0.0
+date-released: 2026-06-04
+keywords:
+  - pdf
+  - table-extraction
+  - data-extraction
+  - python


### PR DESCRIPTION
Closes #818.

Adds a `CITATION.cff` so GitHub renders a **"Cite this repository"** button (with APA/BibTeX export) on the repo homepage, and `git`/Zenodo/tooling can pick up structured citation metadata.

- Author: Vinayak Mehta (original author) + "The Camelot contributors"
- Pinned to the current release (2.0.0, 2026-06-04); the `version`/`date-released` fields can be bumped at each release (worth adding to the release checklist).

Validated against the CFF 1.2.0 required-field set.