### PR TITLE
ci(tests): report the experimental Python 3.15 row green

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: changes
     # Allow the experimental (pre-release) Python entries to fail without
-    # failing the workflow as a whole.
+    # failing the workflow as a whole. This job-level flag keeps a failing
+    # 3.15 row from failing the run, but GitHub still reports the individual
+    # matrix job as red; the step-level flag on "Run Nox" below is what turns
+    # the reported check green.
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
@@ -184,6 +187,14 @@ jobs:
             ${{ steps.pre-commit-cache.outputs.result }}-
 
       - name: Run Nox
+        # Tolerate failures on the pre-release (experimental) Python rows at
+        # the *step* level so the job's check reports green. A core dependency
+        # such as pandas frequently has no wheel for a new pre-release yet and
+        # cannot be built from source (e.g. pandas' meson build errors with
+        # "Unknown compiler(s): cython" on 3.15), which would otherwise mark
+        # every PR's "tests 3.15" check red. The row still runs to give early
+        # signal and will pass on its own once upstream wheels land.
+        continue-on-error: ${{ matrix.experimental || false }}
         run: |
           nox --python=${{ matrix.python }}
 


### PR DESCRIPTION
## Problem

Every PR — most visibly the Dependabot bumps (#842–#846) — shows a red `tests 3.15 / ubuntu-latest` check. The 3.15 row is already marked `experimental: true` with **job-level** `continue-on-error`, which stops it from failing the overall run, but GitHub still reports the individual matrix job as **red**. That's a known Actions limitation: job-level `continue-on-error` does not change the reported conclusion of that job's check.

The row genuinely cannot pass yet: `pandas` has no cp315 wheel, and building it from source on Python 3.15 fails in pandas' meson build with `ERROR: Unknown compiler(s): [['cython']]`.

## Fix

Add **step-level** `continue-on-error: ${{ matrix.experimental || false }}` on the *Run Nox* step. A tolerated step failure makes the job report **success (green)**, so PRs stop showing a spurious red X — while the 3.15 row still runs to give early signal and will go green on its own once upstream ships 3.15 wheels.

No change to any non-experimental row. Verifiable on this PR: the `tests 3.15` check should now report green (or neutral) instead of red.